### PR TITLE
18-Manual-EDFBDF-setting

### DIFF
--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -255,12 +255,13 @@ class EMG:
 
     def to_edf(self, filepath: str, method: str = 'both',
                fft_noise_range: tuple = None, svd_rank: int = None,
-               precision_threshold: float = 0.01, **kwargs) -> None:
+               precision_threshold: float = 0.01, format: str = 'auto',
+               force_format: bool = False, **kwargs) -> None:
         """
-        Export data to EDF format with corresponding channels.tsv file.
+        Export data to EDF/BDF format with corresponding channels.tsv file.
 
         Args:
-            filepath: Path to save the EDF file
+            filepath: Path to save the EDF/BDF file
             method: Method for signal analysis ('svd', 'fft', or 'both')
                 'svd': Uses Singular Value Decomposition for noise floor estimation
                 'fft': Uses Fast Fourier Transform for noise floor estimation
@@ -268,6 +269,11 @@ class EMG:
             fft_noise_range: Optional tuple (min_freq, max_freq) specifying frequency range for noise in FFT method
             svd_rank: Optional manual rank cutoff for signal/noise separation in SVD method
             precision_threshold: Maximum acceptable precision loss percentage (default: 0.01%)
+            format: Format to use ('auto', 'edf', or 'bdf'). Default is 'auto' which selects
+                based on signal characteristics. When specified, the system will still warn
+                if the chosen format is not optimal.
+            force_format: When True, bypasses all format suitability checks and uses the 
+                specified format without warnings. Default is False.
             **kwargs: Additional arguments for the EDF exporter
 
         Raises:
@@ -285,6 +291,12 @@ class EMG:
             'svd_rank': svd_rank,
             'precision_threshold': precision_threshold
         }
+        
+        # Add format parameters
+        if format != 'auto':
+            analysis_params['format'] = format
+        if force_format:
+            analysis_params['force_format'] = force_format
 
         # Combine with any other kwargs
         all_params = {**analysis_params, **kwargs}

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -329,17 +329,17 @@ class EDFExporter:
         # Initialize format variables
         use_bdf = False
         bdf_reason = ""
-        user_format_choice = None
+        user_chose_bdf = None
         
         # Check if user has specified a format
         if format.lower() != 'auto':
             if format.lower() == 'bdf':
-                user_format_choice = True
+                user_chose_bdf = True
                 if force_format:
                     use_bdf = True
                     print("\nUser requested BDF format (forced).")
             elif format.lower() == 'edf':
-                user_format_choice = False
+                user_chose_bdf = False
                 if force_format:
                     use_bdf = False
                     print("\nUser requested EDF format (forced).")
@@ -365,7 +365,7 @@ class EDFExporter:
             recommend_bdf, reason, snr = determine_format_suitability(signal, analysis)
             
             # If using automatic format determination or not forced
-            if user_format_choice is None or not force_format:
+            if user_chose_bdf is None or not force_format:
                 # Perform quantization analysis for chosen format
                 if recommend_bdf:
                     use_bdf = True
@@ -375,7 +375,7 @@ class EDFExporter:
             # Calculate scaling factors
             phys_min, phys_max, dig_min, dig_max, scaling = _determine_scaling_factors(
                 float(np.min(signal)), float(np.max(signal)), 
-                use_bdf=recommend_bdf if user_format_choice is None else user_format_choice
+                use_bdf=recommend_bdf if user_chose_bdf is None else user_chose_bdf
             )
 
             signal_info.append(
@@ -389,20 +389,20 @@ class EDFExporter:
             )
 
         # Handle user format choice if specified
-        if user_format_choice is not None and not force_format:
+        if user_chose_bdf is not None and not force_format:
             # Warn if user choice conflicts with recommendation
-            if user_format_choice and not use_bdf:
+            if user_chose_bdf and not use_bdf:
                 warnings.warn("User requested BDF format, but analysis suggests EDF would be sufficient. "
                               "Respecting user choice but be aware this may use more storage than necessary.")
                 use_bdf = True
                 print("\nUsing BDF format (24-bit) as requested by user, though EDF would be sufficient.")
-            elif not user_format_choice and use_bdf:
+            elif not user_chose_bdf and use_bdf:
                 warnings.warn(f"User requested EDF format, but analysis suggests BDF is needed: {bdf_reason}. "
                               "Respecting user choice but be aware this may result in precision loss.")
                 use_bdf = False
                 print("\nUsing EDF format (16-bit) as requested by user, despite recommendation for BDF.")
                 print(f"This may result in precision loss. Reason for BDF recommendation: {bdf_reason}")
-            elif user_format_choice and use_bdf:
+            elif user_chose_bdf and use_bdf:
                 print("\nUsing BDF format (24-bit) as requested by user, which matches the recommendation.")
             else:  # not user_format_choice and not use_bdf:
                 print("\nUsing EDF format (16-bit) as requested by user, which matches the recommendation.")
@@ -410,14 +410,14 @@ class EDFExporter:
         # Set file format and create writer
         if use_bdf:
             filepath = os.path.splitext(filepath)[0] + '.bdf'
-            if user_format_choice is None:  # Only show this message for automatic selection
+            if user_chose_bdf is None:  # Only show this message for automatic selection
                 print("\nUsing BDF format (24-bit) to preserve precision.")
                 print(f"Reason: {bdf_reason}")
                 warnings.warn(f"Using BDF format to preserve precision. Reason: {bdf_reason}")
             writer = pyedflib.EdfWriter(filepath, len(emg.channels), file_type=pyedflib.FILETYPE_BDFPLUS)
         else:
             filepath = os.path.splitext(filepath)[0] + '.edf'
-            if user_format_choice is None:  # Only show this message for automatic selection
+            if user_chose_bdf is None:  # Only show this message for automatic selection
                 print("\nUsing EDF format (16-bit) as precision loss is within acceptable range.")
             writer = pyedflib.EdfWriter(filepath, len(emg.channels), file_type=pyedflib.FILETYPE_EDFPLUS)
 
@@ -503,7 +503,7 @@ class EDFExporter:
                 analyses[ch_name] = analysis
 
                 # Only update use_bdf if we're in automatic mode
-                if user_format_choice is None:
+                if user_chose_bdf is None:
                     if use_bdf_for_channel:
                         use_bdf = True
                         if not bdf_reason:

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -297,13 +297,14 @@ class EDFExporter:
     @staticmethod
     def export(emg: EMG, filepath: str, precision_threshold: float = 0.01,
                method: str = 'both', fft_noise_range: tuple = None,
-               svd_rank: int = None, **kwargs) -> None:
+               svd_rank: int = None, format: str = 'auto',
+               force_format: bool = False, **kwargs) -> None:
         """
-        Export EMG data to EDF format with corresponding channels.tsv file.
+        Export EMG data to EDF/BDF format with corresponding channels.tsv file.
 
         Args:
             emg: EMG object containing the data
-            filepath: Path to save the EDF file
+            filepath: Path to save the EDF/BDF file
             precision_threshold: Maximum acceptable precision loss percentage (default: 0.01%)
             method: Method for signal analysis ('svd', 'fft', or 'both')
                 'svd': Uses Singular Value Decomposition for noise floor estimation
@@ -311,6 +312,11 @@ class EDFExporter:
                 'both': Uses both methods and takes the minimum noise floor (default)
             fft_noise_range: Optional tuple (min_freq, max_freq) specifying frequency range for noise in FFT method
             svd_rank: Optional manual rank cutoff for signal/noise separation in SVD method
+            format: Format to use ('auto', 'edf', or 'bdf'). Default is 'auto' which selects
+                based on signal characteristics. When specified, the system will still warn
+                if the chosen format is not optimal.
+            force_format: When True, bypasses all format suitability checks and uses the 
+                specified format without warnings. Default is False.
             **kwargs: Additional arguments for the exporter
         """
         if emg.signals is None:
@@ -320,8 +326,25 @@ class EDFExporter:
         print("\nSignal Analysis:")
         print("--------------")
 
+        # Initialize format variables
         use_bdf = False
         bdf_reason = ""
+        user_format_choice = None
+        
+        # Check if user has specified a format
+        if format.lower() != 'auto':
+            if format.lower() == 'bdf':
+                user_format_choice = True
+                if force_format:
+                    use_bdf = True
+                    print("\nUser requested BDF format (forced).")
+            elif format.lower() == 'edf':
+                user_format_choice = False
+                if force_format:
+                    use_bdf = False
+                    print("\nUser requested EDF format (forced).")
+            else:
+                warnings.warn(f"Unknown format: {format}. Valid options are 'auto', 'edf', or 'bdf'. Using 'auto'.")
         signal_info = []
         channel_info_list = []
         channels_tsv_data = {
@@ -329,7 +352,7 @@ class EDFExporter:
             'sample_frequency': [], 'reference': [], 'status': []
         }
 
-        # First pass: analyze signals and determine format
+        # First pass: analyze signals and determine recommended format
         for ch_name in emg.channels:
             signal = emg.signals[ch_name].values
             ch_info = emg.channels[ch_name]
@@ -339,17 +362,20 @@ class EDFExporter:
             analysis = analyze_signal(signal, method=method,
                                       fft_noise_range=fft_noise_range,
                                       svd_rank=svd_rank)
-            use_bdf_for_channel, reason, snr = determine_format_suitability(signal, analysis)
-
-            # Perform quantization analysis for chosen format
-            if use_bdf_for_channel:
-                use_bdf = True
-                if not bdf_reason:  # Only set reason for first channel requiring BDF
-                    bdf_reason = f"Channel {ch_name}: {reason}"
+            recommend_bdf, reason, snr = determine_format_suitability(signal, analysis)
+            
+            # If using automatic format determination or not forced
+            if user_format_choice is None or not force_format:
+                # Perform quantization analysis for chosen format
+                if recommend_bdf:
+                    use_bdf = True
+                    if not bdf_reason:  # Only set reason for first channel requiring BDF
+                        bdf_reason = f"Channel {ch_name}: {reason}"
 
             # Calculate scaling factors
             phys_min, phys_max, dig_min, dig_max, scaling = _determine_scaling_factors(
-                float(np.min(signal)), float(np.max(signal)), use_bdf=use_bdf_for_channel
+                float(np.min(signal)), float(np.max(signal)), 
+                use_bdf=recommend_bdf if user_format_choice is None else user_format_choice
             )
 
             signal_info.append(
@@ -359,19 +385,40 @@ class EDFExporter:
                 f"\n    Noise Floor: {analysis['noise_floor']:.2e} {ch_info['physical_dimension']}"
                 f"\n    SNR: {snr:.1f} dB"
                 f"\n    Method: {analysis.get('method', 'svd')}"
-                f"\n    Format: {'BDF' if use_bdf_for_channel else 'EDF'}"
+                f"\n    Recommended Format: {'BDF' if recommend_bdf else 'EDF'}"
             )
 
+        # Handle user format choice if specified
+        if user_format_choice is not None and not force_format:
+            # Warn if user choice conflicts with recommendation
+            if user_format_choice and not use_bdf:
+                warnings.warn("User requested BDF format, but analysis suggests EDF would be sufficient. "
+                              "Respecting user choice but be aware this may use more storage than necessary.")
+                use_bdf = True
+                print("\nUsing BDF format (24-bit) as requested by user, though EDF would be sufficient.")
+            elif not user_format_choice and use_bdf:
+                warnings.warn(f"User requested EDF format, but analysis suggests BDF is needed: {bdf_reason}. "
+                              "Respecting user choice but be aware this may result in precision loss.")
+                use_bdf = False
+                print("\nUsing EDF format (16-bit) as requested by user, despite recommendation for BDF.")
+                print(f"This may result in precision loss. Reason for BDF recommendation: {bdf_reason}")
+            elif user_format_choice and use_bdf:
+                print("\nUsing BDF format (24-bit) as requested by user, which matches the recommendation.")
+            else:  # not user_format_choice and not use_bdf:
+                print("\nUsing EDF format (16-bit) as requested by user, which matches the recommendation.")
+        
         # Set file format and create writer
         if use_bdf:
             filepath = os.path.splitext(filepath)[0] + '.bdf'
-            print("\nUsing BDF format (24-bit) to preserve precision.")
-            print(f"Reason: {bdf_reason}")
-            warnings.warn(f"Using BDF format to preserve precision. Reason: {bdf_reason}")
+            if user_format_choice is None:  # Only show this message for automatic selection
+                print("\nUsing BDF format (24-bit) to preserve precision.")
+                print(f"Reason: {bdf_reason}")
+                warnings.warn(f"Using BDF format to preserve precision. Reason: {bdf_reason}")
             writer = pyedflib.EdfWriter(filepath, len(emg.channels), file_type=pyedflib.FILETYPE_BDFPLUS)
         else:
             filepath = os.path.splitext(filepath)[0] + '.edf'
-            print("\nUsing EDF format (16-bit) as precision loss is within acceptable range.")
+            if user_format_choice is None:  # Only show this message for automatic selection
+                print("\nUsing EDF format (16-bit) as precision loss is within acceptable range.")
             writer = pyedflib.EdfWriter(filepath, len(emg.channels), file_type=pyedflib.FILETYPE_EDFPLUS)
 
         try:
@@ -455,10 +502,12 @@ class EDFExporter:
                 analysis['use_bdf'] = use_bdf_for_channel
                 analyses[ch_name] = analysis
 
-                if use_bdf_for_channel:
-                    use_bdf = True
-                    if not bdf_reason:
-                        bdf_reason = f"Channel {ch_name}: {reason}"
+                # Only update use_bdf if we're in automatic mode
+                if user_format_choice is None:
+                    if use_bdf_for_channel:
+                        use_bdf = True
+                        if not bdf_reason:
+                            bdf_reason = f"Channel {ch_name}: {reason}"
 
             # Print signal info
             for info in signal_info:

--- a/emgio/tests/test_exporters.py
+++ b/emgio/tests/test_exporters.py
@@ -467,6 +467,98 @@ if __name__ == "__main__":
     print("Final dynamic range: {:.2f} dB".format(dr))
 
 
+def test_user_format_selection():
+    """Test explicit format selection by user."""
+    # Create EMG object
+    emg = EMG()
+    time = np.linspace(0, 1, 1000)
+
+    # Test case 1: High quality signal (would normally use EDF)
+    clean_signal = np.sin(2 * np.pi * 10 * time) * 1000  # Clean 10 Hz sine
+    emg.add_channel('Clean', clean_signal, 1000, 'uV', 'EMG')
+
+    # Test case 2: High dynamic range signal (would normally use BDF)
+    hdr_signal, actual_dr = generate_high_dynamic_range_signal(dynamic_range_db=95)
+    emg.add_channel('HDR', hdr_signal, 1000, 'uV', 'EMG')
+
+    with tempfile.NamedTemporaryFile(suffix='.edf', delete=False) as f:
+        edf_path = f.name
+        bdf_path = os.path.splitext(edf_path)[0] + '.bdf'
+
+    try:
+        # 1. Test explicit EDF format selection (warning expected)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            EDFExporter.export(emg, edf_path, format='edf')
+            # Should have created an EDF file despite one HDR channel
+            assert os.path.exists(edf_path)
+            # Should have warned about potential precision loss
+            format_warnings = [warn for warn in w 
+                              if "EDF format" in str(warn.message) 
+                              and "precision loss" in str(warn.message)]
+            assert len(format_warnings) > 0, "No warning about precision loss when using EDF format"
+
+        # Clean up first test
+        if os.path.exists(edf_path):
+            os.unlink(edf_path)
+        if os.path.exists(bdf_path):
+            os.unlink(bdf_path)
+
+        # 2. Test explicit BDF format selection (warning expected)
+        emg = EMG()  # Create a new EMG object with only clean signal
+        
+        # Add some noise to ensure a more realistic dynamic range that won't trigger BDF
+        np.random.seed(42)  # For reproducibility
+        noisy_signal = np.sin(2 * np.pi * 10 * time) * 100  # Lower amplitude signal
+        noise = np.random.normal(0, 5.0, 1000)  # Add significant noise (5% of signal)
+        noisy_signal = noisy_signal + noise  # This will reduce dynamic range
+        
+        emg.add_channel('LowDR', noisy_signal, 1000, 'uV', 'EMG')
+        
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            EDFExporter.export(emg, edf_path, format='bdf')
+            # Should have created a BDF file despite only having clean signals
+            assert os.path.exists(bdf_path)
+            # Should have warned about unnecessary storage
+            format_warnings = [warn for warn in w 
+                               if "BDF format" in str(warn.message) 
+                               and "storage" in str(warn.message)]
+            assert len(format_warnings) > 0, "No warning about unnecessary storage when using BDF format"
+
+        # Clean up second test
+        if os.path.exists(edf_path):
+            os.unlink(edf_path)
+        if os.path.exists(bdf_path):
+            os.unlink(bdf_path)
+
+        # 3. Test force_format parameter
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # Create a new EMG object with high dynamic range signal
+            emg = EMG()
+            emg.add_channel('HDR', hdr_signal, 1000, 'uV', 'EMG')
+            
+            # Force EDF format despite high dynamic range
+            EDFExporter.export(emg, edf_path, format='edf', force_format=True)
+            
+            # Should have created an EDF file with no warnings
+            assert os.path.exists(edf_path)
+            
+            # Should not have warned about precision loss when force_format=True
+            format_warnings = [warn for warn in w 
+                               if "EDF format" in str(warn.message) 
+                               and "precision loss" in str(warn.message)]
+            assert len(format_warnings) == 0, "Warning shown despite force_format=True"
+
+    finally:
+        # Cleanup
+        if os.path.exists(edf_path):
+            os.unlink(edf_path)
+        if os.path.exists(bdf_path):
+            os.unlink(bdf_path)
+
+
 def test_high_dynamic_range():
     """Test export of signals with very high dynamic range (>90dB)."""
     # Create EMG object


### PR DESCRIPTION
Adding options for manual `format` selection and also forcing the manual selection.

With `force-format=True`, user will bypass all the checks impelmented in the toolbox to determine the suitable foramt.
`force-format=False` will do the same thing, but issues warnings about the format suitablity if necessary.