### PR TITLE
22 create documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r docs/requirements.txt
+      
+      - name: Build documentation
+        run: mkdocs build
+      
+      - name: Deploy documentation
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: site
+          branch: gh-pages 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A Python package for EMG data import/export and manipulation. This package provi
 
 The determination of the EDF/BDF format is based on the dynamic range of the data. If the data is within the range of 16-bit integers (~90dB), the EDF format is used. Otherwise, the BDF format is used. This is to ensure that the data is stored in the most efficient format possible. This determination is made automatically using SVD decomposition and/or FFT to determine the dynamic range of the data.
 
+## Documentation
+
+The documentation including installation instructions, examples, and API reference is available at [https://neuromechanist.github.io/emgio/](https://neuromechanist.github.io/emgio/).
+
 ## Features
 
 - Import EMG data from multiple systems:

--- a/docs/api/emg.md
+++ b/docs/api/emg.md
@@ -1,0 +1,143 @@
+# EMG Class API
+
+The `EMG` class is the main class in EMGIO for working with EMG data. It encapsulates signals, channel information, and metadata, and provides methods for data manipulation and export.
+
+## Class Documentation
+
+::: emgio.core.emg.EMG
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+      show_submodules: true
+
+## Key Methods Summary
+
+### Data Loading
+
+- `from_file()`: Load EMG data from a file (class method)
+- `from_dataframe()`: Create EMG object from a pandas DataFrame (class method)
+
+### Data Access
+
+- `get_sampling_frequency()`: Get the sampling frequency of the data
+- `get_n_samples()`: Get the number of samples
+- `get_n_channels()`: Get the number of channels
+- `get_duration()`: Get the duration of the recording in seconds
+- `get_channel_types()`: Get the unique channel types
+- `get_channels_by_type()`: Get channel names of a specific type
+
+### Data Manipulation
+
+- `select_channels()`: Create a new EMG object with selected channels
+- `set_metadata()`: Set a single metadata field
+- `get_metadata()`: Get a single metadata field
+- `has_metadata()`: Check if a metadata field exists
+
+### Visualization
+
+- `plot_signals()`: Plot EMG signals
+
+### Export
+
+- `to_edf()`: Export data to EDF/BDF format
+
+## Usage Examples
+
+### Loading Data
+
+```python
+from emgio import EMG
+
+# Load from file with automatic importer selection
+emg = EMG.from_file('data.csv')
+
+# Load with explicit importer
+emg = EMG.from_file('data.csv', importer='trigno')
+```
+
+### Creating from DataFrame
+
+```python
+import pandas as pd
+from emgio import EMG
+
+# Create a DataFrame with EMG data
+data = pd.DataFrame({
+    'EMG1': [1, 2, 3, 4, 5],
+    'EMG2': [5, 4, 3, 2, 1]
+})
+
+# Create channels dictionary
+channels = {
+    'EMG1': {
+        'channel_type': 'EMG',
+        'physical_dimension': 'µV',
+        'sample_frequency': 1000
+    },
+    'EMG2': {
+        'channel_type': 'EMG',
+        'physical_dimension': 'µV',
+        'sample_frequency': 1000
+    }
+}
+
+# Create EMG object
+emg = EMG.from_dataframe(data, channels=channels)
+```
+
+### Selecting Channels
+
+```python
+# Select by channel names
+subset = emg.select_channels(['EMG1', 'EMG2'])
+
+# Select by channel type
+emg_only = emg.select_channels(channel_type='EMG')
+```
+
+### Metadata Handling
+
+```python
+# Set metadata
+emg.set_metadata('subject', 'S001')
+
+# Get metadata
+subject = emg.get_metadata('subject')
+
+# Check if metadata exists
+if emg.has_metadata('condition'):
+    condition = emg.get_metadata('condition')
+```
+
+### Plotting
+
+```python
+# Plot all channels
+emg.plot_signals()
+
+# Plot specific channels with time range
+emg.plot_signals(['EMG1', 'EMG2'], time_range=(0, 5))
+
+# Customize plot
+emg.plot_signals(
+    channels=['EMG1', 'EMG2'],
+    time_range=(0, 5),
+    title='EMG Signals',
+    figsize=(12, 6),
+    grid=True
+)
+```
+
+### Exporting
+
+```python
+# Export with automatic format selection
+emg.to_edf('output')
+
+# Force EDF format
+emg.to_edf('output', force_format='edf')
+
+# Control format selection method
+emg.to_edf('output', method='svd')
+``` 

--- a/docs/api/exporters/edf.md
+++ b/docs/api/exporters/edf.md
@@ -1,0 +1,101 @@
+# EDF/BDF Exporter
+
+The EDF/BDF exporter module in EMGIO provides functionality to export EMG data to EDF (European Data Format) or BDF (BioSemi Data Format) files.
+
+## Module Documentation
+
+::: emgio.exporters.edf
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import EMG
+
+# Load data
+emg = EMG.from_file('data.csv', importer='trigno')
+
+# Export to EDF/BDF with automatic format selection
+emg.to_edf('output')  # Will generate output.edf or output.bdf
+
+# Force specific format
+emg.to_edf('output_edf', force_format='edf')  # Forces 16-bit EDF
+emg.to_edf('output_bdf', force_format='bdf')  # Forces 24-bit BDF
+```
+
+## Automatic Format Selection
+
+A key feature of EMGIO's exporter is its ability to automatically determine whether to use EDF (16-bit) or BDF (24-bit) format based on the dynamic range of the data:
+
+```python
+# Control the analysis method for format selection
+emg.to_edf('output', method='svd')  # Use SVD analysis only
+emg.to_edf('output', method='fft')  # Use FFT analysis only 
+emg.to_edf('output', method='both')  # Use both methods (default)
+
+# Customize SVD parameters
+emg.to_edf('output', method='svd', svd_rank=5)  # Manual rank cutoff
+
+# Customize FFT parameters
+emg.to_edf('output', 
+           method='fft', 
+           fft_noise_range=(0.1, 10))  # Manual frequency range for noise floor estimation
+```
+
+## Parameters
+
+The `to_edf` method accepts the following parameters:
+
+- **output_path (str)**: Path for the output file (without extension)
+- **force_format (str, optional)**: Force a specific format ('edf' or 'bdf'). Default is None (automatic).
+- **method (str, optional)**: Method for format selection ('svd', 'fft', or 'both'). Default is 'both'.
+- **svd_rank (int, optional)**: Rank cutoff for SVD analysis. Default is None (automatic).
+- **fft_noise_range (tuple, optional)**: Frequency range (min, max) for noise floor estimation in FFT. Default is None (automatic).
+- **physical_min (float, optional)**: Physical minimum value. Default is None (automatic).
+- **physical_max (float, optional)**: Physical maximum value. Default is None (automatic).
+- **overwrite (bool, optional)**: Whether to overwrite existing files. Default is False.
+- **additional_info (dict, optional)**: Additional information to include in the EDF header.
+
+## Understanding Format Selection
+
+The exporter uses two complementary approaches to determine the appropriate format:
+
+### 1. SVD Analysis
+
+Singular Value Decomposition (SVD) is used to:
+- Estimate the effective dimensionality of the data
+- Analyze the distribution of signal energy across components 
+- Determine if the precision requirements can be satisfied by 16-bit representation
+
+### 2. FFT Analysis
+
+Fast Fourier Transform (FFT) analysis:
+- Examines the frequency domain representation of the data
+- Evaluates the noise floor and signal-to-noise ratio
+- Helps determine if 16-bit precision is sufficient or if 24-bit is needed
+
+## Output Files
+
+When exporting, EMGIO generates the following files:
+
+1. **Main data file**: Either `.edf` or `.bdf` extension depending on the format selected
+2. **Channels metadata file**: A `{output_path}.channels.tsv` file with detailed channel information in BIDS-compatible format
+
+Example channels.tsv file content:
+```
+name    type    units   sampling_frequency
+EMG1    EMG     µV      2000
+EMG2    EMG     µV      2000
+ACC1    ACC     g       2000
+```
+
+## Additional Features
+
+- **Channel scaling**: Signals are automatically scaled to maximize precision
+- **Metadata preservation**: Subject, recording, and other metadata are included in the EDF header
+- **BIDS compatibility**: The exporter follows BIDS conventions for metadata
+- **Multi-channel support**: Handles multiple channel types with appropriate units
+- **Different sampling rates**: Can handle channels with different sampling rates 

--- a/docs/api/importers/base.md
+++ b/docs/api/importers/base.md
@@ -1,0 +1,107 @@
+# Base Importer
+
+The `BaseImporter` class is the abstract base class for all importers in EMGIO. It defines the interface that all specific importers must implement.
+
+## Class Documentation
+
+::: emgio.importers.base
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Creating a Custom Importer
+
+To create a custom importer for a new format, you should inherit from `BaseImporter` and implement its abstract methods:
+
+```python
+from emgio.importers.base import BaseImporter
+import pandas as pd
+
+class MyCustomImporter(BaseImporter):
+    def __init__(self, file_path, **kwargs):
+        """Initialize the importer with a file path."""
+        self.file_path = file_path
+        self.kwargs = kwargs
+        
+    def load(self):
+        """
+        Load and parse the custom format file.
+        
+        Returns
+        -------
+        tuple
+            A tuple containing (signals, channels, metadata)
+            - signals: pandas DataFrame with signal data
+            - channels: dictionary with channel information
+            - metadata: dictionary with additional metadata
+        """
+        # Implement file loading logic for your custom format
+        signals = pd.DataFrame(...)  # Load signal data
+        
+        # Create channels dictionary
+        channels = {
+            'CH1': {
+                'channel_type': 'EMG',
+                'physical_dimension': 'µV',
+                'sample_frequency': 1000,
+                # ...other channel metadata...
+            },
+            # ...additional channels...
+        }
+        
+        # Create metadata dictionary
+        metadata = {
+            'subject': '001',
+            'recording_date': '2023-01-01',
+            # ...other metadata...
+        }
+        
+        return signals, channels, metadata
+```
+
+## Required Return Values
+
+The `load()` method must return a tuple of three elements:
+
+1. **signals**: A pandas DataFrame containing the signal data with:
+   - Columns named after channels
+   - Rows representing time points
+
+2. **channels**: A dictionary with channel information:
+   ```python
+   {
+       'channel_name': {
+           'channel_type': str,        # Type of channel (e.g., 'EMG', 'ACC')
+           'physical_dimension': str,   # Unit (e.g., 'µV', 'mV', 'g')
+           'sample_frequency': float,   # Sampling frequency in Hz
+           # Optional additional fields
+       },
+       # ...more channels...
+   }
+   ```
+
+3. **metadata**: A dictionary with additional information:
+   ```python
+   {
+       'subject': str,            # Subject identifier
+       'recording_date': str,     # Recording date
+       'device': str,             # Recording device
+       # ...other metadata fields...
+   }
+   ```
+
+## Registering a Custom Importer
+
+To make your custom importer available through `EMG.from_file()`, you need to register it:
+
+```python
+from emgio import EMG
+from my_module import MyCustomImporter
+
+# Register the importer with a name
+EMG.register_importer('my_format', MyCustomImporter)
+
+# Now you can use it
+emg = EMG.from_file('data.custom', importer='my_format')
+``` 

--- a/docs/api/importers/edf.md
+++ b/docs/api/importers/edf.md
@@ -1,0 +1,101 @@
+# EDF Importer
+
+The `EDFImporter` class is responsible for importing EMG and other physiological data from EDF (European Data Format) and BDF (BioSemi Data Format) files.
+
+## Class Documentation
+
+::: emgio.importers.edf
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import EMG
+from emgio.importers.edf import EDFImporter
+
+# Method 1: Using EMG.from_file (recommended)
+emg = EMG.from_file('data.edf', importer='edf')  # Works for both .edf and .bdf
+
+# Method 2: Using the importer directly
+importer = EDFImporter('data.edf')
+signals, channels, metadata = importer.load()
+emg = EMG(signals, channels, metadata)
+```
+
+## File Format Support
+
+The EDF importer supports:
+
+1. EDF files (16-bit resolution)
+2. BDF files (24-bit resolution)
+3. EDF+ files with annotations
+4. Different sampling rates for different channels
+5. Time-stamped data
+
+## Channel Type Detection
+
+The EDF importer attempts to identify channel types based on:
+
+1. Channel labels in the EDF header
+2. Signal characteristics 
+3. Common naming conventions (e.g., channels with 'EMG' in the name are classified as 'EMG')
+
+## Parameters
+
+- **file_path (str)**: Path to the EDF/BDF file
+- **kwargs (dict)**: Additional keyword arguments
+  - **load_data (bool, optional)**: Whether to load the data or just metadata. Default is True.
+  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
+  - **start_time (float, optional)**: Start time in seconds for loading a subset of the data.
+  - **end_time (float, optional)**: End time in seconds for loading a subset of the data.
+
+## Return Values
+
+The `load()` method returns a tuple of:
+
+1. **signals (pandas.DataFrame)**: Signal data with channels as columns
+2. **channels (dict)**: Dictionary of channel information including:
+   - channel_type: Type of channel (EMG, EEG, etc.)
+   - physical_dimension: Physical unit (e.g., 'µV', 'mV')
+   - sample_frequency: Sampling rate in Hz
+   - physical_min: Minimum physical value
+   - physical_max: Maximum physical value
+   - digital_min: Minimum digital value
+   - digital_max: Maximum digital value
+
+3. **metadata (dict)**: Dictionary containing metadata from the EDF file, including:
+   - subject: Subject identifier (from EDF patient field)
+   - recording_date: Recording date
+   - start_time: Start time of the recording
+   - duration: Duration of the recording in seconds
+   - file_type: 'EDF' or 'BDF'
+   - annotations: Any annotations found in the file
+
+## Implementation Details
+
+The EDF importer uses the `pyedflib` package to:
+
+1. Read the EDF/BDF file header to extract metadata
+2. Extract channel information and convert to EMGIO's format
+3. Load the signal data, applying appropriate scaling
+4. Handle annotations if present
+5. Convert the data to a pandas DataFrame for use with EMGIO
+
+## Working with Annotations
+
+EDF+ files can contain annotations that mark specific events or segments in the data. The importer preserves these annotations in the metadata dictionary:
+
+```python
+# Load EDF+ file with annotations
+emg = EMG.from_file('data.edf+', importer='edf')
+
+# Access annotations
+annotations = emg.get_metadata('annotations')
+if annotations:
+    for annotation in annotations:
+        onset, duration, description = annotation
+        print(f"Event: {description} at {onset}s, duration: {duration}s")
+``` 

--- a/docs/api/importers/eeglab.md
+++ b/docs/api/importers/eeglab.md
@@ -1,0 +1,77 @@
+# EEGLAB Importer
+
+The `EEGLABImporter` class is responsible for importing EMG (and other biopotential) data from EEGLAB `.set` files.
+
+## Class Documentation
+
+::: emgio.importers.eeglab
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import EMG
+from emgio.importers.eeglab import EEGLABImporter
+
+# Method 1: Using EMG.from_file (recommended)
+emg = EMG.from_file('data.set', importer='eeglab')
+
+# Method 2: Using the importer directly
+importer = EEGLABImporter('data.set')
+signals, channels, metadata = importer.load()
+emg = EMG(signals, channels, metadata)
+```
+
+## File Format Support
+
+The EEGLAB importer supports:
+
+1. MATLAB `.set` files (version 7.3 and earlier)
+2. Both continuous and epoched data
+3. Multiple channel types (EMG, EEG, ACC, etc.)
+4. Event markers and annotations
+
+## Channel Type Detection
+
+The EEGLAB importer attempts to detect channel types based on:
+
+1. Channel labels in the EEGLAB `chanlocs` structure
+2. Channel type information if available
+3. Naming conventions (e.g., channels with 'EMG' in the name are classified as 'EMG')
+
+## Parameters
+
+- **file_path (str)**: Path to the EEGLAB .set file
+- **kwargs (dict)**: Additional keyword arguments
+  - **load_data (bool, optional)**: Whether to load the data or just metadata. Default is True.
+  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
+
+## Return Values
+
+The `load()` method returns a tuple of:
+
+1. **signals (pandas.DataFrame)**: Signal data with channels as columns
+2. **channels (dict)**: Dictionary of channel information including:
+   - channel_type: Type of channel (EMG, EEG, etc.)
+   - physical_dimension: Physical unit (e.g., 'µV')
+   - sample_frequency: Sampling rate in Hz
+   - coordinates: Channel coordinates if available
+
+3. **metadata (dict)**: Dictionary containing metadata from the EEGLAB file, including:
+   - subject: Subject identifier
+   - session: Session identifier
+   - condition: Condition/task information
+   - srate: Sampling rate
+   - xmin/xmax: Time limits
+   - event: Event markers
+   - epoch: Epoch information (if epoched)
+
+## Notes
+
+- The importer automatically handles both continuous and epoched data
+- For epoched data, epochs are concatenated in the time dimension
+- Event markers are preserved in the metadata
+- Channel locations are preserved in the channel information when available 

--- a/docs/api/importers/otb.md
+++ b/docs/api/importers/otb.md
@@ -1,0 +1,84 @@
+# OTB Importer
+
+The `OTBImporter` class is responsible for importing EMG and other electrophysiological data from OT Bioelettronica's OTB+ files.
+
+## Class Documentation
+
+::: emgio.importers.otb
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import EMG
+from emgio.importers.otb import OTBImporter
+
+# Method 1: Using EMG.from_file (recommended)
+emg = EMG.from_file('data.otb+', importer='otb')
+
+# Method 2: Using the importer directly
+importer = OTBImporter('data.otb+')
+signals, channels, metadata = importer.load()
+emg = EMG(signals, channels, metadata)
+```
+
+## File Format Support
+
+The OTB importer supports:
+1. Binary OTB+ files from OT Bioelettronica devices (SESSANTAQUATTRO, MUOVI, etc.)
+2. Multiple channel types (EMG, ACC, TRIG, AUX, IMUX)
+3. Different sampling rates for different channel types
+4. Various bit resolutions (8-bit, 12-bit, 16-bit, etc.)
+
+## Channel Type Mapping
+
+The OTB importer identifies channel types based on the OTB+ file header information. Common channel types include:
+
+- **EMG**: Electromyography channels
+- **ACC**: Accelerometer channels
+- **TRIG**: Trigger channels
+- **AUX**: Auxiliary channels 
+- **IMUX**: Input multiplexer channels
+
+## Parameters
+
+- **file_path (str)**: Path to the OTB+ file
+- **kwargs (dict)**: Additional keyword arguments
+  - **use_matlab (bool, optional)**: Whether to use MATLAB for import (requires MATLAB runtime). Default is False.
+  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
+
+## Return Values
+
+The `load()` method returns a tuple of:
+
+1. **signals (pandas.DataFrame)**: Signal data with channels as columns
+2. **channels (dict)**: Dictionary of channel information including:
+   - channel_type: Type of channel (EMG, ACC, etc.)
+   - physical_dimension: Physical unit (e.g., 'µV' for EMG, 'g' for ACC)
+   - sample_frequency: Sampling rate in Hz
+   - bit_resolution: Bit resolution of the channel
+   - calibration_factor: Calibration factor for converting raw to physical values
+
+3. **metadata (dict)**: Dictionary containing metadata from the OTB+ file, including:
+   - device: Device name (e.g., 'SESSANTAQUATTRO')
+   - recording_date: Recording date if available
+   - signal_resolution: Bit resolution of the signals
+   - device_settings: Additional device-specific settings
+
+## Implementation Details
+
+The OTB importer works by:
+
+1. Reading the binary header information from the OTB+ file
+2. Parsing the header to extract metadata about channels and device settings
+3. Loading the raw signal data from the binary file
+4. Applying calibration factors to convert raw values to physical units
+5. Organizing the data into channel types and creating the appropriate metadata
+
+## Dependencies
+
+- The OTB importer includes a pure Python implementation for parsing OTB+ files
+- It can optionally use the OT Bioelettronica MATLAB functions for import if MATLAB is available 

--- a/docs/api/importers/trigno.md
+++ b/docs/api/importers/trigno.md
@@ -1,0 +1,70 @@
+# Trigno Importer
+
+The `TrignoImporter` class is responsible for importing EMG data from Delsys Trigno CSV files.
+
+## Class Documentation
+
+::: emgio.importers.trigno
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import EMG
+from emgio.importers.trigno import TrignoImporter
+
+# Method 1: Using EMG.from_file (recommended)
+emg = EMG.from_file('data.csv', importer='trigno')
+
+# Method 2: Using the importer directly
+importer = TrignoImporter('data.csv')
+signals, channels, metadata = importer.load()
+emg = EMG(signals, channels, metadata)
+```
+
+## File Format Requirements
+
+The importer expects a CSV file with:
+
+1. A header section (optional) containing metadata lines starting with '#'
+2. A data section with columns:
+   - First column: Time in seconds
+   - Remaining columns: Channel data
+
+Example:
+```
+# Delsys Trigno EMG Data
+# Recording Date: 2023-01-01
+# Subject: S001
+Time(s),EMG1,EMG2,EMG3,EMG4,ACC1_X,ACC1_Y,ACC1_Z
+0.000,0.01,0.02,0.03,0.04,0.05,0.06,0.07
+0.001,0.02,0.03,0.04,0.05,0.06,0.07,0.08
+...
+```
+
+## Channel Type Detection
+
+The Trigno importer automatically detects channel types based on channel names:
+
+- Channels containing 'EMG' or 'emg' are classified as 'EMG'
+- Channels containing 'ACC' or 'acc' are classified as 'ACC'
+- Other channels are classified as 'OTHER'
+
+## Parameters
+
+- **file_path (str)**: Path to the Trigno CSV file
+- **kwargs (dict)**: Additional keyword arguments
+  - **header_rows (int, optional)**: Number of header rows to skip. If not provided, automatically detected.
+  - **delimiter (str, optional)**: Column delimiter. Default is ','.
+  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
+
+## Return Values
+
+The `load()` method returns a tuple of:
+
+1. **signals (pandas.DataFrame)**: Signal data with channels as columns
+2. **channels (dict)**: Dictionary of channel information
+3. **metadata (dict)**: Dictionary containing metadata from the header 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,141 @@
+# Contributing to EMGIO
+
+We welcome contributions to EMGIO! This guide will help you get started with the development process.
+
+## Development Setup
+
+1. Clone the repository:
+```bash
+git clone https://github.com/neuromechanist/emgio.git
+cd emgio
+```
+
+2. Install for development:
+```bash
+pip install -e .
+```
+
+3. Install test dependencies:
+```bash
+pip install -r test-requirements.txt
+```
+
+## Code Structure
+
+The EMGIO codebase is organized as follows:
+
+```
+emgio/
+├── emgio/              # Main package directory
+│   ├── __init__.py     # Package initialization
+│   ├── core/           # Core functionality
+│   │   ├── emg.py      # Main EMG class
+│   ├── importers/      # Data import modules
+│   │   ├── base.py     # Base importer class
+│   │   ├── trigno.py   # Trigno importer
+│   │   ├── eeglab.py   # EEGLAB importer
+│   │   ├── otb.py      # OTB importer
+│   │   ├── edf.py      # EDF importer
+│   ├── exporters/      # Data export modules
+│   │   ├── edf.py      # EDF/BDF exporter
+│   ├── utils/          # Utility functions
+│   ├── analysis/       # Analysis methods
+│   ├── tests/          # Test suite
+├── examples/           # Example scripts
+├── docs/               # Documentation
+```
+
+## Testing
+
+### Running Tests
+
+EMGIO uses pytest for testing. To run the full test suite:
+
+```bash
+pytest
+```
+
+To run tests with coverage:
+
+```bash
+pytest --cov=emgio
+```
+
+### Writing Tests
+
+When adding new features, please include appropriate tests. Tests should be placed in the `emgio/tests` directory, with a naming convention of `test_*.py`.
+
+Example test:
+
+```python
+def test_channel_selection():
+    # Create a test EMG object
+    ...
+    
+    # Run the function being tested
+    ...
+    
+    # Assert the expected outcome
+    assert ...
+```
+
+## Documentation
+
+### Building Documentation
+
+Documentation is built using MkDocs with the Material theme:
+
+1. Install documentation dependencies:
+```bash
+pip install -r docs/requirements.txt
+```
+
+2. Build and serve the documentation locally:
+```bash
+mkdocs serve
+```
+
+3. Open your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
+
+### Writing Documentation
+
+- API documentation is generated automatically from docstrings
+- Use NumPy-style docstrings for all functions and classes
+- Add examples to the examples directory and reference them in the documentation
+- Update the appropriate section of the user guide when adding new features
+
+## Pull Request Process
+
+1. Fork the repository on GitHub
+2. Create a feature branch (`git checkout -b feature/my-new-feature`)
+3. Make your changes and add tests
+4. Ensure all tests pass (`pytest`)
+5. Make sure the documentation builds without errors (`mkdocs build`)
+6. Commit your changes (`git commit -am 'Add new feature'`)
+7. Push to your branch (`git push origin feature/my-new-feature`)
+8. Create a new Pull Request on GitHub
+
+## Coding Style
+
+EMGIO follows PEP 8 guidelines. We recommend using tools like flake8 or pylint to check your code style before submitting a pull request.
+
+Some specific style guidelines:
+- Use 4 spaces for indentation (not tabs)
+- Maximum line length of 100 characters
+- Use docstrings for all public methods and classes
+- Use meaningful variable and function names
+
+## Adding New Importers
+
+To add support for a new EMG format:
+
+1. Create a new file in `emgio/importers/` (e.g., `new_format.py`)
+2. Implement a class that inherits from `BaseImporter`
+3. Implement the required methods
+4. Add the new importer to `__init__.py`
+5. Add tests in `tests/test_importers.py`
+6. Document the new format in the user guide
+
+## License
+
+By contributing to EMGIO, you agree that your contributions will be licensed under the BSD 3-Clause License. 

--- a/docs/examples/eeglab.md
+++ b/docs/examples/eeglab.md
@@ -1,0 +1,183 @@
+# EEGLAB Examples
+
+This page provides examples for working with EEGLAB `.set` files using EMGIO.
+
+## Basic EEGLAB Example
+
+```python
+import os
+from emgio import EMG
+import matplotlib.pyplot as plt
+
+# Load data from an EEGLAB .set file
+data_path = 'path_to_your_eeglab_file.set'
+emg = EMG.from_file(data_path, importer='eeglab')
+
+# Print metadata
+print("\nMetadata:")
+print("-" * 50)
+for key in ['subject', 'session', 'condition', 'srate', 'nbchan', 'pnts']:
+    if key in emg.metadata:
+        print(f"{key}: {emg.get_metadata(key)}")
+
+# Print available channels
+print("\nAvailable channels:")
+print("-" * 50)
+channel_types = emg.get_channel_types()
+for ch_type in channel_types:
+    channels = emg.get_channels_by_type(ch_type)
+    print(f"{ch_type} channels ({len(channels)}):")
+    for i, ch_name in enumerate(channels[:5]):  # Print first 5 channels of each type
+        ch_info = emg.channels[ch_name]
+        print(f"  - {ch_name} (Sampling rate: {ch_info['sample_frequency']} Hz, "
+              f"Unit: {ch_info['physical_dimension']})")
+    if len(channels) > 5:
+        print(f"  ... and {len(channels) - 5} more {ch_type} channels")
+
+# Plot EMG channels
+emg_channels = emg.get_channels_by_type('EMG')
+if emg_channels:
+    # Select EMG channels only
+    emg_only = emg.select_channels(emg_channels)
+    
+    # Plot the first 5 seconds
+    plt.figure(figsize=(12, 8))
+    emg_only.plot_signals(time_range=(0, 5), title="EMG Signals from EEGLAB")
+    plt.tight_layout()
+    plt.show()
+```
+
+## Working with Events
+
+EEGLAB files often contain event markers. Here's how to access and work with them:
+
+```python
+from emgio import EMG
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Load EEGLAB data with events
+emg = EMG.from_file('data_with_events.set', importer='eeglab')
+
+# Check if events exist in the metadata
+if 'event' in emg.metadata:
+    events = emg.get_metadata('event')
+    print(f"Found {len(events)} events")
+    
+    # Print the first 5 events
+    for i, event in enumerate(events[:5]):
+        print(f"Event {i+1}: Type={event.get('type')}, Latency={event.get('latency')}")
+    
+    # Extract specific event types
+    movement_events = [e for e in events if e.get('type') == 'movement']
+    print(f"Found {len(movement_events)} movement events")
+    
+    # Plot signals around an event
+    if movement_events:
+        # Get the timestamp of the first movement event (convert from samples to seconds)
+        event_sample = movement_events[0].get('latency')
+        fs = emg.get_sampling_frequency()
+        event_time = event_sample / fs
+        
+        # Plot 2 seconds before and after the event
+        window = 2  # seconds
+        plt.figure(figsize=(12, 8))
+        emg.plot_signals(
+            time_range=(event_time - window, event_time + window),
+            title=f"EMG around movement event at {event_time:.2f}s"
+        )
+        
+        # Add a vertical line at the event time
+        plt.axvline(x=event_time, color='r', linestyle='--', label='Movement Event')
+        plt.legend()
+        plt.tight_layout()
+        plt.show()
+```
+
+## Converting Epoched Data
+
+EEGLAB can store continuous or epoched data. EMGIO can work with both:
+
+```python
+from emgio import EMG
+import matplotlib.pyplot as plt
+
+# Load epoched EEGLAB data
+emg = EMG.from_file('epoched_data.set', importer='eeglab')
+
+# Check if data is epoched
+is_epoched = emg.get_metadata('trials', 1) > 1
+print(f"Data is {'epoched' if is_epoched else 'continuous'}")
+
+if is_epoched:
+    # Get epoch information
+    n_epochs = emg.get_metadata('trials')
+    epoch_length = emg.get_metadata('pnts')
+    fs = emg.get_sampling_frequency()
+    epoch_duration = epoch_length / fs
+    
+    print(f"Number of epochs: {n_epochs}")
+    print(f"Epoch length: {epoch_length} samples ({epoch_duration:.2f} seconds)")
+    
+    # EMGIO automatically concatenates epochs, so the data is handled as continuous
+    # The total duration is epochs * epoch_duration
+    total_duration = emg.get_duration()
+    print(f"Total duration: {total_duration:.2f} seconds")
+    
+    # Plot signals from different epochs
+    plt.figure(figsize=(15, 10))
+    
+    # Plot first epoch
+    plt.subplot(3, 1, 1)
+    emg.plot_signals(
+        time_range=(0, epoch_duration),
+        title="First Epoch",
+        ax=plt.gca()
+    )
+    
+    # Plot middle epoch
+    middle_epoch = n_epochs // 2
+    middle_start = middle_epoch * epoch_duration
+    plt.subplot(3, 1, 2)
+    emg.plot_signals(
+        time_range=(middle_start, middle_start + epoch_duration),
+        title=f"Middle Epoch (Epoch {middle_epoch+1})",
+        ax=plt.gca()
+    )
+    
+    # Plot last epoch
+    last_start = (n_epochs - 1) * epoch_duration
+    plt.subplot(3, 1, 3)
+    emg.plot_signals(
+        time_range=(last_start, last_start + epoch_duration),
+        title=f"Last Epoch (Epoch {n_epochs})",
+        ax=plt.gca()
+    )
+    
+    plt.tight_layout()
+    plt.show()
+```
+
+## Exporting EEGLAB Data to EDF/BDF
+
+Converting EEGLAB data to EDF/BDF format:
+
+```python
+from emgio import EMG
+
+# Load EEGLAB data
+emg = EMG.from_file('data.set', importer='eeglab')
+
+# Export all channels to EDF/BDF
+output_path = 'eeglab_all_channels'
+emg.to_edf(output_path)  # Format (EDF/BDF) selected automatically
+
+# Export only EMG channels
+emg_only = emg.select_channels(channel_type='EMG')
+output_path = 'eeglab_emg_only'
+emg_only.to_edf(output_path)
+
+print("Conversion complete!")
+```
+
+This example demonstrates loading EEGLAB `.set` files, exploring their structure, working with events, handling epoched data, and exporting to EDF/BDF format. 

--- a/docs/examples/notebooks.md
+++ b/docs/examples/notebooks.md
@@ -1,0 +1,198 @@
+# Jupyter Notebook Examples
+
+EMGIO can be used effectively in Jupyter Notebooks for interactive data analysis and visualization. This page provides an overview of working with EMGIO in Jupyter environments.
+
+## Available Example Notebooks
+
+The EMGIO repository includes several example Jupyter notebooks that demonstrate different aspects of working with EMG data:
+
+1. **Trigno Example Notebook**: Working with Delsys Trigno data
+   - Location: `examples/trigno_example.ipynb`
+
+2. **MATLAB Example Notebook**: Working with MATLAB-exported data
+   - Location: `examples/matlab_example.ipynb`
+
+## Running the Example Notebooks
+
+To run the example notebooks:
+
+1. Install EMGIO and Jupyter:
+   ```bash
+   pip install -e .  # Install EMGIO in development mode
+   pip install jupyter
+   ```
+
+2. Start Jupyter:
+   ```bash
+   jupyter notebook
+   ```
+
+3. Navigate to the `examples` directory and open one of the notebooks.
+
+## Key Features for Jupyter Notebooks
+
+When working with EMGIO in Jupyter notebooks, you can take advantage of these features:
+
+### Interactive Plotting
+
+```python
+from emgio import EMG
+import matplotlib.pyplot as plt
+%matplotlib inline  # For displaying plots in the notebook
+
+# Load EMG data
+emg = EMG.from_file('data.csv', importer='trigno')
+
+# Plot signals with customized appearance
+emg.plot_signals(
+    channels=['EMG1', 'EMG2'],
+    time_range=(0, 5),
+    title='EMG Signals',
+    figsize=(12, 6),
+    grid=True
+)
+```
+
+### Data Exploration
+
+Jupyter notebooks are excellent for interactively exploring your EMG data:
+
+```python
+# Load data
+emg = EMG.from_file('data.otb+', importer='otb')
+
+# Display channel information
+channel_types = emg.get_channel_types()
+for ch_type in channel_types:
+    channels = emg.get_channels_by_type(ch_type)
+    print(f"{ch_type} channels: {len(channels)}")
+    
+    # Show details of the first channel
+    if channels:
+        ch_name = channels[0]
+        ch_info = emg.channels[ch_name]
+        print(f"  Sample channel: {ch_name}")
+        for key, value in ch_info.items():
+            print(f"    {key}: {value}")
+```
+
+### Creating Interactive Widgets
+
+You can use ipywidgets to create interactive controls for exploring your data:
+
+```python
+import ipywidgets as widgets
+from IPython.display import display
+
+# Load data
+emg = EMG.from_file('data.set', importer='eeglab')
+
+# Get all channels
+all_channels = list(emg.channels.keys())
+
+# Create widgets
+channel_dropdown = widgets.Dropdown(
+    options=all_channels,
+    description='Channel:',
+    disabled=False,
+)
+
+time_slider = widgets.FloatRangeSlider(
+    value=[0, 5],
+    min=0,
+    max=emg.get_duration(),
+    step=1,
+    description='Time (s):',
+    disabled=False,
+    continuous_update=False,
+    readout=True,
+    readout_format='.1f',
+)
+
+# Define update function
+def update_plot(channel, time_range):
+    plt.figure(figsize=(12, 6))
+    emg.plot_signals(
+        channels=[channel],
+        time_range=time_range,
+        title=f'Channel: {channel}, Time: {time_range[0]}-{time_range[1]}s',
+        grid=True
+    )
+    plt.show()
+
+# Create interactive output
+out = widgets.interactive_output(
+    update_plot, 
+    {'channel': channel_dropdown, 'time_range': time_slider}
+)
+
+# Display widgets and output
+display(widgets.HBox([channel_dropdown, time_slider]), out)
+```
+
+### Exporting Figures
+
+You can easily export high-quality figures for publications:
+
+```python
+# Create a figure
+plt.figure(figsize=(10, 6), dpi=300)  # High DPI for publication quality
+emg.plot_signals(
+    channels=emg.get_channels_by_type('EMG')[:4],  # First 4 EMG channels
+    time_range=(10, 15),
+    title='EMG Signals During Movement',
+    grid=True
+)
+plt.tight_layout()
+
+# Save the figure in various formats
+plt.savefig('emg_plot.png', dpi=300)  # PNG for presentations
+plt.savefig('emg_plot.pdf')  # PDF for publications
+plt.savefig('emg_plot.svg')  # SVG for editing
+```
+
+## Tips for Jupyter Notebooks
+
+1. **Memory management**: When working with large files, consider using:
+   ```python
+   # Load only metadata first
+   importer = EDFImporter('large_file.edf')
+   signals, channels, metadata = importer.load(load_data=False)
+   
+   # Then load specific time segments as needed
+   importer = EDFImporter('large_file.edf')
+   signals, channels, metadata = importer.load(start_time=10, end_time=20)
+   ```
+
+2. **Progress tracking**: For long operations, use `tqdm` for progress bars:
+   ```python
+   from tqdm.notebook import tqdm
+   
+   channel_stats = {}
+   for channel in tqdm(emg.channels.keys()):
+       # Perform analysis on each channel
+       signal = emg.signals[channel].values
+       channel_stats[channel] = {
+           'mean': signal.mean(),
+           'std': signal.std(),
+           'max': signal.max(),
+           'min': signal.min()
+       }
+   ```
+
+3. **Table display**: Format channel information as a dataframe for better visualization:
+   ```python
+   import pandas as pd
+   
+   # Convert channel info to DataFrame
+   channel_df = pd.DataFrame()
+   for ch_name, ch_info in emg.channels.items():
+       ch_data = pd.Series(ch_info)
+       ch_data.name = ch_name
+       channel_df = channel_df.append(ch_data)
+   
+   # Display as an interactive table
+   channel_df
+   ```
+
+These examples show how to leverage Jupyter notebooks for interactive exploration and analysis of EMG data with EMGIO. 

--- a/docs/examples/otb.md
+++ b/docs/examples/otb.md
@@ -1,0 +1,229 @@
+# OTB Examples
+
+This page provides examples for working with OTB+ files from OT Bioelettronica devices using EMGIO.
+
+## Basic OTB Example
+
+```python
+import matplotlib.pyplot as plt
+from emgio import EMG
+
+# Load OTB data
+data_path = 'path_to_your_otb_file.otb+'
+emg = EMG.from_file(data_path, importer='otb')
+
+# Print device information
+print("\nDevice Information:")
+print("-" * 50)
+print(f"Device: {emg.get_metadata('device')}")
+print(f"Resolution: {emg.get_metadata('signal_resolution')} bits")
+
+# Print channel type summary
+print("\nChannel Type Summary:")
+print("-" * 50)
+channel_types = emg.get_channel_types()
+for ch_type in channel_types:
+    channels = emg.get_channels_by_type(ch_type)
+    print(f"{ch_type}: {len(channels)} channels")
+
+# Plot one channel of each type
+plt.figure(figsize=(12, 8))
+subplot_count = len(channel_types)
+for i, ch_type in enumerate(channel_types, 1):
+    channels = emg.get_channels_by_type(ch_type)
+    if channels:
+        plt.subplot(subplot_count, 1, i)
+        # Select the first channel of this type
+        sample_channel = emg.select_channels([channels[0]])
+        sample_channel.plot_signals(
+            time_range=(0, 5),
+            title=f"{ch_type} Sample: {channels[0]}",
+            ax=plt.gca()
+        )
+
+plt.tight_layout()
+plt.show()
+```
+
+## Working with EMG Channels
+
+OTB files often contain multiple channel types. Here's how to work specifically with EMG channels:
+
+```python
+from emgio import EMG
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Load OTB data
+emg = EMG.from_file('otb_data.otb+', importer='otb')
+
+# Create a new EMG object with only EMG channels
+emg_channels = emg.get_channels_by_type('EMG')
+
+if emg_channels:
+    print(f"Found {len(emg_channels)} EMG channels")
+    
+    # Select EMG channels
+    emg_data = emg.select_channels(emg_channels)
+    
+    # Plot EMG data
+    plt.figure(figsize=(15, 10))
+    
+    # If there are many channels, select a subset
+    channels_to_plot = emg_channels[:8] if len(emg_channels) > 8 else emg_channels
+    
+    emg_data.plot_signals(
+        channels=channels_to_plot,
+        time_range=(0, 5),
+        title='EMG Channels from OTB File',
+        grid=True
+    )
+    
+    plt.tight_layout()
+    plt.show()
+    
+    # Optional: Calculate and plot RMS of EMG signals
+    plt.figure(figsize=(15, 6))
+    
+    # Calculate RMS in 100ms windows
+    fs = emg_data.get_sampling_frequency()
+    window_size = int(0.1 * fs)  # 100ms window
+    
+    for i, channel in enumerate(channels_to_plot):
+        # Get signal data
+        signal = emg_data.signals[channel].values
+        
+        # Calculate RMS in windows
+        n_windows = len(signal) // window_size
+        rms = np.zeros(n_windows)
+        
+        for w in range(n_windows):
+            start = w * window_size
+            end = start + window_size
+            window_data = signal[start:end]
+            rms[w] = np.sqrt(np.mean(np.square(window_data)))
+        
+        # Create time vector for RMS
+        time = np.arange(n_windows) * (window_size / fs)
+        
+        # Plot RMS
+        plt.plot(time, rms, label=channel)
+    
+    plt.title('RMS of EMG Signals (100ms windows)')
+    plt.xlabel('Time (s)')
+    plt.ylabel('RMS Amplitude')
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+else:
+    print("No EMG channels found in the file")
+```
+
+## Working with Multiple OTB Files
+
+When working with multiple recordings from the same experiment:
+
+```python
+from emgio import EMG
+import matplotlib.pyplot as plt
+
+# Load two OTB files
+file1 = 'session1.otb+'
+file2 = 'session2.otb+'
+
+emg1 = EMG.from_file(file1, importer='otb')
+emg2 = EMG.from_file(file2, importer='otb')
+
+# Add metadata to distinguish them
+emg1.set_metadata('session', '1')
+emg1.set_metadata('condition', 'rest')
+emg2.set_metadata('session', '2')
+emg2.set_metadata('condition', 'contraction')
+
+# Check that they have the same channel structure
+channels1 = set(emg1.channels.keys())
+channels2 = set(emg2.channels.keys())
+common_channels = channels1.intersection(channels2)
+
+print(f"File 1 has {len(channels1)} channels")
+print(f"File 2 has {len(channels2)} channels")
+print(f"Common channels: {len(common_channels)}")
+
+# Compare EMG channels between sessions
+emg_channels = [ch for ch in common_channels 
+                if emg1.channels[ch]['channel_type'] == 'EMG']
+
+if emg_channels:
+    # Select a channel to compare
+    channel_to_compare = emg_channels[0]
+    
+    plt.figure(figsize=(12, 8))
+    
+    # Plot channel from first session
+    plt.subplot(2, 1, 1)
+    emg1.plot_signals(
+        [channel_to_compare], 
+        time_range=(0, 5),
+        title=f"Session 1 ({emg1.get_metadata('condition')}): {channel_to_compare}",
+        ax=plt.gca()
+    )
+    
+    # Plot same channel from second session
+    plt.subplot(2, 1, 2)
+    emg2.plot_signals(
+        [channel_to_compare], 
+        time_range=(0, 5),
+        title=f"Session 2 ({emg2.get_metadata('condition')}): {channel_to_compare}",
+        ax=plt.gca()
+    )
+    
+    plt.tight_layout()
+    plt.show()
+```
+
+## Exporting OTB Data to EDF/BDF
+
+Converting OTB data to EDF/BDF format:
+
+```python
+from emgio import EMG
+
+# Load OTB data
+emg = EMG.from_file('data.otb+', importer='otb')
+
+# Add metadata for export
+emg.set_metadata('subject', 'S001')
+emg.set_metadata('recording_date', '2023-01-15')
+emg.set_metadata('experimenter', 'Researcher')
+
+# Export all channels
+output_path = 'otb_all_channels'
+emg.to_edf(output_path)  # Format (EDF/BDF) selected automatically
+print(f"Exported all channels to: {output_path}")
+
+# Export only EMG channels for clarity
+emg_channels = emg.get_channels_by_type('EMG')
+if emg_channels:
+    emg_only = emg.select_channels(emg_channels)
+    output_path = 'otb_emg_only'
+    emg_only.to_edf(output_path)
+    print(f"Exported EMG channels to: {output_path}")
+
+# If there are too many channels for EDF, you might need to split
+# EDF has limitations on the number of channels it can handle
+if len(emg.channels) > 100:  # EDF typically handles fewer channels
+    print("Large number of channels detected, splitting export")
+    
+    # Split into groups of 50 channels
+    channel_lists = [list(emg.channels.keys())[i:i+50] 
+                    for i in range(0, len(emg.channels), 50)]
+    
+    for i, channel_list in enumerate(channel_lists):
+        subset_emg = emg.select_channels(channel_list)
+        output_path = f'otb_split_{i+1}'
+        subset_emg.to_edf(output_path)
+        print(f"Exported channel group {i+1} to: {output_path}")
+```
+
+These examples demonstrate how to load OTB data, explore channel information, work with specific channel types, compare multiple recordings, and export to EDF/BDF format. 

--- a/docs/examples/trigno.md
+++ b/docs/examples/trigno.md
@@ -1,0 +1,155 @@
+# Trigno Examples
+
+This page demonstrates how to work with EMG data from the Delsys Trigno wireless EMG system. Trigno data is typically exported as CSV files with a specific format that EMGIO can parse.
+
+## Basic Trigno Example
+
+```python
+import os
+from emgio import EMG
+import matplotlib.pyplot as plt
+
+# Load data from Trigno CSV file
+data_path = 'path_to_your_trigno_data.csv'
+emg = EMG.from_file(data_path, importer='trigno')
+
+# Print information about the loaded data
+print(f"Number of channels: {emg.get_n_channels()}")
+print(f"Number of samples: {emg.get_n_samples()}")
+print(f"Sampling frequency: {emg.get_sampling_frequency()} Hz")
+print(f"Recording duration: {emg.get_duration()} seconds")
+
+# List available channels
+print("\nAvailable channels:")
+for ch_name, ch_info in emg.channels.items():
+    print(f"- {ch_name} ({ch_info['channel_type']})")
+    print(f"  Sampling rate: {ch_info['sample_frequency']} Hz")
+    print(f"  Dimension: {ch_info['physical_dimension']}")
+
+# Plot EMG signals
+emg.plot_signals(time_range=(0, 5), title="Raw EMG Signals")
+plt.tight_layout()
+plt.show()
+```
+
+## Separating EMG and ACC Channels
+
+Trigno systems often record both EMG and accelerometer data. You can separate these channels for analysis:
+
+```python
+# Get EMG channels
+emg_channels = emg.get_channels_by_type('EMG')
+print(f"EMG channels: {emg_channels}")
+
+# Create EMG-only object
+emg_only = emg.select_channels(emg_channels)
+
+# Get accelerometer channels
+acc_channels = emg.get_channels_by_type('ACC')
+print(f"ACC channels: {acc_channels}")
+
+# Create ACC-only object
+acc_only = emg.select_channels(acc_channels)
+
+# Plot EMG and ACC signals separately
+plt.figure(figsize=(10, 8))
+
+plt.subplot(2, 1, 1)
+emg_only.plot_signals(time_range=(0, 5), title="EMG Signals", ax=plt.gca())
+
+plt.subplot(2, 1, 2)
+acc_only.plot_signals(time_range=(0, 5), title="Accelerometer Signals", ax=plt.gca())
+
+plt.tight_layout()
+plt.show()
+```
+
+## Exporting Trigno Data to EDF/BDF
+
+You can export the Trigno data to EDF or BDF format for use with other software:
+
+```python
+# Export all channels
+output_path = 'trigno_all_channels'
+emg.to_edf(output_path)  # Format (EDF/BDF) will be selected automatically
+print(f"Exported to: {output_path}")
+
+# Export only EMG channels
+emg_only = emg.select_channels(channel_type='EMG')
+output_path = 'trigno_emg_only'
+emg_only.to_edf(output_path)
+print(f"Exported EMG channels to: {output_path}")
+```
+
+## Working with Multiple Trigno Recordings
+
+If you have multiple recordings from the same experiment, you can load them separately and compare:
+
+```python
+# Load two recordings
+session1 = EMG.from_file('session1.csv', importer='trigno')
+session2 = EMG.from_file('session2.csv', importer='trigno')
+
+# Add metadata to distinguish them
+session1.set_metadata('session', '1')
+session1.set_metadata('condition', 'rest')
+
+session2.set_metadata('session', '2')
+session2.set_metadata('condition', 'active')
+
+# Plot channels from both sessions
+channel_to_compare = 'EMG1'  # Replace with your channel name
+
+plt.figure(figsize=(10, 6))
+plt.subplot(2, 1, 1)
+session1.plot_signals([channel_to_compare], time_range=(0, 5), 
+                     title=f"Session 1: {session1.get_metadata('condition')}", 
+                     ax=plt.gca())
+
+plt.subplot(2, 1, 2)
+session2.plot_signals([channel_to_compare], time_range=(0, 5), 
+                     title=f"Session 2: {session2.get_metadata('condition')}", 
+                     ax=plt.gca())
+
+plt.tight_layout()
+plt.show()
+```
+
+## Complete Trigno Workflow Example
+
+Here's a complete workflow using Trigno data:
+
+```python
+import os
+from emgio import EMG
+import matplotlib.pyplot as plt
+import numpy as np
+
+# 1. Load the data
+data_path = 'trigno_recording.csv'
+emg = EMG.from_file(data_path, importer='trigno')
+
+# 2. Add metadata
+emg.set_metadata('subject', 'S001')
+emg.set_metadata('condition', 'reaching')
+emg.set_metadata('sampling_rate', emg.get_sampling_frequency())
+
+# 3. Select only EMG channels
+emg_only = emg.select_channels(channel_type='EMG')
+
+# 4. Plot raw signals
+plt.figure(figsize=(12, 6))
+emg_only.plot_signals(time_range=(0, 10), 
+                     title="Raw EMG Signals", 
+                     ax=plt.gca())
+plt.tight_layout()
+plt.savefig('raw_emg.png')
+
+# 5. Export to EDF/BDF
+output_path = 'processed_emg'
+emg_only.to_edf(output_path)
+
+print(f"Processing complete. Data exported to: {output_path}")
+```
+
+This example demonstrates a complete workflow from loading Trigno data to selecting channels, visualizing, and exporting to EDF/BDF format. 

--- a/docs/formats/edf.md
+++ b/docs/formats/edf.md
@@ -1,0 +1,94 @@
+# EDF/BDF Format
+
+EDF (European Data Format) and BDF (BioSemi Data Format) are standard formats for storing multichannel biological and physical signals. EMGIO supports both importing from and exporting to these formats.
+
+## Format Description
+
+### EDF Format
+
+EDF (European Data Format) is a simple and flexible format for exchange and storage of multichannel biological and physical signals:
+
+- 16-bit resolution (range: ±32767)
+- Supports varying sampling rates between channels
+- Includes metadata in the header
+- Supports annotations and events
+
+### BDF Format
+
+BDF (BioSemi Data Format) is an extension of EDF that uses 24-bit resolution instead of 16-bit:
+
+- 24-bit resolution (range: ±8,388,607)
+- Higher dynamic range for signals with larger amplitude variations
+- Otherwise identical to EDF
+
+### File Structure
+
+Both formats consist of:
+
+1. **Header Record**: Contains metadata about the recording:
+   - Version information
+   - Patient and recording information
+   - Date and time
+   - Number of channels
+   - Sampling rates
+   - Calibration values
+   
+2. **Data Records**: Contains the actual signal data, organized in blocks.
+
+## EMGIO's Approach to EDF/BDF
+
+EMGIO can both import from and export to EDF/BDF formats. When exporting, EMGIO automatically determines which format to use based on the dynamic range of the data:
+
+- If the signal's dynamic range is within 16-bit resolution (~90dB), it uses EDF
+- If the signal requires greater precision, it uses BDF
+
+This determination is made using:
+- SVD (Singular Value Decomposition) analysis to determine the effective rank and energy distribution
+- FFT (Fast Fourier Transform) analysis to evaluate the noise floor and signal-to-noise ratio
+
+## Importer Implementation
+
+The EDF importer in EMGIO (`emgio.importers.edf`) uses the `pyedflib` package to:
+
+1. Read the EDF/BDF file header to extract metadata
+2. Load the signal data for all channels
+3. Convert channel information to EMGIO's format
+4. Handle different sampling rates across channels
+
+## Exporter Implementation
+
+The EDF exporter in EMGIO (`emgio.exporters.edf`) also uses `pyedflib` to:
+
+1. Automatically determine whether to use EDF or BDF based on signal characteristics
+2. Generate appropriate header information
+3. Scale the signals correctly for storage
+4. Create a sidecar channels.tsv file with detailed channel metadata (BIDS-compatible)
+
+## Code Example
+
+```python
+from emgio import EMG
+
+# Import from EDF file
+emg = EMG.from_file('input.edf', importer='edf')
+
+# Print basic information
+print(f"Number of channels: {emg.get_n_channels()}")
+print(f"Sampling frequency: {emg.get_sampling_frequency()} Hz")
+print(f"Recording duration: {emg.get_duration()} seconds")
+
+# Export to EDF/BDF (format selected automatically)
+emg.to_edf('output')  # Will add .edf or .bdf extension automatically
+
+# Force a specific format
+emg.to_edf('output_edf', force_format='edf')  # Forces 16-bit EDF
+emg.to_edf('output_bdf', force_format='bdf')  # Forces 24-bit BDF
+```
+
+## Notes and Limitations
+
+- The BIDS-compatible channels.tsv sidecar file includes detailed channel information
+- Annotations in EDF files are preserved in EMGIO's metadata
+- When importing from EDF, EMGIO attempts to identify channel types based on labels and signal characteristics
+- When exporting to EDF/BDF, EMGIO automatically handles scaling to maximize precision
+- EDF has limitations on channel naming (maximum 16 characters) 

--- a/docs/formats/eeglab.md
+++ b/docs/formats/eeglab.md
@@ -1,0 +1,79 @@
+# EEGLAB Format
+
+EEGLAB is a MATLAB toolbox for processing EEG, MEG, and other electrophysiological data. EMGIO can import EEGLAB `.set` files to work with EMG data stored in this format.
+
+## Format Description
+
+EEGLAB `.set` files are MATLAB files that contain:
+
+- Signal data in a matrix format
+- Channel information (names, locations, types)
+- Event markers
+- Metadata about the recording
+- Processing history
+
+### Structure
+
+A typical EEGLAB `.set` file contains these fields:
+
+| Field | Description |
+|-------|-------------|
+| `data` | Signal data matrix (channels × time points) |
+| `chanlocs` | Channel information (names, types, locations) |
+| `srate` | Sampling rate in Hz |
+| `xmin` | Time of first data point (seconds) |
+| `xmax` | Time of last data point (seconds) |
+| `times` | Time points vector |
+| `event` | Event markers |
+| `epoch` | Epoch information (if epoched) |
+| `subject` | Subject identifier |
+| `condition` | Condition name or description |
+
+## Importer Implementation
+
+The EEGLAB importer in EMGIO (`emgio.importers.eeglab`) works by:
+
+1. Loading the `.set` file using Python's `scipy.io.loadmat` (for MATLAB files)
+2. Extracting the EEG structure with signal data and metadata
+3. Converting channel information to EMGIO's channel format
+4. Creating appropriate metadata dictionary
+5. Handling both continuous and epoched data
+
+## Code Example
+
+```python
+from emgio import EMG
+
+# Load data from EEGLAB .set file
+emg = EMG.from_file('data.set', importer='eeglab')
+
+# Print metadata
+print(f"Subject: {emg.get_metadata('subject')}")
+print(f"Condition: {emg.get_metadata('condition')}")
+print(f"Sampling rate: {emg.get_metadata('srate')} Hz")
+
+# Print channel information
+print(f"Number of channels: {emg.get_n_channels()}")
+channel_types = emg.get_channel_types()
+print(f"Channel types: {channel_types}")
+
+# Plot data
+emg.plot_signals(time_range=(0, 5))
+```
+
+## Channel Type Mapping
+
+EEGLAB doesn't always explicitly designate channel types. EMGIO's EEGLAB importer uses the following rules to assign channel types:
+
+1. Channels with 'EMG' in the name are assigned type 'EMG'
+2. Channels with 'EEG' in the name are assigned type 'EEG'
+3. Channels with 'ACC' in the name are assigned type 'ACC'
+4. Other channels are assigned type 'OTHER'
+
+## Notes and Limitations
+
+- EMGIO supports both MATLAB v7.3 and older format .set files
+- Event markers are preserved in the metadata
+- Channel locations (if available) are preserved in the channel information
+- Some EEGLAB-specific information may not be fully preserved in the conversion
+- Time information is properly handled to maintain accurate timing in the imported data 

--- a/docs/formats/otb.md
+++ b/docs/formats/otb.md
@@ -1,0 +1,90 @@
+# OTB Format
+
+OTB/OTB+ is a data format developed by OT Bioelettronica for storing multi-channel electrophysiological data. EMGIO provides support for importing data from OTB+ files.
+
+## Format Description
+
+OTB files typically have a `.otb+` extension and are binary files containing:
+
+- Header information with metadata
+- Multi-channel signal data
+- Potentially multiple signals types (EMG, ACC, etc.)
+- Optional event markers
+
+### Structure
+
+The OTB+ format consists of:
+
+1. A header section containing information about:
+   - Device type and configuration
+   - Number of channels
+   - Sampling frequency
+   - Bit resolution
+   - Calibration values
+   
+2. A data section containing:
+   - Raw signal data for all channels
+   - Potentially interleaved channel types (EMG, accelerometer, etc.)
+
+## Importer Implementation
+
+The OTB importer in EMGIO (`emgio.importers.otb`) works by:
+
+1. Reading the binary OTB+ file header to extract metadata
+2. Parsing the data section and arranging it into a structured format
+3. Identifying different channel types based on the header information
+4. Setting appropriate units and calibration values
+5. Creating a properly formatted channel dictionary
+
+## Code Example
+
+```python
+from emgio import EMG
+import matplotlib.pyplot as plt
+
+# Load data from OTB file
+emg = EMG.from_file('data.otb+', importer='otb')
+
+# Print device information
+print(f"Device: {emg.get_metadata('device')}")
+print(f"Resolution: {emg.get_metadata('signal_resolution')} bits")
+
+# Summarize channel types
+channel_types = emg.get_channel_types()
+print(f"Channel types: {channel_types}")
+
+for ch_type in channel_types:
+    channels = emg.get_channels_by_type(ch_type)
+    print(f"{ch_type} channels: {len(channels)}")
+
+# Select only EMG channels
+emg_only = emg.select_channels(channel_type='EMG')
+
+# Plot EMG channels
+emg_only.plot_signals(time_range=(0, 5))
+plt.tight_layout()
+plt.show()
+```
+
+## Channel Types
+
+OTB files can contain various channel types:
+
+- **EMG** - Electromyography channels
+- **ACC** - Accelerometer channels 
+- **IMUX** - Input multiplexer channels (for OT Bioelettronica devices)
+- **AUX** - Auxiliary input channels
+- **TRIG** - Trigger or event marker channels
+
+## Notes and Limitations
+
+- OTB files can come from different devices (SESSANTAQUATTRO, MUOVI, etc.)
+- Channel naming conventions may vary between devices
+- Sampling rates can be different for different channel types
+- Some OTB+ files may contain additional proprietary information
+- The EMGIO importer preserves as much metadata as possible from the original file
+
+## References
+
+- OT Bioelettronica: [https://otbioelettronica.it/](https://otbioelettronica.it/)
+- The OTB importer in EMGIO is based on the MATLAB import functions provided by OT Bioelettronica 

--- a/docs/formats/trigno.md
+++ b/docs/formats/trigno.md
@@ -1,0 +1,70 @@
+# Trigno Format
+
+The Delsys Trigno wireless EMG system exports data in a CSV format. This page describes the format and how EMGIO works with it.
+
+## Format Description
+
+Trigno CSV files typically have the following structure:
+
+- A header section with metadata
+- A data section with columns for each channel
+- EMG and accelerometer data in separate columns
+
+### Example File Structure
+
+```
+# Trigno Data File
+# Date: 2023-05-01
+# Time: 10:30:00
+# Device: Trigno Wireless System
+# ...additional metadata...
+
+Time(s),EMG1,EMG2,EMG3,EMG4,ACC1_X,ACC1_Y,ACC1_Z,...
+0.000,0.01,0.02,0.03,0.04,0.1,0.2,0.3,...
+0.001,0.02,0.03,0.04,0.05,0.1,0.2,0.3,...
+0.002,0.03,0.04,0.05,0.06,0.1,0.2,0.3,...
+```
+
+## Channel Types
+
+EMGIO recognizes the following channel types in Trigno CSV files:
+
+- **EMG** - Electromyography channels (typically in μV or mV)
+- **ACC** - Accelerometer channels (typically in g)
+
+## Importer Implementation
+
+The Trigno importer in EMGIO (`emgio.importers.trigno`) processes these files by:
+
+1. Reading the header section to extract metadata
+2. Parsing the data section as a pandas DataFrame
+3. Identifying channel types based on naming conventions
+4. Setting appropriate units and sampling frequencies for each channel
+
+## Code Example
+
+```python
+from emgio import EMG
+
+# Load data from Trigno CSV file
+emg = EMG.from_file('data.csv', importer='trigno')
+
+# Print identified channel types
+channel_types = emg.get_channel_types()
+print(f"Identified channel types: {channel_types}")
+
+# Get EMG channels
+emg_channels = emg.get_channels_by_type('EMG')
+print(f"EMG channels: {emg_channels}")
+
+# Get accelerometer channels
+acc_channels = emg.get_channels_by_type('ACC')
+print(f"ACC channels: {acc_channels}")
+```
+
+## Notes and Limitations
+
+- Trigno systems can have different sampling rates for EMG and accelerometer channels
+- The importer automatically detects the sampling rate from the time column
+- Column names may vary between different Trigno system versions
+- Some metadata may be missing depending on the export settings 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,65 @@
+# Welcome to EMGIO
+
+[![Tests](https://github.com/neuromechanist/emgio/actions/workflows/tests.yml/badge.svg)](https://github.com/neuromechanist/emgio/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/neuromechanist/emgio/branch/main/graph/badge.svg?token=63EDIA9TWD)](https://codecov.io/gh/neuromechanist/emgio)
+
+EMGIO is a Python package for EMG data import/export and manipulation. It provides a unified interface for working with EMG data from various systems and exporting to standardized formats with harmonized metadata.
+
+## Why EMGIO?
+
+Working with EMG data across multiple recording systems can be challenging due to:
+
+- Different file formats
+- Varied metadata structures
+- Inconsistent channel naming
+- Diverse sampling rates and filtering
+
+EMGIO simplifies this process by providing a standardized interface for loading, manipulating, and exporting EMG data regardless of the original source.
+
+## Key Features
+
+- **Multi-system support**:
+  - EEGLAB set files (supported)
+  - Delsys Trigno (supported)
+  - OTB Systems (supported)
+  - EDF (supported)
+  - Noraxon (planned)
+  
+- **Intelligent export**:
+  - Automatic determination of EDF/BDF format based on signal quality
+  - Smart handling of precision requirements
+  - BIDS-compatible metadata formatting
+  
+- **Data manipulation**:
+  - Channel selection
+  - Metadata handling
+  - Basic signal visualization
+  - Raw data access and modification
+
+## Quick Example
+
+```python
+from emgio import EMG
+
+# Load data from Trigno system
+emg = EMG.from_file('data.csv', importer='trigno')
+
+# Plot specific channels
+emg.plot_signals(['EMG1', 'EMG2'])
+
+# Export to EDF/BDF (format automatically determined)
+emg.to_edf('output')  # Extension will be added automatically
+```
+
+## Documentation Structure
+
+This documentation is organized as follows:
+
+- **User Guide**: Step-by-step instructions for using EMGIO
+- **Data Formats**: Details about supported input/output formats
+- **API Reference**: Complete documentation of classes and methods
+- **Examples**: Practical examples for various use cases
+
+## License
+
+This project is licensed under the BSD 3-Clause License. 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+mkdocs
+mkdocs-material
+mkdocstrings
+mkdocstrings-python
+pymdown-extensions
+mkdocs-jupyter
+mike 

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -1,0 +1,93 @@
+# Basic Usage
+
+EMGIO provides a unified interface for working with EMG data from various systems. This page covers the core functionality that's common across all supported data formats.
+
+## Loading Data
+
+The main entry point for loading data is the `EMG.from_file()` method. This method automatically determines the correct importer based on the file extension, or you can specify the importer explicitly:
+
+```python
+from emgio import EMG
+
+# Automatic importer selection based on file extension
+emg = EMG.from_file('data.csv')  # Will use Trigno importer for CSV files
+
+# Explicit importer selection
+emg = EMG.from_file('data.csv', importer='trigno')
+emg = EMG.from_file('data.set', importer='eeglab')
+emg = EMG.from_file('data.otb+', importer='otb')
+emg = EMG.from_file('data.edf', importer='edf')
+```
+
+## Accessing Data
+
+Once you've loaded data, you can access the signals and metadata:
+
+```python
+# Access raw signal data (returns a pandas DataFrame)
+signals = emg.signals
+
+# Get information about channels
+channels = emg.channels
+
+# Get sampling frequency
+fs = emg.get_sampling_frequency()
+
+# Get the number of samples
+n_samples = emg.get_n_samples()
+
+# Get the number of channels
+n_channels = emg.get_n_channels()
+```
+
+## Plotting Signals
+
+EMGIO provides methods to visualize the EMG signals:
+
+```python
+# Plot all channels
+emg.plot_signals()
+
+# Plot specific channels
+emg.plot_signals(['EMG1', 'EMG2'])
+
+# Plot with time range (in seconds)
+emg.plot_signals(time_range=(0, 5))
+
+# Customize plot
+emg.plot_signals(
+    channels=['EMG1', 'EMG2'],
+    time_range=(0, 5),
+    title='EMG Signals',
+    grid=True,
+    figsize=(12, 6)
+)
+```
+
+## Exporting Data
+
+EMGIO can export data to EDF/BDF formats:
+
+```python
+# Export to EDF or BDF (format selected automatically)
+emg.to_edf('output')  # Extension (.edf/.bdf) will be added automatically
+
+# Force EDF format
+emg.to_edf('output', force_format='edf')
+
+# Force BDF format
+emg.to_edf('output', force_format='bdf')
+
+# Control the analysis method for format selection
+emg.to_edf('output', method='svd')  # Use SVD analysis only
+emg.to_edf('output', method='fft')  # Use FFT analysis only
+emg.to_edf('output', method='both')  # Use both methods (default)
+```
+
+## Next Steps
+
+After mastering these basics, you might want to explore:
+
+- [Channel Selection](channel-selection.md) - Learn how to select and manipulate channels
+- [EDF/BDF Format Selection](edf-bdf-selection.md) - Understanding how EMGIO selects the appropriate format
+- [Metadata Handling](metadata.md) - Working with metadata in EMGIO 

--- a/docs/user-guide/channel-selection.md
+++ b/docs/user-guide/channel-selection.md
@@ -1,0 +1,99 @@
+# Channel Selection
+
+EMG recordings often contain various channel types (EMG, accelerometer, gyroscope, etc.) or channels you may want to exclude from analysis. EMGIO provides flexible methods for selecting and working with specific channels.
+
+## Getting Channel Information
+
+Before selecting channels, you may want to explore the available channels:
+
+```python
+# Get a dictionary of all channels and their properties
+channels = emg.channels
+
+# Print channel information
+for ch_name, ch_info in emg.channels.items():
+    print(f"Channel: {ch_name}")
+    print(f"  Type: {ch_info['channel_type']}")
+    print(f"  Unit: {ch_info['physical_dimension']}")
+    print(f"  Sampling rate: {ch_info['sample_frequency']} Hz")
+```
+
+## Selecting Channels by Name
+
+You can create a new EMG object with only the channels you specify:
+
+```python
+# Select specific channels by name
+subset_emg = emg.select_channels(['EMG1', 'EMG2', 'ACC1'])
+
+# The original EMG object remains unchanged
+print(f"Original channels: {len(emg.channels)}")
+print(f"Selected channels: {len(subset_emg.channels)}")
+```
+
+## Selecting Channels by Type
+
+EMGIO allows you to select channels based on their type:
+
+```python
+# Get available channel types
+channel_types = emg.get_channel_types()
+print(f"Available channel types: {channel_types}")
+
+# Get channel names of a specific type
+emg_channels = emg.get_channels_by_type('EMG')
+print(f"EMG channels: {emg_channels}")
+acc_channels = emg.get_channels_by_type('ACC')
+print(f"ACC channels: {acc_channels}")
+
+# Select all channels of a specific type
+emg_only = emg.select_channels(channel_type='EMG')
+acc_only = emg.select_channels(channel_type='ACC')
+```
+
+## Selecting Channels by Regular Expression
+
+You can also select channels using regular expressions:
+
+```python
+import re
+
+# Select all EMG channels with numbers 1-5
+pattern = re.compile(r'EMG[1-5]')
+selected_channels = [ch for ch in emg.channels if pattern.match(ch)]
+subset_emg = emg.select_channels(selected_channels)
+```
+
+## Working with Selected Channels
+
+After selecting channels, you can work with the new EMG object just like the original:
+
+```python
+# Plot the selected channels
+subset_emg.plot_signals()
+
+# Export only the selected channels
+subset_emg.to_edf('output_subset')
+```
+
+## Combining Selection Methods
+
+You can combine different selection methods for more complex filtering:
+
+```python
+# Get all EMG channels
+emg_channels = emg.get_channels_by_type('EMG')
+
+# Filter to only include those from a specific muscle group
+bicep_channels = [ch for ch in emg_channels if 'Bicep' in ch]
+
+# Create a new EMG object with just these channels
+bicep_emg = emg.select_channels(bicep_channels)
+```
+
+## Channel Selection Best Practices
+
+- Always verify the selected channels by checking `emg.channels` after selection
+- When working with multiple EMG devices, use channel selection to group channels by device
+- For large datasets, selecting only necessary channels can improve performance
+- Consider creating utility functions for commonly used channel selections in your workflow 

--- a/docs/user-guide/edf-bdf-selection.md
+++ b/docs/user-guide/edf-bdf-selection.md
@@ -1,0 +1,98 @@
+# EDF/BDF Format Selection
+
+One of the key features of EMGIO is its ability to automatically determine whether to use the EDF (16-bit) or BDF (24-bit) format when exporting data. This decision is based on the dynamic range and precision requirements of your EMG data.
+
+## Why Format Selection Matters
+
+### EDF (European Data Format)
+- 16-bit precision (range: ±32767)
+- Widely supported by analysis software
+- Smaller file size
+- Suitable for most EMG recordings
+
+### BDF (BioSemi Data Format)
+- 24-bit precision (range: ±8,388,607)
+- Required for high-precision recordings
+- Larger file size
+- Necessary when dynamic range exceeds 16-bit capabilities
+
+Using 16-bit EDF when possible reduces storage requirements while maintaining sufficient precision for most analyses. However, when data contains very small signal components relative to the peak values, higher precision may be necessary to avoid quantization errors and preserve information.
+
+## How EMGIO Selects the Format
+
+EMGIO uses two complementary approaches to determine the appropriate format:
+
+### 1. SVD (Singular Value Decomposition) Analysis
+
+The SVD method decomposes the signal matrix to evaluate its effective rank and the distribution of signal energy:
+
+```python
+# Simplified implementation of SVD analysis
+U, s, Vh = np.linalg.svd(signals, full_matrices=False)
+effective_rank = np.sum(s > threshold)
+```
+
+This approach:
+- Identifies the essential dimensions in the data
+- Measures how much precision is needed to represent these dimensions
+- Determines if 16-bit precision (90dB dynamic range) is sufficient
+
+### 2. FFT (Fast Fourier Transform) Analysis
+
+The FFT method examines the frequency domain representation:
+
+```python
+# Simplified implementation of FFT analysis
+fft_result = np.fft.rfft(signals)
+noise_floor = estimate_noise_floor(fft_result)
+dynamic_range_db = 20 * np.log10(peak_amplitude / noise_floor)
+```
+
+This approach:
+- Estimates the noise floor in the frequency domain
+- Calculates the dynamic range in decibels
+- Compares against the ~90dB limit of 16-bit data
+
+## Controlling Format Selection
+
+You can control the format selection process when exporting:
+
+```python
+# Use both methods (default)
+emg.to_edf('output', method='both')
+
+# Use only SVD analysis
+emg.to_edf('output', method='svd', svd_rank=None)  # Auto threshold
+emg.to_edf('output', method='svd', svd_rank=5)     # Manual threshold
+
+# Use only FFT analysis
+emg.to_edf('output', method='fft', fft_noise_range=None)    # Auto range
+emg.to_edf('output', method='fft', fft_noise_range=(0.1, 10))  # Manual range
+
+# Force a specific format
+emg.to_edf('output', force_format='edf')  # Force EDF (16-bit)
+emg.to_edf('output', force_format='bdf')  # Force BDF (24-bit)
+```
+
+## Understanding the Output
+
+After export, EMGIO will indicate which format was selected:
+
+```
+Exporting to EDF format: dynamic range is 78.3 dB (less than 90 dB threshold)
+Output file: output.edf
+```
+
+or:
+
+```
+Exporting to BDF format: dynamic range is 108.2 dB (exceeds 90 dB threshold)
+Output file: output.bdf
+```
+
+## Best Practices
+
+- Let EMGIO automatically determine the format when possible
+- When in doubt, visualize your data to see if it contains very small but important signal components
+- For critical applications, consider using the BDF format to ensure maximum precision
+- If file size is a concern and precision is adequate, force the EDF format 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,0 +1,64 @@
+# Installation
+
+There are several ways to install EMGIO depending on your needs.
+
+## From GitHub Repository
+
+The recommended way to install the latest version of EMGIO is directly from the GitHub repository:
+
+```bash
+git clone https://github.com/neuromechanist/emgio.git
+cd emgio
+pip install .
+```
+
+## Development Installation
+
+For development purposes, you can install EMGIO in editable mode:
+
+```bash
+git clone https://github.com/neuromechanist/emgio.git
+cd emgio
+pip install -e .
+```
+
+This allows you to modify the source code and see the changes without reinstalling.
+
+## Dependencies
+
+EMGIO has the following dependencies:
+
+| Dependency    | Purpose                | Minimum Version |
+|---------------|------------------------|----------------|
+| numpy         | Array operations       | -              |
+| pandas        | Data manipulation      | -              |
+| scipy         | Signal processing      | -              |
+| matplotlib    | Visualization          | -              |
+| pyedflib      | EDF/BDF file handling  | -              |
+
+These dependencies will be automatically installed when you install EMGIO.
+
+## Testing
+
+To run the tests, you need to install the test dependencies:
+
+```bash
+pip install -r test-requirements.txt
+```
+
+Then you can run the tests with:
+
+```bash
+pytest
+```
+
+## Verifying Installation
+
+You can verify that EMGIO is correctly installed by running:
+
+```python
+import emgio
+print(emgio.__version__)
+```
+
+If you don't see any error messages, EMGIO is installed correctly. 

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -1,0 +1,102 @@
+# Metadata Handling
+
+EMGIO provides comprehensive metadata management capabilities, allowing you to work with recording session information, subject details, and other contextual data. Proper metadata handling is particularly important when working with research data that needs to be shared or archived.
+
+## Accessing Metadata
+
+When you load data into EMGIO, any available metadata from the source file is automatically imported:
+
+```python
+# Load data
+emg = EMG.from_file('data.set', importer='eeglab')
+
+# Access all metadata
+all_metadata = emg.metadata
+print(all_metadata)
+
+# Access specific metadata field
+subject = emg.get_metadata('subject')
+print(f"Subject: {subject}")
+
+# Check if a metadata field exists
+if emg.has_metadata('condition'):
+    condition = emg.get_metadata('condition')
+    print(f"Condition: {condition}")
+```
+
+## Setting Metadata
+
+You can add or modify metadata fields:
+
+```python
+# Set a single metadata field
+emg.set_metadata('subject', 'S001')
+
+# Set multiple metadata fields at once
+emg.set_metadata_dict({
+    'subject': 'S001',
+    'condition': 'resting',
+    'experimenter': 'John Doe',
+    'recording_date': '2023-01-15'
+})
+```
+
+## Common Metadata Fields
+
+While EMGIO is flexible about what metadata you can store, some common fields include:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `subject` | Subject identifier | `"S001"` |
+| `session` | Session identifier | `"1"` |
+| `condition` | Experimental condition | `"rest"` |
+| `recording_date` | Date of recording | `"2023-01-15"` |
+| `device` | Recording device | `"Trigno Wireless"` |
+| `srate` | Sampling rate in Hz | `2000` |
+
+## Metadata in Exported Files
+
+When exporting to EDF/BDF, EMGIO automatically includes metadata in the file header and generates a sidecar channels.tsv file with channel-specific metadata following BIDS conventions:
+
+```python
+# Export to EDF with metadata
+emg.to_edf('output')
+
+# This will create:
+# - output.edf or output.bdf (depending on format selection)
+# - output.channels.tsv (channel metadata in tab-separated format)
+```
+
+The channels.tsv file will include information like:
+
+```
+name    type    units   sampling_frequency    ...
+EMG1    EMG     µV      2000                  ...
+EMG2    EMG     µV      2000                  ...
+ACC1    ACC     g       2000                  ...
+```
+
+## Copying Metadata Between EMG Objects
+
+When working with multiple EMG objects, you can copy metadata between them:
+
+```python
+# Create a subset with only EMG channels
+emg_only = emg.select_channels(channel_type='EMG')
+
+# Copy all metadata from original to subset
+emg_only.metadata = emg.metadata.copy()
+
+# Or selectively copy metadata
+emg_only.set_metadata('subject', emg.get_metadata('subject'))
+```
+
+## Best Practices for Metadata
+
+1. **Consistency**: Establish conventions for metadata fields and stick to them
+2. **Completeness**: Include all relevant information about the recording context
+3. **Standardization**: Use standard units and nomenclature
+4. **Validation**: Verify metadata accuracy before export
+5. **Documentation**: Document your metadata structure for collaborators
+
+By maintaining good metadata practices, you ensure that your EMG data remains interpretable and useful for future analysis. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,79 @@
+site_name: EMGIO Documentation
+site_description: Documentation for EMGIO - EMG data import/export and manipulation
+site_author: EMGIO Team
+repo_url: https://github.com/neuromechanist/emgio
+repo_name: neuromechanist/emgio
+
+theme:
+  name: material
+  palette:
+    primary: indigo
+    accent: indigo
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.expand
+    - navigation.indexes
+    - content.code.copy
+    - content.code.annotate
+
+plugins:
+  - search:
+      lang: en
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: numpy
+            show_source: true
+            show_root_heading: true
+  - mkdocs-jupyter
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.arithmatex:
+      generic: true
+  - admonition
+  - footnotes
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - User Guide:
+    - Installation: user-guide/installation.md
+    - Basic Usage: user-guide/basic-usage.md
+    - Channel Selection: user-guide/channel-selection.md
+    - EDF/BDF Format Selection: user-guide/edf-bdf-selection.md
+    - Metadata Handling: user-guide/metadata.md
+  - Data Formats:
+    - Trigno: formats/trigno.md
+    - EEGLAB: formats/eeglab.md
+    - OTB: formats/otb.md
+    - EDF: formats/edf.md
+  - API Reference: 
+    - EMG Class: api/emg.md
+    - Importers:
+      - Base Importer: api/importers/base.md
+      - Trigno Importer: api/importers/trigno.md
+      - EEGLAB Importer: api/importers/eeglab.md
+      - OTB Importer: api/importers/otb.md
+      - EDF Importer: api/importers/edf.md
+    - Exporters:
+      - EDF/BDF Exporter: api/exporters/edf.md
+  - Examples:
+    - Trigno Examples: examples/trigno.md
+    - EEGLAB Examples: examples/eeglab.md
+    - OTB Examples: examples/otb.md
+    - Converting Jupyter Notebooks: examples/notebooks.md
+  - Contributing: contributing.md
+
+extra:
+  version:
+    provider: mike
+    default: latest 


### PR DESCRIPTION
## Summary
This PR adds a complete documentation system for EMGIO using MkDocs with the Material theme. The documentation covers most of the library including installation, usage guides, API references, and detailed examples.

## Changes Made

### Infrastructure
- Added MkDocs configuration with Material theme
- Set up required dependencies in `docs/requirements.txt`
- Implemented GitHub Actions workflow for automatic documentation deployment
- Configured versioning support with Mike

### Documentation Structure
1. **User Guide**
   - Installation instructions
   - Basic usage guide
   - Channel selection documentation
   - EDF/BDF format selection explanation
   - Metadata handling guidelines

2. **Data Format Documentation**
   - Trigno format specification and usage
   - EEGLAB format specification and usage
   - OTB format specification and usage
   - EDF/BDF format specification and usage

3. **API Reference**
   - Core EMG class documentation
   - Importers
     - Base importer interface
     - Format-specific importers (Trigno, EEGLAB, OTB, EDF)
   - Exporters
     - EDF/BDF exporter

4. **Examples**
   - Detailed examples for each supported format
   - Jupyter notebook integration guide

5. **Contributing Guide**
   - Development setup instructions
   - Code structure explanation
   - Testing instructions
   - Documentation guidelines
   - Pull request process

## Key Features
- Automatic API documentation generation from docstrings
- Interactive examples with syntax highlighting
- Mobile-friendly responsive design
- Search functionality
- BIDS-compatible metadata documentation
- Detailed explanations of EDF/BDF format selection algorithms

## Testing
The documentation has been tested locally using `mkdocs serve` and all pages are accessible.

## Screenshots
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/2329e40a-da91-43f6-8375-198a0a72bc0b" />