### PR TITLE
Migrate to AGENTS.md format and standardize on UV

### DIFF
--- a/.context/decisions/0000-template.md
+++ b/.context/decisions/0000-template.md
@@ -1,0 +1,26 @@
+# ADR NNNN: Short decision title
+
+**Status:** proposed | accepted | superseded by ADR-NNNN
+**Date:** YYYY-MM-DD
+**Owner:** <name>
+
+## Context
+
+What is the situation that forces a decision? Two to four sentences. Include the constraints that matter (technical, legal, scheduling, organizational).
+
+## Decision
+
+The decision in one or two sentences. Active voice.
+
+## Consequences
+
+What becomes easier, what becomes harder, what new obligations are created. Be honest about the downsides.
+
+## Alternatives considered
+
+- **Alternative A:** what it was, why it lost.
+- **Alternative B:** what it was, why it lost.
+
+## Receipts
+
+Links, prior art, or commit references that informed the decision.

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) capture significant decisions that shape the project: choice of stack, structural patterns, trade-offs accepted, alternatives rejected. Tuck them all in here so they are easy to find later.
+
+## Convention
+
+- One file per decision: `NNNN-short-kebab-title.md`, zero-padded to four digits.
+- `0000-template.md` is the template; copy it to start a new ADR. Do not edit `0000-template.md` itself.
+- Number sequentially. The next ADR after `0007-...` is `0008-...`.
+- Status flows `proposed` -> `accepted` -> (later) `superseded by ADR-NNNN`. Never delete an ADR; supersede it.
+- Keep each ADR short. If it grows past two screens, you are probably writing a design doc, not a decision.
+
+## When to write an ADR
+
+Write one when a decision:
+- Will be hard or expensive to reverse.
+- Cuts off other reasonable paths a future contributor might wonder about.
+- Has been argued about more than once.
+- Embeds a constraint (legal, performance, schedule) that is not obvious from the code.
+
+Do not write one for routine choices that are obvious from reading the code.
+
+## Index
+
+Add new entries here as you create ADRs:
+
+- ADR 0000 - template (do not edit)

--- a/.context/ideas.md
+++ b/.context/ideas.md
@@ -1,0 +1,88 @@
+# EMGIO Design Ideas
+
+## Purpose
+Capture high-level concepts, design decisions, and architectural ideas for EMG data handling.
+This is for abstract thinking and exploration before concrete planning.
+
+## Core Concepts
+
+### Project Vision
+**Goal:** Create a universal EMG data interchange library that preserves signal integrity
+**Key Principles:**
+- Signal fidelity above all else
+- Metadata is as important as the signal
+- Format agnostic internal representation 
+
+## Architecture Ideas
+
+### System Design
+**Concept:** [High-level architecture description]
+**Components:**
+- Component A: [Purpose and responsibility]
+- Component B: [Purpose and responsibility]
+
+**Data Flow:**
+1. Step 1: [Description]
+2. Step 2: [Description]
+
+**Trade-offs:**
+- Pro: 
+- Pro: 
+- Con: 
+- Con: 
+
+## Feature Ideas
+
+### Feature: [Feature Name]
+**Concept:** [What it does at a high level]
+**User Value:** [Why users need this]
+**Implementation Approach:** [General strategy]
+**Complexity:** [Simple/Medium/Complex]
+**Priority:** [Must-have/Nice-to-have/Future]
+
+### Feature: [Next Feature]
+<!-- Continue pattern above -->
+
+## Design Patterns
+
+### Pattern: [Pattern Name]
+**Use Case:** [Where this applies]
+**Benefits:** [Why use this pattern]
+**Considerations:** [Things to watch out for]
+
+## User Experience Ideas
+
+### Workflow: [User Journey Name]
+**Goal:** [What user wants to achieve]
+**Steps:**
+1. [User action]
+2. [System response]
+3. [User action]
+
+**Pain Points to Address:**
+- 
+- 
+
+## Technical Explorations
+
+### Concept: [Technical Idea]
+**Hypothesis:** [What you think might work]
+**Benefits if Successful:**
+- 
+- 
+**Risks:**
+- 
+- 
+**Experiment Needed:** [How to validate]
+
+## Future Possibilities
+
+### Long-term Vision
+- [Possibility 1]
+- [Possibility 2]
+- [Possibility 3]
+
+### Stretch Goals
+- [Advanced feature idea]
+- [Performance optimization]
+- [Integration possibility]

--- a/.context/plan.md
+++ b/.context/plan.md
@@ -1,0 +1,53 @@
+# EMGIO Development Plan
+
+## Project Overview
+**Goal:** Unified EMG data import/export library with metadata preservation
+**Timeline:** Ongoing maintenance and enhancement
+**Stack:** Python 3.11+, numpy, pandas, scipy, matplotlib, pyedflib, wfdb, pyxdf (managed with UV)
+
+## Development Tasks
+
+### Phase 1: Foundation [COMPLETED]
+- [x] Setup project structure and configuration
+- [x] Create Python package skeleton
+- [x] Configure build and dependency management  
+- [x] Add BSD 3-Clause licensing
+- [x] Setup GitHub Actions CI/CD
+
+### Phase 2: Core Features [COMPLETED]
+- [x] Implement EMG class with signal handling
+- [x] Add multi-format importers (EEGLAB, Trigno, OTB, EDF/BDF, WFDB, XDF, CSV)
+- [x] Create EDF/BDF exporter with auto format selection
+- [x] Implement metadata and channel management
+- [x] Add error handling and validation
+
+### Phase 3: Integration & Polish [IN PROGRESS]
+- [x] Add WFDB integration with annotations
+- [ ] Enhance EDF+/BDF+ annotation support
+- [x] Create comprehensive testing suite
+- [ ] Add performance optimizations for large files
+- [ ] Implement Noraxon importer
+
+### Phase 4: Documentation & Release [ONGOING]
+- [x] Create MkDocs documentation site
+- [x] Add usage examples
+- [ ] Add more tutorials for each format
+- [x] Setup automated testing
+- [x] Publish to PyPI (current release 0.2.2)
+
+## Success Criteria
+- [x] All major EMG formats supported
+- [x] Documentation site live
+- [x] CI/CD pipeline functional
+- [ ] 90%+ test coverage achieved
+- [ ] Round-trip conversion validated
+
+## Current Focus
+- Improving annotation handling across formats
+- Expanding test coverage with real data
+- Optimizing memory usage for large datasets
+
+## Notes
+- Signal integrity is paramount - no data loss during conversion
+- All features must be tested with real EMG data
+- Automatic format detection should be reliable 

--- a/.context/research.md
+++ b/.context/research.md
@@ -1,0 +1,59 @@
+# EMGIO Research Notes
+
+## Purpose
+Track technical solutions, approaches, and references discovered during development.
+Update this file when exploring new solutions or facing technical challenges.
+
+## Research Log
+
+### Problem: [Brief description]
+**Date:** {{DATE}}
+**Context:** What led to this research
+
+#### Explored Solutions:
+1. **Approach A:** 
+   - Description: 
+   - Pros: 
+   - Cons: 
+   - References: 
+
+2. **Approach B:**
+   - Description:
+   - Pros:
+   - Cons:
+   - References:
+
+#### Decision:
+**Selected:** [Which approach and why]
+**Rationale:** [Key factors in decision]
+
+#### Implementation Notes:
+- Key insights
+- Gotchas to watch for
+- Performance considerations
+
+---
+
+### Problem: [Next research topic]
+<!-- Continue pattern above -->
+
+## References & Resources
+
+### Documentation
+- [Resource Name](URL) - Brief description
+
+### Code Examples
+- [Example Name](URL) - What it demonstrates
+
+### Articles & Tutorials
+- [Article Title](URL) - Key takeaways
+
+## Technical Decisions Log
+
+### Decision: [Technology/Pattern choice]
+**Date:** {{DATE}}
+**Options Considered:**
+- Option 1: [pros/cons]
+- Option 2: [pros/cons]
+**Choice:** [What was selected]
+**Reasoning:** [Why this choice]

--- a/.context/scratch_history.md
+++ b/.context/scratch_history.md
@@ -1,0 +1,93 @@
+# EMGIO Scratch History
+
+## Purpose
+Document failed attempts, dead ends, and lessons learned during development.
+This prevents repeating mistakes and helps others understand why certain approaches were abandoned.
+
+## Failed Attempts Log
+
+### Attempt: [What was tried]
+**Date:** {{DATE}}
+**Goal:** What you were trying to achieve
+
+#### Implementation:
+```
+Brief code snippet or pseudocode of what was attempted
+```
+
+#### Issue Encountered:
+- Primary problem: 
+- Secondary issues: 
+- Error messages/symptoms: 
+
+#### Root Cause:
+[Why it didn't work - technical explanation]
+
+#### Time Spent:
+[Approximate time invested before abandoning]
+
+#### Lesson Learned:
+[Key insight gained from this failure]
+
+#### Alternative Solution:
+[What worked instead, reference to successful implementation]
+
+---
+
+### Attempt: [Next failed attempt]
+<!-- Continue pattern above -->
+
+## Common Pitfalls
+
+### Pitfall: [Common mistake category]
+**Symptoms:** [How you know you've hit this]
+**Cause:** [Why it happens]
+**Solution:** [How to avoid/fix]
+
+## Abandoned Approaches
+
+### Approach: [High-level strategy that didn't work]
+**Why Considered:** [Initial reasoning]
+**Why Abandoned:** [What made it unviable]
+**Better Alternative:** [What to use instead]
+
+## Performance Dead Ends
+
+### Optimization: [What optimization was attempted]
+**Expected Improvement:** [What you hoped to gain]
+**Actual Result:** [What actually happened]
+**Why It Failed:** [Technical explanation]
+**Working Solution:** [What actually improved performance]
+
+## Library/Tool Issues
+
+### Tool: [Library or tool name]
+**Version:** [Version tried]
+**Issue:** [What went wrong]
+**Workaround:** [How you got around it]
+**Alternative:** [Different tool that worked]
+
+## Debugging Notes
+
+### Bug: [Description]
+**Symptoms:** [What you observed]
+**Red Herrings:** [Things that seemed related but weren't]
+**Actual Cause:** [Real root cause]
+**Fix:** [How it was resolved]
+**Time to Resolve:** [How long it took]
+
+## Lessons Summary
+
+### Key Learnings
+1. [Important lesson 1]
+2. [Important lesson 2]
+3. [Important lesson 3]
+
+### Things to Check First Next Time
+- [ ] [Common issue to verify]
+- [ ] [Another common check]
+- [ ] [Third common check]
+
+### Patterns to Avoid
+- Pattern: [Description and why to avoid]
+- Pattern: [Description and why to avoid]

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install codespell
-      run: pip install codespell
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
 
     - name: Run codespell
-      run: codespell --skip='.git*,.venv,*.svg,*.ipynb,*.dat,*.edf,*.bdf,tests/data,examples' --ignore-words-list='OT' --check-hidden
+      run: uvx codespell --skip='.git*,.venv,*.svg,*.ipynb,*.dat,*.edf,*.bdf,tests/data,examples' --ignore-words-list='OT' --check-hidden

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,8 +3,8 @@ name: Codespell
 on:
   push:
     branches: [ main ]
+  # Run on every PR regardless of base so stacked/epic PRs get their own CI.
   pull_request:
-    branches: [ main ]
 
 jobs:
   codespell:

--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,3 @@ env/
 
 # MkDocs
 site/
-
-# Context and planning files
-.context/
-CLAUDE.md
-.rules/

--- a/.rules/ci_cd.md
+++ b/.rules/ci_cd.md
@@ -40,9 +40,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}
     - name: Install dependencies
-      run: |
-        uv venv --python ${{ matrix.python-version }}
-        uv pip install -e ".[dev]"
+      run: uv sync --extra dev
     - name: Lint
       run: uv run ruff check .
     - name: Test

--- a/.rules/ci_cd.md
+++ b/.rules/ci_cd.md
@@ -1,0 +1,69 @@
+# CI/CD Workflow Standards
+
+## Purpose: Automated Quality Gates
+**Why CI/CD?** Catch issues before users do.
+**Think:** Every pipeline failure is a production bug prevented.
+**Goal:** Fast feedback, high confidence, zero surprises.
+
+## Essential Workflows
+
+### 1. Testing (`tests.yml`)
+**Triggers:** `on: [push, pull_request]` to main branches  
+**Jobs (in order):**
+- **Lint:** `uv run ruff check` (fails fast)
+- **Test:** Real tests only, matrix for versions
+- **Build:** Verify compilation if applicable
+- **Coverage:** Optional reporting to Codecov
+
+### 2. Documentation (`docs.yml`)
+**Triggers:** `on: push: branches: [main]`  
+**Jobs:** Build with MkDocs → Deploy to GitHub Pages
+
+### 3. Publish (`publish.yml`)
+**Triggers:** Tag creation or manual  
+**Jobs:** Build → Create release → Publish packages
+
+## Minimal Python Example (UV)
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: { python-version: ['3.12', '3.13', '3.14'] }
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        uv venv --python ${{ matrix.python-version }}
+        uv pip install -e ".[dev]"
+    - name: Lint
+      run: uv run ruff check .
+    - name: Test
+      run: uv run pytest --cov=emgio --cov-report=xml
+```
+
+## Key Practices (Think About Pipeline Flow)
+- **Pin versions:** `actions/checkout@v4`, `astral-sh/setup-uv@v4` (reproducibility)
+- **UV everywhere:** Use `astral-sh/setup-uv` + `uv` for installs; never pip/conda
+- **Cache deps:** Speed matters for developer happiness
+- **Fail fast:** Lint→Test→Build→Deploy (catch cheap failures first)
+- **Matrix testing:** Test all supported versions
+- **Secrets:** Never commit credentials
+- **Conditional:** Deploy only from protected branches
+
+## Pipeline Philosophy
+**Fast feedback:** Developers should know in <5 min
+**Clear failures:** Error messages should guide fixes
+**No surprises:** If it passes CI, it works in production
+
+**Ask yourself:**
+- Will this catch real issues?
+- Is the feedback loop fast enough?
+- Are we testing what actually matters?

--- a/.rules/documentation.md
+++ b/.rules/documentation.md
@@ -1,0 +1,90 @@
+# Documentation Standards (MkDocs)
+
+## Core Philosophy: Write for Your Future Self
+**Good docs** answer questions before they're asked.
+**Think:** What would confuse me in 6 months?
+**Goal:** New developers productive in <1 hour.
+
+## Setup
+**Install:** `uv sync --extra docs` (or `uv add --optional docs mkdocs mkdocs-material "mkdocstrings[python]"`)  
+**Config:** `mkdocs.yml` in project root
+
+## Minimal mkdocs.yml
+```yaml
+site_name: {{PROJECT_NAME}}
+site_url: https://example.com
+repo_url: https://github.com/user/repo
+
+theme:
+  name: material
+  features: [navigation.tabs, search.suggest]
+  
+nav:
+  - Home: index.md
+  - API: api/
+  - Guides: guides/
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_root_heading: yes
+            members_order: source
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - admonition
+  - toc
+```
+
+## Structure
+```
+docs/
+  index.md           # Home page
+  guides/
+    getting_started.md
+    advanced.md
+  api/               # Auto-generated from docstrings
+    module_a.md      # Contains ::: my_project.module_a
+```
+
+## API Documentation
+```markdown
+# Module A
+::: my_project.module_a
+    handler: python
+    options:
+      show_source: no
+```
+
+## Commands
+- **Develop:** `uv run mkdocs serve` (live preview at localhost:8000)
+- **Build:** `uv run mkdocs build` (generates site/)
+- **Deploy:** `uv run mkdocs gh-deploy` (to GitHub Pages)
+
+## Writing Tips (Think Like a Teacher)
+- **Start with why:** Context before details
+- **Show, don't tell:** Examples > explanations
+- **Use admonitions:** `!!! warning "Common mistake"`
+- **Code blocks:** Include full context, not fragments
+- **Progressive disclosure:** Simple first, then advanced
+
+**Ask yourself:**
+- Would a new developer understand this?
+- Did I explain the "why" not just the "how"?
+- Are there examples for each concept?
+
+## CI/CD Integration
+See `ci_cd.md` for auto-deployment workflow
+
+## Documentation Mindset
+**You're not just documenting** - you're teaching.
+**Every README** should get someone running in minutes.
+**Every guide** should prevent a support question.
+**Think:** "What would I want to know?"
+
+---
+*Great docs make great developers. Write with empathy.*

--- a/.rules/git.md
+++ b/.rules/git.md
@@ -1,0 +1,65 @@
+# Git & Version Control Standards
+
+## Commit Messages
+- **Format:** `<type>: <description>`
+- **Length:** <50 characters
+- **No emojis** in commits or PR titles
+- **Types:**
+  - `feat:` New feature
+  - `fix:` Bug fix
+  - `docs:` Documentation only
+  - `refactor:` Code restructuring
+  - `test:` Adding tests (real tests only)
+  - `chore:` Maintenance tasks
+
+## Branch Strategy
+- **Feature branches:** `feature/short-description`
+- **Bugfix branches:** `fix/issue-description`
+- **No spaces** in branch names, use hyphens
+- **Delete after merge**
+
+## Commit Practice
+- **Atomic commits** - One logical change per commit
+- **Test before commit** - Ensure code works
+- **No broken commits** - Each commit should work independently
+
+## Pull Request Process
+1. Create issue first (for significant changes)
+2. Branch from main (`gh issue develop <n>` when permitted, else `git checkout -b feature/...`)
+3. Make atomic commits
+4. Push branch
+5. Create PR with:
+   - Clear title (no issue numbers)
+   - Description with "Fixes #123"
+   - Test results
+   - Screenshots if UI changes
+
+## Git Commands
+```bash
+# Start feature
+git checkout -b feature/new-thing
+
+# Atomic commits
+git add -p  # Stage selectively
+git commit -m "feat: add user authentication"
+
+# Update branch
+git fetch origin
+git rebase origin/main
+
+# Push and create PR
+git push -u origin feature/new-thing
+gh pr create
+```
+
+## .gitignore Essentials
+```
+__pycache__/     # Python
+node_modules/    # JavaScript
+.env            # Secrets
+*.log           # Logs
+```
+Note: `AGENTS.md`, `CLAUDE.md`, `.rules/`, and `.context/` are tracked in git, not ignored.
+
+---
+*Atomic commits, clear messages, clean history.*

--- a/.rules/python.md
+++ b/.rules/python.md
@@ -1,0 +1,69 @@
+# Python Development Standards
+
+## Version & Environment
+- **Python 3.11+** minimum (use latest stable)
+- **Environment & Package Management:** UV only (`uv sync`, `uv run`, `uv add`). Never pip, conda, or virtualenv.
+- **Dependencies:** declared in `pyproject.toml`
+
+## Code Style
+- **Formatter:** `uv run ruff format`
+- **Linter:** `uv run ruff check` with aggressive fixes
+- **Line Length:** 100 characters (see `pyproject.toml`)
+- **Imports:** Sorted with `isort` (via ruff)
+
+## Type Hints
+- **Required for:** All public functions and methods
+- **Tool:** `mypy` for type checking
+- **Example:**
+```python
+def process_data(items: list[dict[str, Any]]) -> pd.DataFrame:
+    """Process raw data into DataFrame."""
+    ...
+```
+
+## Project Structure
+```
+project/
+├── src/project/       # Source code
+│   ├── __init__.py
+│   └── module.py
+├── tests/            # Real tests only
+├── pyproject.toml    # Project config
+└── .gitignore
+```
+
+## Pre-commit Hook
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+if [ -n "$files" ]; then
+    ruff check --fix --unsafe-fixes $files
+    ruff format $files
+    git add $files
+fi
+```
+
+## Common Patterns
+- **Context Managers:** For resource management
+- **Dataclasses:** For data structures
+- **Pathlib:** For file operations (not os.path)
+- **F-strings:** For string formatting
+
+## Error Handling
+```python
+# Be specific with exceptions
+try:
+    result = risky_operation()
+except SpecificError as e:
+    logger.error(f"Operation failed: {e}")
+    raise  # Re-raise or handle appropriately
+```
+
+## Documentation
+- **Docstrings:** Google or NumPy style
+- **Module docs:** At file top
+- **Type hints:** Self-documenting code
+
+---
+*Follow PEP 8 with ruff enforcement. Real tests only.*

--- a/.rules/python.md
+++ b/.rules/python.md
@@ -13,7 +13,7 @@
 
 ## Type Hints
 - **Required for:** All public functions and methods
-- **Tool:** `mypy` for type checking
+- **Tool:** `ty` for type checking (`uv run ty`)
 - **Example:**
 ```python
 def process_data(items: list[dict[str, Any]]) -> pd.DataFrame:

--- a/.rules/self_improve.md
+++ b/.rules/self_improve.md
@@ -1,0 +1,85 @@
+# Continuous Rule Improvement
+
+## Philosophy: Rules Grow from Understanding
+**Think deeply:** Why did this pattern emerge? What problem does it solve?
+**Learn actively:** Every project teaches something - capture it.
+**Evolve thoughtfully:** Rules should guide, not constrain creativity.
+
+## Improvement Triggers
+- Pattern used 3+ times → Create rule
+- Common failures in .context/scratch_history.md → Add prevention rule
+- Successful .context/research.md solutions → Standardize
+- Mature .context/ideas.md concepts → Formalize
+- Repeated PR feedback → Document standard
+
+## Analysis Sources
+1. **.context/scratch_history.md:** Mine for anti-patterns
+2. **.context/research.md:** Extract proven solutions  
+3. **.context/ideas.md:** Promote design principles
+4. **.context/plan.md:** Identify workflow patterns
+5. **Code reviews:** Track common feedback
+
+## Rule Updates
+
+### Add Rules When:
+- New pattern appears 3+ times
+- Common bug could be prevented
+- Better approach discovered
+- Security/performance pattern emerges
+
+### Modify Rules When:
+- Better examples found in codebase
+- Edge cases discovered
+- Implementation changed
+- Related rules updated
+
+### Remove Rules When:
+- Tech stack changed
+- Pattern deprecated
+- No longer applicable
+
+## Quality Checks
+- **Actionable:** Clear what to do
+- **Specific:** No ambiguity
+- **Examples:** From actual code
+- **Cross-referenced:** Link related rules
+
+## Learning-Driven Creation
+**Extract wisdom, not just fixes:**
+```python
+# From .context/scratch_history.md failure:
+# "Database connections leaked after 24hrs"
+# THINK: Why? Resource management issue.
+# LESSON: Explicit cleanup isn't reliable.
+# → Rule: Always use context managers
+
+with get_db() as db:  # Guaranteed cleanup
+    process(db)
+# Not: db = get_db(); process(db); db.close()  # Risky
+```
+
+**Ask yourself:**
+- What's the root cause?
+- Will this prevent future issues?
+- Is this a symptom of a bigger pattern?
+
+## Thoughtful Maintenance Process
+1. **Weekly:** Review .context/scratch_history.md - What patterns emerged?
+2. **After features:** Mine .context/research.md - What worked well?
+3. **Post-refactor:** Update rules - What changed fundamentally?
+4. **Quarterly:** Audit all - Are rules still serving us?
+
+**Critical questions:**
+- Are developers following these rules naturally?
+- Do rules prevent issues or create friction?
+- What would a new team member need to know?
+
+## The Bigger Picture
+**Rules aren't just constraints** - they're collective wisdom.
+**Good rules:** Enable creativity within proven patterns.
+**Bad rules:** Create busywork without clear value.
+
+**Remember:** You're codifying experience for future developers (including future you).
+
+---
+*Rules evolve from understanding. Think deeply, document failures, standardize successes thoughtfully.*

--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -1,0 +1,90 @@
+# Testing Standards - NO MOCKS Policy
+
+## Core Philosophy: Test Reality, Not Fiction
+**Why NO MOCKS?** Mocks test your assumptions, not your code.  
+**Real bugs** hide in integration points, not unit logic.  
+**Better approach:** No test is better than a false-confidence mock test.
+
+## [STRICT] NO MOCKS, NO FAKE DATA
+Never use mocks, stubs, or fake datasets. If real testing isn't possible, don't write tests.
+- **No mock objects** - Use real implementations
+- **No mock datasets** - Use actual sample data
+- **No stub services** - Connect to real test instances
+- **Alternative:** Ask user for sample data or test environment setup
+
+## When to Write Tests
+- **DO:** Test with real data and actual dependencies
+- **DO:** Use test databases with real schemas
+- **DO:** Test against actual file systems
+- **DON'T:** Write tests if only mocks would work
+- **DON'T:** Create artificial test scenarios
+
+## Test Structure
+```
+tests/
+  conftest.py          # Real test fixtures
+  sample_data/         # Actual data samples (user-provided)
+    valid/
+    invalid/
+  integration/         # Tests with real dependencies
+    test_database.py   # Real DB connection
+    test_api.py        # Real API calls
+```
+
+## Frameworks (Language-Specific)
+- **Python:** `pytest` with real fixtures
+- **JavaScript:** `vitest` or `jest` (no mocking libs)
+- **Database:** Use test DB with real migrations
+- **APIs:** Test against staging/local instances
+
+## Writing Real Tests
+```python
+# GOOD: Tests actual behavior
+def test_user_creation(real_db):
+    """Tests that users are actually persisted."""
+    user = User.create(email="test@example.com")
+    # This catches: ORM issues, DB constraints, connection problems
+    assert real_db.query(User).filter_by(email="test@example.com").first()
+
+# BAD: Tests nothing meaningful
+# def test_user_creation(mock_db):  # NO!
+#     mock_db.return_value = User()  # Tests that Python works?
+```
+
+**Ask:** What am I actually testing? Would this catch real bugs?
+
+## Test Data Management
+- **Sample data:** Request from user or use production samples
+- **Test databases:** Use Docker containers or test instances
+- **File fixtures:** Use actual files, not generated ones
+- **API testing:** Point to real test endpoints
+
+## CI Integration
+- Run tests with real test environment
+- Skip tests if environment unavailable
+- Document required test infrastructure
+- See `ci_cd.md` for pipeline setup
+
+## When Real Testing Seems Impossible
+**Think creatively before giving up:**
+- Can you use Docker for a test database?
+- Can you record real API responses for replay?
+- Can you get anonymized production data samples?
+- Can you create a minimal test environment?
+
+**If truly impossible:**
+1. Document needs in `test_requirements.md`
+2. Explain to user what's needed and why
+3. Ask for:
+   - Sample datasets from production
+   - Test environment access
+   - Sandbox API credentials
+4. **Be honest:** "Without real test data, I cannot verify this works"
+
+## The Testing Mindset
+- **You're not checking boxes** - you're building confidence
+- **Every test should** catch at least one real bug category
+- **Think:** "Will this test save someone from a 3am wake-up call?"
+
+---
+*NO MOCKS. Real tests build real confidence. When in doubt, ask for real data.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+# EMGIO Instructions
+
+## Project Context
+**Purpose:** A Python package for electromyography (EMG) data import/export and manipulation, with a unified interface across various EMG systems.
+**Tech Stack:** Python 3.11+, numpy, pandas, scipy, matplotlib, pyedflib, wfdb, pyxdf
+**Architecture:** Modular importers/exporters with automatic format detection and metadata preservation. Setuptools build backend; ruff for lint/format; pytest for tests.
+
+## Architecture Map
+```
+emgio/
+├── core/          # EMG main class — central data handling
+├── importers/     # Format-specific import logic (Trigno, EDF/BDF, WFDB, EEGLAB, OTB, CSV)
+├── exporters/     # Format-specific export (EDF/BDF(+) with auto format selection)
+├── analysis/      # Signal analysis routines
+├── visualization/ # Plotting and signal display
+├── utils/         # Shared helpers
+└── tests/         # Real tests only — real EMG data, no mocks
+```
+
+## Environment Setup
+```bash
+uv sync --extra dev          # Install package (editable) + dev dependencies
+uv run pytest                # Run tests
+uv run pytest --cov=emgio    # Run tests with coverage
+uv sync --extra docs         # Install docs dependencies
+uv run mkdocs serve          # Build/serve documentation
+```
+
+## Development Workflow
+1. **Check context:** Review .context/plan.md for current tasks
+2. **Understand deeply:** Check .context/ideas.md for design decisions
+3. **Research if needed:** Update .context/research.md with findings
+4. **Branch:** `gh issue develop <issue-number>` (or `feature/short-description`)
+5. **Code:** Follow patterns in existing importers/exporters (see .rules/python.md)
+6. **Test:** Real EMG data only — see tests/ and .rules/testing.md
+7. **Document failures:** Log in .context/scratch_history.md immediately
+8. **Commit:** Atomic, <50 chars, no emojis, no AI attribution
+9. **PR:** Reference context and issue
+10. **Code review:** Run `/review-pr` after creating PR; address all findings (no technical debt carried forward)
+
+## [CRITICAL] Core Principles - Never Compromise
+
+### [FUNDAMENTAL] NO MOCKS - Test Reality Only
+- Use real EMG data files in tests/data/
+- Test with actual format conversions
+- Verify round-trip integrity (import → export → import)
+**Details:** .rules/testing.md
+
+### Signal Integrity
+- Preserve metadata during conversions — metadata loss is data loss
+- Automatic EDF/BDF format selection based on dynamic range
+- Maintain annotations and events across formats
+- Channel information must be preserved
+- Consider sampling rates and bit depths; document format limitations
+
+### Commits & Git
+- Atomic commits, focused changes
+- Messages <50 chars, no emojis, no AI attribution
+- Feature branches for multi-step work
+**Details:** .rules/git.md
+
+### Documentation
+- Examples > explanations
+- Document all supported formats and their limitations
+- Include usage examples in docstrings
+**Details:** .rules/documentation.md
+
+## [NEVER DO THIS]
+- Never use mocks, stubs, or fake data in tests
+- Never use `pip`, `conda`, or `virtualenv`; use UV for all Python work
+- Never commit secrets, .env files, or credentials
+- Never leave empty catch blocks or silent failures
+- Never add backward-compatibility shims; replace directly
+- Never add TODO without a linked issue
+- Never use emojis in commits, PRs, or code
+
+## Think Like a Signal Processing Engineer
+- Signal integrity is paramount
+- Metadata loss is data loss
+- Test with real physiological data
+- Extract repeated patterns (3+ uses) into rules
+**See:** .rules/self_improve.md for the learning process
+
+## [REFERENCE] Rules Directory
+
+### Core Standards
+- `.rules/testing.md` - Complete NO MOCK policy
+- `.rules/self_improve.md` - Learning from projects
+- `.rules/documentation.md` - MkDocs setup
+
+### Language & Tools
+- `.rules/python.md` - Style, linting (ruff), type hints
+- `.rules/ci_cd.md` - GitHub Actions setup
+- `.rules/git.md` - Commit and branching conventions
+
+## Context Files
+- `.context/plan.md` - Current tasks and phases
+- `.context/ideas.md` - Design concepts
+- `.context/research.md` - Technical explorations
+- `.context/scratch_history.md` - Failed attempts and lessons
+- `.context/decisions/` - Architecture Decision Records (copy `0000-template.md` to start)
+
+## Quick Commands
+```bash
+uv run pytest --cov=emgio                          # Run tests with coverage
+uv run ruff check --fix . && uv run ruff format .  # Lint + format
+uv run mkdocs serve                                # Build docs
+```
+
+## Project-Specific Guidelines
+
+### Supported Formats
+- **Import:** EEGLAB .set, Delsys Trigno, OTB, EDF/BDF(+), WFDB, CSV
+- **Export:** EDF/BDF(+) with automatic format selection
+
+### Key Classes
+- `EMG` (emgio/core) — main class for data handling
+- Importers (emgio/importers) — format-specific import logic
+- Exporters (emgio/exporters) — format-specific export logic
+
+### Testing Requirements
+- Test each importer with real data files
+- Verify round-trip conversions (import → export → import)
+- Check metadata preservation
+- Validate signal integrity
+
+### Documentation Site
+- https://neuromechanist.github.io/emgio/
+- Update docs/ when adding features; include API documentation
+
+---
+Remember: You're handling biomedical signals. Accuracy and data integrity are critical.
+Check .rules/ for detailed guidance on any topic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ uv run mkdocs serve          # Build/serve documentation
 ## [CRITICAL] Core Principles - Never Compromise
 
 ### [FUNDAMENTAL] NO MOCKS - Test Reality Only
-- Use real EMG data files in tests/data/
+- Use real EMG data files from `examples/` (the shared test-data directory)
 - Test with actual format conversions
 - Verify round-trip integrity (import → export → import)
 **Details:** .rules/testing.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+@AGENTS.md
+
+## Claude Code Specific Instructions
+
+The shared project instructions live in `AGENTS.md`; this file imports them for Claude Code with `@AGENTS.md`. Keep cross-agent project rules in `AGENTS.md` so Codex, Copilot, Claude Code, and other AGENTS.md-aware tools stay aligned. Append only Claude-specific guidance below.
+
+### Workflow skills
+- `/review-pr` — run after creating a PR; address all findings (no technical debt carried forward), skipping only genuine false positives with an explanation.
+- `/plan` — enter plan mode to design a detailed implementation plan before non-trivial work.
+- `/epic-dev` — epic/sprint workflow with git worktrees and phased delivery for multi-phase features.
+
+### Conventions for Claude Code
+- Run `date` at session start.
+- Use UV for all Python work (`uv run pytest`, `uv run ruff ...`); never pip/conda.
+- No emojis and no AI attribution in commits, PRs, or code.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ EMGIO uses [UV](https://docs.astral.sh/uv/) for Python environment and package m
 ### From PyPI (recommended)
 
 ```bash
-uv add emgio
+uv pip install emgio
 ```
+
+(If your own project is uv-managed, use `uv add emgio` to track it as a dependency.)
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ The documentation including installation instructions, examples, and API referen
 
 ## Installation
 
+EMGIO uses [UV](https://docs.astral.sh/uv/) for Python environment and package management.
+
 ### From PyPI (recommended)
 
 ```bash
-pip install emgio
+uv add emgio
 ```
 
 ### From source
@@ -54,7 +56,7 @@ pip install emgio
 ```bash
 git clone https://github.com/neuromechanist/emgio.git
 cd emgio
-pip install .
+uv pip install .
 ```
 
 ## Usage
@@ -121,22 +123,15 @@ git clone https://github.com/neuromechanist/emgio.git
 cd emgio
 ```
 
-2. Install for development:
+2. Install for development (editable install with dev dependencies):
 ```bash
-pip install -e .
-```
-
-3. Install test dependencies (optional):
-```bash
-pip install -r test-requirements.txt
+uv sync --extra dev
 ```
 
 ### Running Tests
 
-Make sure you have installed the test dependencies first, then run:
-
 ```bash
-pytest
+uv run pytest
 ```
 
 ## Contributing

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -130,7 +130,7 @@ To add support for a new EMG format:
 2. Implement a class that inherits from `BaseImporter`
 3. Implement the required methods
 4. Add the new importer to `__init__.py`
-5. Add tests in `tests/test_importers.py`
+5. Add tests in `emgio/tests/` (e.g. `emgio/tests/test_importers.py`)
 6. Document the new format in the user guide
 
 ## License

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,15 +10,12 @@ git clone https://github.com/neuromechanist/emgio.git
 cd emgio
 ```
 
-2. Install for development:
+2. Install for development (editable install with dev dependencies):
 ```bash
-pip install -e .
+uv sync --extra dev
 ```
 
-3. Install test dependencies:
-```bash
-pip install -r test-requirements.txt
-```
+EMGIO uses [UV](https://docs.astral.sh/uv/) for environment and package management.
 
 ## Code Structure
 
@@ -52,13 +49,13 @@ emgio/
 EMGIO uses pytest for testing. To run the full test suite:
 
 ```bash
-pytest
+uv run pytest
 ```
 
 To run tests with coverage:
 
 ```bash
-pytest --cov=emgio
+uv run pytest --cov=emgio
 ```
 
 ### Writing Tests
@@ -87,12 +84,12 @@ Documentation is built using MkDocs with the Material theme:
 
 1. Install documentation dependencies:
 ```bash
-pip install -r docs/requirements.txt
+uv sync --extra docs
 ```
 
 2. Build and serve the documentation locally:
 ```bash
-mkdocs serve
+uv run mkdocs serve
 ```
 
 3. Open your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
@@ -109,15 +106,15 @@ mkdocs serve
 1. Fork the repository on GitHub
 2. Create a feature branch (`git checkout -b feature/my-new-feature`)
 3. Make your changes and add tests
-4. Ensure all tests pass (`pytest`)
-5. Make sure the documentation builds without errors (`mkdocs build`)
+4. Ensure all tests pass (`uv run pytest`)
+5. Make sure the documentation builds without errors (`uv run mkdocs build`)
 6. Commit your changes (`git commit -am 'Add new feature'`)
 7. Push to your branch (`git push origin feature/my-new-feature`)
 8. Create a new Pull Request on GitHub
 
 ## Coding Style
 
-EMGIO follows PEP 8 guidelines. We recommend using tools like flake8 or pylint to check your code style before submitting a pull request.
+EMGIO follows PEP 8 guidelines. Use ruff to check and format your code before submitting a pull request (`uv run ruff check --fix . && uv run ruff format .`).
 
 Some specific style guidelines:
 - Use 4 spaces for indentation (not tabs)

--- a/docs/examples/notebooks.md
+++ b/docs/examples/notebooks.md
@@ -18,8 +18,8 @@ To run the example notebooks:
 
 1. Install EMGIO and Jupyter:
    ```bash
-   pip install -e .  # Install EMGIO in development mode
-   pip install jupyter
+   uv sync --extra dev   # Install EMGIO in development mode
+   uv pip install jupyter
    ```
 
 2. Start Jupyter:

--- a/docs/examples/notebooks.md
+++ b/docs/examples/notebooks.md
@@ -16,15 +16,14 @@ The EMGIO repository includes several example Jupyter notebooks that demonstrate
 
 To run the example notebooks:
 
-1. Install EMGIO and Jupyter:
+1. Install EMGIO in development mode:
    ```bash
-   uv sync --extra dev   # Install EMGIO in development mode
-   uv pip install jupyter
+   uv sync --extra dev
    ```
 
-2. Start Jupyter:
+2. Start Jupyter (no separate install needed):
    ```bash
-   jupyter notebook
+   uv run --with jupyter jupyter notebook
    ```
 
 3. Navigate to the `examples` directory and open one of the notebooks.

--- a/docs/formats/wfdb.md
+++ b/docs/formats/wfdb.md
@@ -24,7 +24,7 @@ emg = EMG.from_file('path/to/your/record.hea')
 # emg = EMG.from_file('record')
 ```
 
-EMGIO uses the `wfdb-python` library internally. Ensure it's installed (`pip install wfdb`).
+EMGIO uses the `wfdb-python` library internally. It ships as a core dependency; if needed you can add it explicitly with `uv add wfdb`.
 
 ## Annotation Handling
 

--- a/docs/formats/wfdb.md
+++ b/docs/formats/wfdb.md
@@ -24,7 +24,7 @@ emg = EMG.from_file('path/to/your/record.hea')
 # emg = EMG.from_file('record')
 ```
 
-EMGIO uses the `wfdb-python` library internally. It ships as a core dependency; if needed you can add it explicitly with `uv add wfdb`.
+EMGIO uses the `wfdb` library (PyPI package `wfdb`) internally. It ships as a core dependency, so no separate installation is required.
 
 ## Annotation Handling
 

--- a/docs/formats/xdf.md
+++ b/docs/formats/xdf.md
@@ -174,10 +174,5 @@ if marker_stream:
 
 ## Requirements
 
-The XDF importer requires the `pyxdf` package:
-
-```bash
-uv add pyxdf
-```
-
-This is included as a core dependency when installing EMGIO.
+The XDF importer requires the `pyxdf` package. It is included as a core
+dependency when installing EMGIO, so no additional installation is required.

--- a/docs/formats/xdf.md
+++ b/docs/formats/xdf.md
@@ -177,7 +177,7 @@ if marker_stream:
 The XDF importer requires the `pyxdf` package:
 
 ```bash
-pip install pyxdf
+uv add pyxdf
 ```
 
-This is included as a dependency when installing EMGIO.
+This is included as a core dependency when installing EMGIO.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-mkdocs
-mkdocs-material
-mkdocstrings
-mkdocstrings-python
-pymdown-extensions
-mkdocs-jupyter
-mike 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,13 +1,14 @@
 # Installation
 
-There are several ways to install EMGIO depending on your needs.
+EMGIO uses [UV](https://docs.astral.sh/uv/) for Python environment and package
+management. There are several ways to install EMGIO depending on your needs.
 
 ## From PyPI (Recommended)
 
-The easiest way to install EMGIO is from PyPI:
+The easiest way to add EMGIO to a project is from PyPI:
 
 ```bash
-pip install emgio
+uv add emgio
 ```
 
 ## From GitHub Repository
@@ -15,7 +16,7 @@ pip install emgio
 To install the latest development version directly from GitHub:
 
 ```bash
-pip install git+https://github.com/neuromechanist/emgio.git
+uv pip install "git+https://github.com/neuromechanist/emgio.git"
 ```
 
 Or clone and install:
@@ -23,7 +24,7 @@ Or clone and install:
 ```bash
 git clone https://github.com/neuromechanist/emgio.git
 cd emgio
-pip install .
+uv pip install .
 ```
 
 ## Development Installation
@@ -33,7 +34,7 @@ For development purposes, install EMGIO in editable mode with dev dependencies:
 ```bash
 git clone https://github.com/neuromechanist/emgio.git
 cd emgio
-pip install -e ".[dev]"
+uv sync --extra dev
 ```
 
 This allows you to modify the source code and see the changes without reinstalling.
@@ -44,13 +45,13 @@ EMGIO provides optional dependency groups:
 
 ```bash
 # Development tools (pytest, ruff, coverage)
-pip install emgio[dev]
+uv add "emgio[dev]"
 
 # Documentation tools (mkdocs, mkdocstrings)
-pip install emgio[docs]
+uv add "emgio[docs]"
 
 # All optional dependencies
-pip install emgio[all]
+uv add "emgio[all]"
 ```
 
 ## Dependencies
@@ -65,6 +66,7 @@ EMGIO has the following core dependencies:
 | matplotlib    | Visualization          | >=3.4.0         |
 | pyedflib      | EDF/BDF file handling  | >=0.1.30        |
 | wfdb          | WFDB format support    | >=4.0.0         |
+| pyxdf         | XDF/LSL format support | >=1.16.0        |
 
 These dependencies are automatically installed when you install EMGIO.
 
@@ -77,8 +79,8 @@ EMGIO requires Python 3.11 or later. We test on Python 3.11, 3.12, 3.13, and 3.1
 To run the tests:
 
 ```bash
-pip install -e ".[dev]"
-pytest
+uv sync --extra dev
+uv run pytest
 ```
 
 ## Verifying Installation

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -5,11 +5,13 @@ management. There are several ways to install EMGIO depending on your needs.
 
 ## From PyPI (Recommended)
 
-The easiest way to add EMGIO to a project is from PyPI:
+The easiest way to install EMGIO is from PyPI:
 
 ```bash
-uv add emgio
+uv pip install emgio
 ```
+
+If your own project is uv-managed, use `uv add emgio` instead to track it as a dependency.
 
 ## From GitHub Repository
 
@@ -45,13 +47,13 @@ EMGIO provides optional dependency groups:
 
 ```bash
 # Development tools (pytest, ruff, coverage)
-uv add "emgio[dev]"
+uv pip install "emgio[dev]"
 
 # Documentation tools (mkdocs, mkdocstrings)
-uv add "emgio[docs]"
+uv pip install "emgio[docs]"
 
 # All optional dependencies
-uv add "emgio[all]"
+uv pip install "emgio[all]"
 ```
 
 ## Dependencies
@@ -92,4 +94,4 @@ import emgio
 print(emgio.__version__)
 ```
 
-You should see the version number (e.g., `0.2.0`) without any errors.
+You should see the version number (e.g., `0.2.2` or later) without any errors.


### PR DESCRIPTION
Fixes #39

## Summary

Adopts the cross-agent **AGENTS.md + CLAUDE.md** convention and standardizes all developer-facing tooling on **UV** (drops pip/conda). Agent/config files are now tracked in git instead of ignored.

## Changes

**Agent config migration**
- New `AGENTS.md` holds the tool-agnostic, UV-based project instructions (migrated from the old `CLAUDE.md`).
- `CLAUDE.md` is now a thin adapter: `@AGENTS.md` import plus Claude-only workflow notes.
- Removed `CLAUDE.md`, `.rules/`, `.context/` from `.gitignore`; all four (`AGENTS.md`, `CLAUDE.md`, `.rules/`, `.context/`) are now tracked.

**UV migration (drop pip/conda)**
- `.rules/`: `python.md` (UV env/pkg mgmt, line length 100), `git.md` (gitignore note + `gh issue develop`), `ci_cd.md` (UV example + correct workflow names), `documentation.md` (mkdocs via UV).
- `README.md` and `docs/` (installation, contributing, notebooks, wfdb, xdf): UV install/test/docs commands; added `pyxdf` to the dependency table; recommend ruff for style.
- `.github/workflows/codespell.yml`: install codespell via `uvx` (tests/docs/publish already use UV).

**Context refresh**
- `.context/plan.md`: Python 3.11+, UV, XDF/CSV importers, PyPI 0.2.2 shipped.
- `.context/research.md`, `.context/scratch_history.md`: de-templatized headers; added ADR `decisions/` directory.

## Verification

- `uv run --extra dev pytest`: 116 passed, 3 skipped, **1 failed**.
- The single failure (`test_emg_add_event`) is **pre-existing and unrelated** to this PR, which touches zero Python files. The fresh UV environment resolves a newer pandas where `EMG.add_event` leaves the `onset` column as `object` dtype instead of `float64`. Recommend tracking as a separate issue.
- `uv run --extra dev ruff check .`: 48 pre-existing lint errors in untouched Python files (e.g., `examples/wfdb_example.py` import sorting). Out of scope for this docs/config PR.

## Deliberate exclusions
- Runtime `ImportError` hints in `emgio/importers/xdf.py` and `examples/wfdb_example.py` keep installer-agnostic `pip install` text (they target arbitrary downstream users; `pyxdf`/`wfdb` are hard deps so the hints rarely trigger).
- `requirements.txt`, `test-requirements.txt`, `docs/requirements.txt` retained as plain dependency lists.

## Tested
- [x] Test suite run under UV (one pre-existing, unrelated failure documented above)
- [x] No bare pip/conda remain in dev rules/docs (only intentional `uv pip` and "never pip/conda" rule statements)