### PR TITLE
Make channels.tsv BIDS-compliant and optional

### DIFF
--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -257,6 +257,7 @@ class EMG:
                verify_channel_map: Optional[Dict[str, str]] = None,
                verify_plot: bool = False,
                events_df: Optional[pd.DataFrame] = None,
+               create_channels_tsv: bool = True,
                **kwargs
                ) -> Union[str, None]:
         """
@@ -289,6 +290,7 @@ class EMG:
             verify_plot: If True and verify is True, plots a comparison of original vs reloaded signals.
             events_df: Optional DataFrame with events ('onset', 'duration', 'description').
                       If None, uses self.events. (This provides flexibility)
+            create_channels_tsv: If True, create a BIDS-compliant channels.tsv file (default: True)
             **kwargs: Additional arguments for the EDF exporter
 
         Returns:
@@ -344,6 +346,7 @@ class EMG:
             'format': format,
             'bypass_analysis': final_bypass_analysis,
             'events_df': events_to_export,  # Pass the events dataframe
+            'create_channels_tsv': create_channels_tsv,
             **kwargs
         }
 

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -302,9 +302,10 @@ class EDFExporter:
                svd_rank: int = None, format: Literal['auto', 'edf', 'bdf'] = 'auto',
                bypass_analysis: bool = False,
                events_df: Optional[pd.DataFrame] = None,
+               create_channels_tsv: bool = True,
                **kwargs) -> None:
         """
-        Export EMG data to EDF/BDF format with corresponding channels.tsv file.
+        Export EMG data to EDF/BDF format with optional BIDS-compliant channels.tsv file.
 
         Args:
             emg: EMG object containing the data
@@ -326,6 +327,7 @@ class EDFExporter:
             events_df: Optional DataFrame containing events/annotations to write.
                      Columns should include 'onset', 'duration', 'description'.
                      If None or empty, no annotations are written.
+            create_channels_tsv: If True, create a BIDS-compliant channels.tsv file (default: True)
             **kwargs: Additional arguments for the exporter
         """
         if emg.signals is None:
@@ -417,9 +419,15 @@ class EDFExporter:
         #     pass # logging.log(logging.CRITICAL, "Signal analysis bypassed.")
 
         # Set file format and create writer
+        # Initialize BIDS-compliant channels.tsv data structure
+        # Required columns in BIDS order: name, type, units
         channels_tsv_data = {
-            'name': [], 'channel_type': [], 'physical_dimension': [],
-            'sample_frequency': [], 'reference': [], 'status': []
+            'name': [],
+            'type': [],
+            'units': [],
+            'sampling_frequency': [],
+            'reference': [],
+            'status': []
         }
         channel_info_list = []
 
@@ -468,13 +476,28 @@ class EDFExporter:
                 }
                 channel_info_list.append(ch_dict)
 
-                # Add to channels.tsv data
+                # Add to BIDS-compliant channels.tsv data
                 channels_tsv_data['name'].append(ch_name)
-                channels_tsv_data['channel_type'].append(ch_info.get('channel_type', 'Unknown'))
-                channels_tsv_data['physical_dimension'].append(ch_info['physical_dimension'])
-                channels_tsv_data['sample_frequency'].append(ch_info['sample_frequency'])
-                channels_tsv_data['reference'].append('n/a')  # Assuming no specific reference info
-                channels_tsv_data['status'].append('good')  # Assuming good status
+                
+                # Map channel type to BIDS-compliant uppercase values
+                ch_type = ch_info.get('channel_type', 'Unknown').upper()
+                # Map common channel types to BIDS standard values
+                if ch_type in ['EMG', 'EEG', 'MEG','ECG', 'EOG', 'VEOG', 'HEOG', 'REF', 'TRIG', 'MISC']:
+                    bids_type = ch_type
+                elif 'EMG' in ch_type:
+                    bids_type = 'EMG'
+                elif 'ACC' in ch_type or 'ACCEL' in ch_type:
+                    bids_type = 'MISC'
+                elif 'GYRO' in ch_type:
+                    bids_type = 'MISC'
+                else:
+                    bids_type = 'MISC'
+                
+                channels_tsv_data['type'].append(bids_type)
+                channels_tsv_data['units'].append(ch_info['physical_dimension'])
+                channels_tsv_data['sampling_frequency'].append(ch_info['sample_frequency'])
+                channels_tsv_data['reference'].append('n/a')  # Can be updated if reference info is available
+                channels_tsv_data['status'].append('good')  # Default to good, can be updated based on signal quality
 
             # Set headers and write data (pass physical signals)
             writer.setSignalHeaders(channel_info_list)
@@ -510,10 +533,20 @@ class EDFExporter:
             if file_size == 0:
                 raise IOError(f"File {filepath} was created but is empty")
 
-            # Generate channels.tsv file using stored analyses
-            channels_tsv_path = os.path.splitext(filepath)[0] + '_channels.tsv'
-            pd.DataFrame(channels_tsv_data).to_csv(channels_tsv_path, sep='\t', index=False)
-            print(f"\nChannels metadata saved to: {channels_tsv_path}")
+            # Generate BIDS-compliant channels.tsv file if requested
+            if create_channels_tsv:
+                channels_tsv_path = os.path.splitext(filepath)[0] + '_channels.tsv'
+                # Create DataFrame with columns in BIDS-specified order
+                # Required columns first: name, type, units
+                # Then optional columns in the order they appear in data
+                ordered_columns = ['name', 'type', 'units']
+                optional_columns = [col for col in channels_tsv_data.keys() if col not in ordered_columns]
+                column_order = ordered_columns + optional_columns
+                
+                channels_df = pd.DataFrame(channels_tsv_data)
+                channels_df = channels_df[column_order]
+                channels_df.to_csv(channels_tsv_path, sep='\t', index=False, na_rep='n/a')
+                print(f"\nBIDS-compliant channels metadata saved to: {channels_tsv_path}")
 
             # Print summary using stored analyses, only if analysis was performed
             if not bypass_analysis:

--- a/emgio/tests/test_core.py
+++ b/emgio/tests/test_core.py
@@ -513,7 +513,9 @@ def test_to_edf_export(sample_emg, mock_edf_exporter):
     assert 'events_df' in mock_edf_exporter.last_export['kwargs']
     pd.testing.assert_frame_equal(mock_edf_exporter.last_export['kwargs']['events_df'], sample_emg.events)
     assert len(mock_edf_exporter.last_export['kwargs']['events_df']) == 2
-    assert len(mock_edf_exporter.last_export['kwargs']) == 1 # Only events_df expected here
+    assert 'create_channels_tsv' in mock_edf_exporter.last_export['kwargs']
+    assert mock_edf_exporter.last_export['kwargs']['create_channels_tsv'] is True  # Default value
+    assert len(mock_edf_exporter.last_export['kwargs']) == 2  # events_df + create_channels_tsv
 
     # Test with specific format and additional kwargs (format=bdf should bypass analysis by default)
     custom_kwargs = {'patient_id': 'TEST001'}
@@ -526,7 +528,8 @@ def test_to_edf_export(sample_emg, mock_edf_exporter):
     pd.testing.assert_frame_equal(mock_edf_exporter.last_export['kwargs']['events_df'], sample_emg.events)
     assert len(mock_edf_exporter.last_export['kwargs']['events_df']) == 2
     assert mock_edf_exporter.last_export['kwargs']['patient_id'] == 'TEST001'
-    assert len(mock_edf_exporter.last_export['kwargs']) == 2  # events_df + patient_id
+    assert 'create_channels_tsv' in mock_edf_exporter.last_export['kwargs']
+    assert len(mock_edf_exporter.last_export['kwargs']) == 3  # events_df + create_channels_tsv + patient_id
 
     # Test passing an external events DataFrame
     external_events = pd.DataFrame([
@@ -605,7 +608,8 @@ def test_to_edf_export(sample_emg, mock_edf_exporter):
     assert 'events_df' in mock_edf_exporter.last_export['kwargs']
     pd.testing.assert_frame_equal(mock_edf_exporter.last_export['kwargs']['events_df'], sample_emg.events)
     assert mock_edf_exporter.last_export['kwargs']['patient_id'] == 'TEST001'
-    assert len(mock_edf_exporter.last_export['kwargs']) == 2  # events_df + patient_id
+    assert 'create_channels_tsv' in mock_edf_exporter.last_export['kwargs']
+    assert len(mock_edf_exporter.last_export['kwargs']) == 3  # events_df + create_channels_tsv + patient_id
 
 
 def test_to_edf_empty(empty_emg, mock_edf_exporter):

--- a/emgio/tests/test_exporters.py
+++ b/emgio/tests/test_exporters.py
@@ -241,13 +241,13 @@ def test_edf_export(sample_emg):
             assert np.allclose(original_acc_data, reconstructed_acc_data, atol=1e-3), \
                    f"ACC1 scaling incorrect. Max diff: {np.max(np.abs(original_acc_data - reconstructed_acc_data)):.2e}"
 
-        # Verify channels.tsv content
+        # Verify BIDS-compliant channels.tsv content
         channels_df = pd.read_csv(channels_tsv_path, sep='\t')
         assert len(channels_df) == 2
         assert list(channels_df['name']) == ['EMG1', 'ACC1']
-        assert list(channels_df['channel_type']) == ['EMG', 'ACC']
-        assert list(channels_df['physical_dimension']) == ['mV', 'g']
-        assert list(channels_df['sample_frequency']) == [1000, 1000]
+        assert list(channels_df['type']) == ['EMG', 'MISC']  # ACC mapped to MISC in BIDS
+        assert list(channels_df['units']) == ['mV', 'g']
+        assert list(channels_df['sampling_frequency']) == [1000, 1000]
 
     finally:
         # Cleanup
@@ -257,6 +257,32 @@ def test_edf_export(sample_emg):
             os.unlink(bdf_path)
         if os.path.exists(channels_tsv_path):
             os.unlink(channels_tsv_path)
+
+
+def test_edf_export_no_channels_tsv(sample_emg):
+    """Test that channels.tsv is not created when create_channels_tsv=False."""
+    with tempfile.NamedTemporaryFile(suffix='.edf', delete=False) as f:
+        edf_path = f.name
+        bdf_path = os.path.splitext(edf_path)[0] + '.bdf'
+    
+    try:
+        # Export with create_channels_tsv=False
+        EDFExporter.export(sample_emg, edf_path, create_channels_tsv=False, precision_threshold=1)
+        
+        # Check if either EDF or BDF file was created
+        actual_path = bdf_path if os.path.exists(bdf_path) else edf_path
+        assert os.path.exists(actual_path), f"Neither {edf_path} nor {bdf_path} was created"
+        
+        # Check that channels.tsv was NOT created
+        channels_tsv_path = os.path.splitext(actual_path)[0] + '_channels.tsv'
+        assert not os.path.exists(channels_tsv_path), "channels.tsv should not be created when create_channels_tsv=False"
+        
+    finally:
+        # Cleanup
+        if os.path.exists(edf_path):
+            os.unlink(edf_path)
+        if os.path.exists(bdf_path):
+            os.unlink(bdf_path)
 
 
 def test_edf_export_no_signals():


### PR DESCRIPTION
## Summary
- Update channels.tsv format to comply with BIDS EMG specification
- Add option to disable channels.tsv generation when not needed
- Maintain backward compatibility by defaulting to creating the file

## Changes
1. **BIDS-compliant format**: Updated column names (type, units) and order per BIDS spec
2. **Channel type mapping**: Map to BIDS uppercase values (EMG, ECG, MISC, etc)  
3. **Optional generation**: Added create_channels_tsv parameter (default: True)
4. **Updated tests**: All tests updated and passing

## Test plan
- [x] Run existing EDF export tests
- [x] Test BIDS-compliant column format
- [x] Test disabling channels.tsv creation
- [x] Verify backward compatibility

Fixes #33