### PR TITLE
Enforce ruff in CI; add non-blocking ty type-check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
+  # Run on every PR regardless of base so stacked/epic PRs get their own CI.
   pull_request:
-    branches:
-      - main
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,6 +25,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Ruff lint
         run: uvx ruff check --output-format=github .
@@ -45,6 +46,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
 
       - name: ty check
         run: uvx ty check emgio

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 # Cancel superseded runs on the same ref for fast feedback.
 concurrency:
-  group: lint-${{ github.workflow }}-${{ github.ref }}
+  group: lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,8 +33,10 @@ jobs:
     name: ty (type check, non-blocking)
     runs-on: ubuntu-latest
     # Type checking is informational for now: ty still reports pre-existing
-    # diagnostics across the codebase. Do not fail CI on it yet (tracked
-    # separately); flip continue-on-error to false once diagnostics reach zero.
+    # diagnostics across the codebase, so it does not fail CI yet. NOTE:
+    # continue-on-error makes this job's result invisible to branch protection,
+    # so it cannot be a required check until the diagnostics are driven to zero
+    # and continue-on-error is flipped to false. Tracked in issue #43.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,8 @@ name: Lint
 on:
   push:
     branches: [ main ]
+  # Run on every PR regardless of base so stacked/epic PRs get their own CI.
   pull_request:
-    branches: [ main ]
 
 # Cancel superseded runs on the same ref for fast feedback.
 concurrency:
@@ -33,12 +33,6 @@ jobs:
   ty:
     name: ty (type check, non-blocking)
     runs-on: ubuntu-latest
-    # Type checking is informational for now: ty still reports pre-existing
-    # diagnostics across the codebase, so it does not fail CI yet. NOTE:
-    # continue-on-error makes this job's result invisible to branch protection,
-    # so it cannot be a required check until the diagnostics are driven to zero
-    # and continue-on-error is flipped to false. Tracked in issue #43.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -48,5 +42,11 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
+      # Type checking is informational for now: ty still reports pre-existing
+      # diagnostics. continue-on-error at the STEP level lets the step fail while
+      # the JOB (and its status check) stays green -- job-level continue-on-error
+      # instead surfaces a FAILED check that branch rules block on. Remove this
+      # to make ty a blocking gate once diagnostics reach zero. Tracked in #43.
       - name: ty check
+        continue-on-error: true
         run: uvx ty check emgio

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Cancel superseded runs on the same ref for fast feedback.
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    name: ruff (lint + format)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Ruff lint
+        run: uvx ruff check --output-format=github .
+
+      - name: Ruff format check
+        run: uvx ruff format --check .
+
+  ty:
+    name: ty (type check, non-blocking)
+    runs-on: ubuntu-latest
+    # Type checking is informational for now: ty still reports pre-existing
+    # diagnostics across the codebase. Do not fail CI on it yet (tracked
+    # separately); flip continue-on-error to false once diagnostics reach zero.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: ty check
+        run: uvx ty check emgio

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ name: Tests
 on:
   push:
     branches: [ main ]
+  # Run on every PR regardless of base so stacked/epic PRs get their own CI.
   pull_request:
-    branches: [ main ]
 
 concurrency:
   group: tests-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,6 +22,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
 
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
+        cache-dependency-glob: "pyproject.toml"
 
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}

--- a/emgio/analysis/verification.py
+++ b/emgio/analysis/verification.py
@@ -90,7 +90,12 @@ def compare_signals(
             min_len = min(len(original_channels), len(reloaded_channels))
             original_list = sorted(original_channels)
             reloaded_list = sorted(reloaded_channels)
-            channel_pairs = list(zip(original_list[:min_len], reloaded_list[:min_len], strict=True))
+            # Both lists are explicitly sliced to min_len, so truncation here is
+            # intentional (unmatched channels are tracked below); strict=False
+            # documents that the differing original/reloaded counts are tolerated.
+            channel_pairs = list(
+                zip(original_list[:min_len], reloaded_list[:min_len], strict=False)
+            )
             channel_summary["unmatched_original"] = original_list[min_len:]
             channel_summary["unmatched_reloaded"] = reloaded_list[min_len:]
 

--- a/emgio/analysis/verification.py
+++ b/emgio/analysis/verification.py
@@ -3,7 +3,7 @@ Functions for verifying signal integrity after operations like export/import.
 """
 
 import logging
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -16,7 +16,7 @@ def compare_signals(
     emg_original: "EMG",
     emg_reloaded: "EMG",
     tolerance: float = 0.01,  # Default tolerance 1% for NRMSE and Max Norm Abs Diff
-    channel_map: Optional[Dict[str, str]] = None,
+    channel_map: dict[str, str] | None = None,
 ) -> dict:
     """
     Compare signals between two EMG objects using normalized metrics.
@@ -90,7 +90,7 @@ def compare_signals(
             min_len = min(len(original_channels), len(reloaded_channels))
             original_list = sorted(original_channels)
             reloaded_list = sorted(reloaded_channels)
-            channel_pairs = list(zip(original_list[:min_len], reloaded_list[:min_len]))
+            channel_pairs = list(zip(original_list[:min_len], reloaded_list[:min_len], strict=True))
             channel_summary["unmatched_original"] = original_list[min_len:]
             channel_summary["unmatched_reloaded"] = reloaded_list[min_len:]
 

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -485,10 +485,14 @@ class EMG:
             description: Event description string.
         """
         new_event = pd.DataFrame(
-            [{"onset": onset, "duration": duration, "description": description}]
+            [{"onset": float(onset), "duration": float(duration), "description": description}]
         )
-        # Use pd.concat for appending, ignore_index=True resets the index
-        self.events = pd.concat([self.events, new_event], ignore_index=True)
+        # Avoid concatenating onto the empty, object-dtype events frame, which
+        # would coerce the numeric columns to object. Start from the typed
+        # new_event when there are no existing events.
+        if self.events.empty:
+            self.events = new_event
+        else:
+            self.events = pd.concat([self.events, new_event], ignore_index=True)
         # Sort events by onset time for consistency
-        self.events.sort_values(by="onset", inplace=True)
-        self.events.reset_index(drop=True, inplace=True)
+        self.events = self.events.sort_values(by="onset").reset_index(drop=True)

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -490,7 +490,7 @@ class EMG:
         # Avoid concatenating onto the empty, object-dtype events frame, which
         # would coerce the numeric columns to object. Start from the typed
         # new_event when there are no existing events.
-        if self.events.empty:
+        if self.events is None or self.events.empty:
             self.events = new_event
         else:
             self.events = pd.concat([self.events, new_event], ignore_index=True)

--- a/emgio/importers/csv.py
+++ b/emgio/importers/csv.py
@@ -1,5 +1,3 @@
-from typing import Dict, Optional
-
 import numpy as np
 import pandas as pd
 
@@ -15,7 +13,7 @@ class CSVImporter(BaseImporter):
     headers, time columns, and allow for specific column selection.
     """
 
-    def _detect_specialized_format(self, filepath: str) -> Optional[str]:
+    def _detect_specialized_format(self, filepath: str) -> str | None:
         """
         Detect if the file matches a known specialized format.
 
@@ -159,7 +157,7 @@ class CSVImporter(BaseImporter):
                     if all(col.startswith("Channel_") for col in col_names):
                         # Rename columns to be sequential
                         new_names = [f"Channel_{i}" for i in range(len(col_names))]
-                        rename_map = dict(zip(col_names, new_names))
+                        rename_map = dict(zip(col_names, new_names, strict=True))
                         df = df.rename(columns=rename_map)
             else:
                 # Filter by column names
@@ -261,7 +259,7 @@ class CSVImporter(BaseImporter):
 
         return emg
 
-    def _analyze_csv_structure(self, filepath: str) -> Dict:
+    def _analyze_csv_structure(self, filepath: str) -> dict:
         """
         Analyze the CSV file structure to detect delimiter, headers, and rows to skip.
 
@@ -356,7 +354,7 @@ class CSVImporter(BaseImporter):
         except ValueError:
             return False
 
-    def _detect_time_column(self, df: pd.DataFrame) -> Optional[str]:
+    def _detect_time_column(self, df: pd.DataFrame) -> str | None:
         """
         Try to detect which column represents time.
 

--- a/emgio/importers/edf.py
+++ b/emgio/importers/edf.py
@@ -1,5 +1,3 @@
-from typing import Dict, Tuple
-
 import numpy as np
 import pyedflib
 
@@ -35,7 +33,7 @@ class EDFImporter(BaseImporter):
         else:
             return "OTHER"
 
-    def _extract_metadata(self, edf_reader: pyedflib.EdfReader) -> Dict:
+    def _extract_metadata(self, edf_reader: pyedflib.EdfReader) -> dict:
         """
         Extract metadata from EDF file header.
 
@@ -73,7 +71,7 @@ class EDFImporter(BaseImporter):
 
     def _read_signal_data(
         self, edf_reader: pyedflib.EdfReader, signal_idx: int
-    ) -> Tuple[np.ndarray, Dict]:
+    ) -> tuple[np.ndarray, dict]:
         """
         Read signal data and header information for a specific channel.
 

--- a/emgio/importers/eeglab.py
+++ b/emgio/importers/eeglab.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -11,7 +11,7 @@ from .base import BaseImporter
 class EEGLABImporter(BaseImporter):
     """Importer for EEGLAB .set files containing EMG data."""
 
-    def _extract_metadata(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _extract_metadata(self, data: dict[str, Any]) -> dict[str, Any]:
         """
         Extract metadata from EEGLAB .set file.
 
@@ -73,7 +73,7 @@ class EEGLABImporter(BaseImporter):
 
         return metadata
 
-    def _determine_channel_type(self, channel_info: Dict[str, Any]) -> str:
+    def _determine_channel_type(self, channel_info: dict[str, Any]) -> str:
         """
         Determine channel type based on channel information.
 
@@ -114,7 +114,7 @@ class EEGLABImporter(BaseImporter):
         # Default to EMG if we can't determine the type
         return "EMG"
 
-    def _process_channel_info(self, chanlocs: np.ndarray) -> List[Dict[str, Any]]:
+    def _process_channel_info(self, chanlocs: np.ndarray) -> list[dict[str, Any]]:
         """
         Process channel location information.
 
@@ -155,7 +155,7 @@ class EEGLABImporter(BaseImporter):
 
         return channel_info_list
 
-    def _process_events(self, events: np.ndarray) -> List[Dict[str, Any]]:
+    def _process_events(self, events: np.ndarray) -> list[dict[str, Any]]:
         """
         Process event information.
 

--- a/emgio/importers/otb.py
+++ b/emgio/importers/otb.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import tempfile
 import xml.etree.ElementTree as ET
-from typing import Dict, Tuple
 
 import numpy as np
 
@@ -54,7 +53,7 @@ class OTBImporter(BaseImporter):
             print(f"Error during extraction: {str(e)}")
             raise ValueError(f"Could not extract OTB file: {str(e)}") from e
 
-    def _parse_xml_metadata(self, xml_path: str) -> Dict:
+    def _parse_xml_metadata(self, xml_path: str) -> dict:
         """
         Parse XML metadata file to extract device and channel information.
 
@@ -189,7 +188,7 @@ class OTBImporter(BaseImporter):
 
         return metadata
 
-    def _read_signal_data(self, sig_path: str, metadata: Dict) -> Tuple[np.ndarray, float]:
+    def _read_signal_data(self, sig_path: str, metadata: dict) -> tuple[np.ndarray, float]:
         """
         Read binary signal data and apply appropriate scaling.
 

--- a/emgio/importers/trigno.py
+++ b/emgio/importers/trigno.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 import pandas as pd
 
 from ..core.emg import EMG
@@ -9,7 +7,7 @@ from .base import BaseImporter
 class TrignoImporter(BaseImporter):
     """Importer for Delsys Trigno EMG system data."""
 
-    def _analyze_csv_structure(self, csv_path: str) -> Tuple[List[str], int, str]:
+    def _analyze_csv_structure(self, csv_path: str) -> tuple[list[str], int, str]:
         """
         Analyze the CSV file structure to identify metadata and data sections.
 
@@ -41,7 +39,7 @@ class TrignoImporter(BaseImporter):
 
         return metadata_lines, data_start_line, header_line
 
-    def _parse_metadata(self, metadata_lines: List[str]) -> dict:
+    def _parse_metadata(self, metadata_lines: list[str]) -> dict:
         """
         Parse metadata lines to extract channel information.
 

--- a/emgio/tests/test_core.py
+++ b/emgio/tests/test_core.py
@@ -485,6 +485,9 @@ def test_emg_add_event(empty_emg):
     pd.testing.assert_frame_equal(
         empty_emg.events, pd.DataFrame([{"onset": 1.0, "duration": 0.5, "description": "Event A"}])
     )
+    # onset/duration must be float64 (not object) even from the empty frame
+    assert empty_emg.events["onset"].dtype == np.float64
+    assert empty_emg.events["duration"].dtype == np.float64
 
     # Add second event (should be sorted)
     empty_emg.add_event(onset=0.5, duration=0.1, description="Event B")
@@ -508,6 +511,18 @@ def test_emg_add_event(empty_emg):
         ]
     )
     pd.testing.assert_frame_equal(empty_emg.events, expected_df)
+    # dtype must survive the concat path too
+    assert empty_emg.events["onset"].dtype == np.float64
+    assert empty_emg.events["duration"].dtype == np.float64
+
+
+def test_add_event_integer_inputs_coerced_to_float(empty_emg):
+    """Integer onset/duration must be stored as float64, not int64 or object."""
+    empty_emg.add_event(onset=2, duration=0, description="Integer onset")
+    assert empty_emg.events["onset"].dtype == np.float64
+    assert empty_emg.events["duration"].dtype == np.float64
+    assert empty_emg.events.loc[0, "onset"] == 2.0
+    assert empty_emg.events.loc[0, "duration"] == 0.0
 
 
 def test_to_edf_export(sample_emg, mock_edf_exporter):

--- a/examples/csv_detection_test.py
+++ b/examples/csv_detection_test.py
@@ -8,16 +8,16 @@ This example shows:
 """
 
 import os
+
 from emgio import EMG
-from emgio.importers.csv import CSVImporter
 
 
 def test_format_detection():
     """Test CSV format detection on a sample file."""
     # Sample Trigno CSV file
-    trigno_csv = 'examples/truncated_trigno_sample.csv'
+    trigno_csv = "examples/truncated_trigno_sample.csv"
     # Sample generic CSV file (our EMG sample file)
-    generic_csv = 'examples/truncated_emg_sample_zenodo7668251.txt'
+    generic_csv = "examples/truncated_emg_sample_zenodo7668251.txt"
 
     print("\n=== Testing Automatic Format Detection ===\n")
 
@@ -27,7 +27,7 @@ def test_format_detection():
         try:
             # This should detect Trigno format and suggest using the Trigno importer
             print("Attempting to load Trigno CSV with generic CSV importer...")
-            emg = EMG.from_file(trigno_csv, importer='csv')
+            EMG.from_file(trigno_csv, importer="csv")
             print("File loaded successfully (you shouldn't see this)")
         except ValueError as e:
             print(f"Format detection message: {str(e)}")
@@ -35,14 +35,14 @@ def test_format_detection():
         # Load with the specialized importer
         print("\nLoading with specialized Trigno importer...")
         try:
-            trigno_emg = EMG.from_file(trigno_csv, importer='trigno')
+            trigno_emg = EMG.from_file(trigno_csv, importer="trigno")
 
             # Print channel information from Trigno importer
             print("\nChannel Information (Trigno Importer):")
             print("-" * 50)
             ch_types = {}
-            for ch_name, ch_info in trigno_emg.channels.items():
-                ch_type = ch_info['channel_type']
+            for ch_info in trigno_emg.channels.values():
+                ch_type = ch_info["channel_type"]
                 if ch_type not in ch_types:
                     ch_types[ch_type] = 1
                 else:
@@ -61,7 +61,7 @@ def test_format_detection():
 
             print("\nMetadata from Trigno importer:")
             for key, value in trigno_emg.metadata.items():
-                if key != 'source_file':
+                if key != "source_file":
                     print(f"- {key}: {value}")
         except Exception as e:
             print(f"Error loading with Trigno importer: {str(e)}")
@@ -79,23 +79,23 @@ def test_format_detection():
 
             # We need to provide additional parameters for the generic CSV
             csv_params = {
-                'has_header': False,
-                'sample_frequency': 1000.0,
-                'channel_types': {
-                    'Channel_0': 'EMG',
-                    'Channel_1': 'EMG',
-                    'Channel_2': 'EMG',
-                    'Channel_3': 'EMG'
+                "has_header": False,
+                "sample_frequency": 1000.0,
+                "channel_types": {
+                    "Channel_0": "EMG",
+                    "Channel_1": "EMG",
+                    "Channel_2": "EMG",
+                    "Channel_3": "EMG",
                 },
-                'physical_dimensions': {
-                    'Channel_0': 'mV',
-                    'Channel_1': 'mV',
-                    'Channel_2': 'mV',
-                    'Channel_3': 'mV'
-                }
+                "physical_dimensions": {
+                    "Channel_0": "mV",
+                    "Channel_1": "mV",
+                    "Channel_2": "mV",
+                    "Channel_3": "mV",
+                },
             }
 
-            generic_emg = EMG.from_file(generic_csv, importer='csv', **csv_params)
+            generic_emg = EMG.from_file(generic_csv, importer="csv", **csv_params)
 
             # Print channel information
             print("\nChannel Information (Generic CSV):")

--- a/examples/csv_example.py
+++ b/examples/csv_example.py
@@ -11,12 +11,13 @@ The file contains unlabeled columns of EMG data with no header.
 """
 
 import os
+
 from emgio import EMG
 
 
 def main():
     # Sample data path - replace with your actual data path
-    data_path = 'examples/truncated_emg_sample_zenodo7668251.txt'
+    data_path = "examples/truncated_emg_sample_zenodo7668251.txt"
 
     if not os.path.exists(data_path):
         print(f"Sample file not found: {data_path}")
@@ -24,21 +25,21 @@ def main():
         return
 
     # Set up channel naming and metadata for the unlabeled data file
-    channel_names = ['EMG_CH1', 'EMG_CH2', 'EMG_CH3', 'EMG_CH4']
+    channel_names = ["EMG_CH1", "EMG_CH2", "EMG_CH3", "EMG_CH4"]
 
     # Define channel types (all are EMG channels in this case)
-    channel_types = {name: 'EMG' for name in channel_names}
+    channel_types = dict.fromkeys(channel_names, "EMG")
 
     # Define physical dimensions (units) for each channel
-    physical_dimensions = {name: 'mV' for name in channel_names}
+    physical_dimensions = dict.fromkeys(channel_names, "mV")
 
     # Additional metadata for the recording
     metadata = {
-        'subject': 'Sample Subject',
-        'device': 'Sample EMG Device',
-        'recording_date': '2023-01-01',
-        'experiment': 'Sample EMG Recording',
-        'source': 'Zenodo Dataset 7668251'
+        "subject": "Sample Subject",
+        "device": "Sample EMG Device",
+        "recording_date": "2023-01-01",
+        "experiment": "Sample EMG Recording",
+        "source": "Zenodo Dataset 7668251",
     }
 
     # Load the data using CSV importer
@@ -47,18 +48,18 @@ def main():
     try:
         # Prepare parameters for the CSV importer
         csv_params = {
-            'columns': [0, 1, 2, 3],  # Select columns by index (0-based)
-            'has_header': False,       # No header in this file
-            'delimiter': None,         # Auto-detect delimiter
-            'sample_frequency': 1000.0,  # 1kHz sampling rate
-            'channel_names': channel_names,
-            'channel_types': channel_types,
-            'physical_dimensions': physical_dimensions,
-            'metadata': metadata
+            "columns": [0, 1, 2, 3],  # Select columns by index (0-based)
+            "has_header": False,  # No header in this file
+            "delimiter": None,  # Auto-detect delimiter
+            "sample_frequency": 1000.0,  # 1kHz sampling rate
+            "channel_names": channel_names,
+            "channel_types": channel_types,
+            "physical_dimensions": physical_dimensions,
+            "metadata": metadata,
         }
 
         # Create importer and load the data
-        emg = EMG.from_file(data_path, importer='csv', **csv_params)
+        emg = EMG.from_file(data_path, importer="csv", **csv_params)
 
         # Rename channels and set their types and units
         print("Renaming channels and setting metadata...")
@@ -98,31 +99,24 @@ def main():
     print("\nRecording Information:")
     print("-" * 50)
     for key, value in emg.metadata.items():
-        if key != 'source_file':  # Skip the file path
+        if key != "source_file":  # Skip the file path
             print(f"{key}: {value}")
 
     # Plot the first 3 seconds of data
     print("\nPlotting EMG signals...")
     try:
         # Default plot
-        emg.plot_signals(
-            time_range=(0, 3),
-            title="EMG Signals - First 3 Seconds",
-            grid=True
-        )
+        emg.plot_signals(time_range=(0, 3), title="EMG Signals - First 3 Seconds", grid=True)
 
         # Plot with detrending (removes mean)
         emg.plot_signals(
-            time_range=(0, 3),
-            title="EMG Signals - Detrended",
-            detrend=True,
-            grid=True
+            time_range=(0, 3), title="EMG Signals - Detrended", detrend=True, grid=True
         )
     except Exception as e:
         print(f"Error plotting signals: {str(e)}")
 
     # Export to EDF/BDF
-    output_path = 'examples/csv_emg'  # Extension will be added by the exporter (.edf or .bdf)
+    output_path = "examples/csv_emg"  # Extension will be added by the exporter (.edf or .bdf)
     print("\nExporting EMG data...")
 
     try:

--- a/examples/eeglab_example.py
+++ b/examples/eeglab_example.py
@@ -9,14 +9,13 @@ This example shows how to:
 """
 
 import os
+
 from emgio import EMG
 
 
 def main():
     # Sample data path - replace with your actual data path
-    data_path = (
-        'examples/wristbandEMG_truncated.set'  # Update this path to your EEGLAB .set file
-    )
+    data_path = "examples/wristbandEMG_truncated.set"  # Update this path to your EEGLAB .set file
 
     if not os.path.exists(data_path):
         print(f"Sample file not found: {data_path}")
@@ -25,12 +24,12 @@ def main():
 
     # Load the data using EEGLAB importer
     print("Loading EMG data from EEGLAB .set file...")
-    emg = EMG.from_file(data_path, importer='eeglab')
+    emg = EMG.from_file(data_path, importer="eeglab")
 
     # Print metadata
     print("\nMetadata:")
     print("-" * 50)
-    for key in ['subject', 'session', 'condition', 'srate', 'nbchan', 'pnts']:
+    for key in ["subject", "session", "condition", "srate", "nbchan", "pnts"]:
         if key in emg.metadata:
             print(f"{key}: {emg.get_metadata(key)}")
 
@@ -41,29 +40,32 @@ def main():
     for ch_type in channel_types:
         channels = emg.get_channels_by_type(ch_type)
         print(f"{ch_type} channels ({len(channels)}):")
-        for i, ch_name in enumerate(channels[:5]):  # Print first 5 channels of each type
+        for ch_name in channels[:5]:  # Print first 5 channels of each type
             ch_info = emg.channels[ch_name]
-            print(f"  - {ch_name} (Sampling rate: {ch_info['sample_frequency']} Hz, "
-                  f"Unit: {ch_info['physical_dimension']})")
+            print(
+                f"  - {ch_name} (Sampling rate: {ch_info['sample_frequency']} Hz, "
+                f"Unit: {ch_info['physical_dimension']})"
+            )
         if len(channels) > 5:
             print(f"  ... and {len(channels) - 5} more {ch_type} channels")
 
     # Print event information if available
-    if 'events' in emg.metadata and emg.metadata['events']:
+    if "events" in emg.metadata and emg.metadata["events"]:
         print("\nEvents:")
         print("-" * 50)
-        events = emg.metadata['events']
+        events = emg.metadata["events"]
         print(f"Number of events: {len(events)}")
         for i, event in enumerate(events[:5]):  # Print first 5 events
-            print(f"  Event {i + 1}: Type={event['type']}, "
-                  f"Latency={event['latency']:.1f}")
+            print(f"  Event {i + 1}: Type={event['type']}, Latency={event['latency']:.1f}")
         if len(events) > 5:
             print(f"  ... and {len(events) - 5} more events")
 
     # Select EMG channels only and create a new EMG object
-    emg_channels = emg.get_channels_by_type('EMG')
+    emg_channels = emg.get_channels_by_type("EMG")
     if emg_channels:
-        emg_only = emg.select_channels(emg_channels)  # Creates a new EMG object with only EMG channels
+        emg_only = emg.select_channels(
+            emg_channels
+        )  # Creates a new EMG object with only EMG channels
 
         # Plot the first 5 seconds of data with different configurations
         print("\nPlotting EMG signals...")
@@ -76,11 +78,13 @@ def main():
         emg_only.plot_signals(
             channels=emg_only.signals.columns[:8],  # Plot first 8 channels
             time_range=(0, plot_end),
-            title="EMG Signals - Uniform Scale"
+            title="EMG Signals - Uniform Scale",
         )
 
         # Export to EDF/BDF (format will be automatically selected)
-        output_path = 'examples/eeglab_emg'  # Extension will be added by the exporter (.edf or .bdf)
+        output_path = (
+            "examples/eeglab_emg"  # Extension will be added by the exporter (.edf or .bdf)
+        )
         print("\nExporting EMG data...")
         print("Note: The exporter will automatically:")
         print("- Choose between EDF/BDF based on precision requirements")

--- a/examples/matlab_example.ipynb
+++ b/examples/matlab_example.ipynb
@@ -31,7 +31,7 @@
    ],
    "source": [
     "# load the example data\n",
-    "data = loadmat('wristbandEMG_truncated.set')\n",
+    "data = loadmat(\"wristbandEMG_truncated.set\")\n",
     "keys = data.keys()\n",
     "print(keys)"
    ]
@@ -75,7 +75,7 @@
     }
    ],
    "source": [
-    "data['event']"
+    "data[\"event\"]"
    ]
   },
   {
@@ -127,7 +127,7 @@
     }
    ],
    "source": [
-    "data['chanlocs']"
+    "data[\"chanlocs\"]"
    ]
   },
   {

--- a/examples/otb_example.py
+++ b/examples/otb_example.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+
 from emgio.core.emg import EMG
 
 
@@ -6,7 +7,7 @@ def main():
     # Load OTB data
     print("Loading OTB data...")
     # example two: one_sessantaquattro_truncated.otb+, example two: two_mouvi_truncated.otb+
-    emg = EMG.from_file('examples/one_sessantaquattro_truncated.otb+', importer='otb')
+    emg = EMG.from_file("examples/one_sessantaquattro_truncated.otb+", importer="otb")
 
     # Print metadata
     print("\nDevice Information:")
@@ -19,7 +20,7 @@ def main():
     print("-" * 50)
     channel_types = {}
     for ch_info in emg.channels.values():
-        ch_type = ch_info['channel_type']
+        ch_type = ch_info["channel_type"]
         if ch_type not in channel_types:
             channel_types[ch_type] = 1
         else:
@@ -29,24 +30,24 @@ def main():
         print(f"{ch_type}: {count} channels")
 
     # Create a new EMG object with only EMG channels
-    emg_data = emg.select_channels(channel_type='EMG')
+    emg_data = emg.select_channels(channel_type="EMG")
     if emg_data.signals is not None and not emg_data.signals.empty:
         print("\nPlotting EMG channels...")
         emg_data.plot_signals(
-            title='EMG Channels',
+            title="EMG Channels",
             grid=True,
-            channels=list(emg_data.channels.keys())[33:-1]  # optionally plot a subset of channels
+            channels=list(emg_data.channels.keys())[33:-1],  # optionally plot a subset of channels
         )
         plt.show()
     else:
         print("\nNo EMG channels found in the data")
 
     # Export EMG channels to EDF
-    output_path = 'examples/otb_emg'
+    output_path = "examples/otb_emg"
     emg_data.to_edf(output_path)  # Use the EMG-only data for export
 
     print("\nExport complete!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/trigno_example.ipynb
+++ b/examples/trigno_example.ipynb
@@ -16,8 +16,10 @@
    "source": [
     "# Import required libraries\n",
     "import os\n",
-    "from emgio import EMG\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from emgio import EMG\n",
     "\n",
     "# Set up the environment for EMG data processing\n",
     "# (No additional setup required for this example)"
@@ -92,7 +94,7 @@
     "# Load EMG Data\n",
     "\n",
     "# Sample data path - replace with your actual data path\n",
-    "data_path = 'truncated_trigno_sample.csv'  # Update this path to your Trigno CSV file\n",
+    "data_path = \"truncated_trigno_sample.csv\"  # Update this path to your Trigno CSV file\n",
     "\n",
     "if not os.path.exists(data_path):\n",
     "    print(f\"Sample file not found: {data_path}\")\n",
@@ -100,7 +102,7 @@
     "else:\n",
     "    # Load the data using Trigno importer\n",
     "    print(\"Loading EMG data...\")\n",
-    "    emg = EMG.from_file(data_path, importer='trigno')\n",
+    "    emg = EMG.from_file(data_path, importer=\"trigno\")\n",
     "\n",
     "    # Print available channels\n",
     "    print(\"\\nAvailable channels:\")\n",
@@ -185,7 +187,7 @@
     "    print(f\"  Unit: {ch_info['unit']}\")\n",
     "\n",
     "# Select and filter EMG channels from the dataset\n",
-    "emg_channels = [ch for ch, info in emg.channels.items() if info['type'] == 'EMG']\n",
+    "emg_channels = [ch for ch, info in emg.channels.items() if info[\"type\"] == \"EMG\"]\n",
     "# emg.select_channels(emg_channels)  # TODO: #3 This removes all other channels in place, behavior should change."
    ]
   },
@@ -310,7 +312,7 @@
     "# Export to EDF Format\n",
     "\n",
     "# Define the output path for the EDF file\n",
-    "output_path = 'trigno_emg.edf'\n",
+    "output_path = \"trigno_emg.edf\"\n",
     "\n",
     "# Export the processed EMG data to EDF format\n",
     "print(f\"\\nExporting to EDF: {output_path}\")\n",

--- a/examples/trigno_example.py
+++ b/examples/trigno_example.py
@@ -8,14 +8,13 @@ This example shows how to:
 """
 
 import os
+
 from emgio import EMG
 
 
 def main():
     # Sample data path - replace with your actual data path
-    data_path = (
-        'examples/truncated_trigno_sample.csv'  # Update this path to your Trigno CSV file
-    )
+    data_path = "examples/truncated_trigno_sample.csv"  # Update this path to your Trigno CSV file
 
     if not os.path.exists(data_path):
         print(f"Sample file not found: {data_path}")
@@ -24,7 +23,7 @@ def main():
 
     # Load the data using Trigno importer
     print("Loading EMG data...")
-    emg = EMG.from_file(data_path, importer='trigno')
+    emg = EMG.from_file(data_path, importer="trigno")
 
     # Print available channels
     print("\nAvailable channels:")
@@ -34,7 +33,7 @@ def main():
         print(f"  Dimension: {ch_info['physical_dimension']}")
 
     # Select EMG channels only and create a new EMG object
-    emg_channels = [ch for ch, info in emg.channels.items() if info['channel_type'] == 'EMG']
+    emg_channels = [ch for ch, info in emg.channels.items() if info["channel_type"] == "EMG"]
     emg_only = emg.select_channels(emg_channels)  # Creates a new EMG object with only EMG channels
     # Original emg object remains unchanged with all channels
 
@@ -42,13 +41,10 @@ def main():
     print("\nPlotting EMG signals from EMG-only channels...")
 
     # Default plot with uniform scaling
-    emg_only.plot_signals(
-        time_range=(0, 5),
-        title="EMG Signals - Uniform Scale"
-    )
+    emg_only.plot_signals(time_range=(0, 5), title="EMG Signals - Uniform Scale")
 
     # Export to EDF/BDF (format will be automatically selected)
-    output_path = 'examples/trigno_emg'  # Extension will be added by the exporter (.edf or .bdf)
+    output_path = "examples/trigno_emg"  # Extension will be added by the exporter (.edf or .bdf)
     print("\nExporting EMG data...")
     print("Note: The exporter will automatically:")
     print("- Convert voltage units to mV if needed")
@@ -62,7 +58,7 @@ def main():
     # fft_noise_range: Optional tuple (min_freq, max_freq) for FFT method
     # Since the non-emg channels have different sampling frequency, the output will become bdf to handle
     # NaNs for the missing values in the non-emg channels. This is the default behavior for mixed sampling frequencies.
-    emg_only.to_edf(output_path, method='both', svd_rank=None, fft_noise_range=None)
+    emg_only.to_edf(output_path, method="both", svd_rank=None, fft_noise_range=None)
 
     # Alternative examples:
     # Using only FFT method:

--- a/examples/verification_example.py
+++ b/examples/verification_example.py
@@ -1,15 +1,16 @@
-import os
 import logging
+import os
 import sys
+
 from emgio.core.emg import EMG
 
 # Add the project root to the Python path
 # This allows importing emgio even if it's not installed
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_root)
 
 # Configure logging
-logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s')
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 # --- Configuration ---
 # Use a file that exists in the examples directory
@@ -34,8 +35,10 @@ try:
     logging.info("EMG data loaded successfully.")
     logging.info(f"Channels found: {list(emg_data.signals.columns)}")
     logging.info(f"Duration: {emg_data.signals.index[-1]:.2f} seconds")
-    emg_channels = emg_data.get_channels_by_type('EMG')
-    emg_only = emg_data.select_channels(emg_channels[:2])  # Creates a new EMG object with only EMG channels
+    emg_channels = emg_data.get_channels_by_type("EMG")
+    emg_only = emg_data.select_channels(
+        emg_channels[:2]
+    )  # Creates a new EMG object with only EMG channels
 
 
 except FileNotFoundError:
@@ -50,13 +53,13 @@ logging.info(f"\n--- Exporting to EDF ({output_file_edf}) ---")
 try:
     verification_results_edf = emg_only.to_edf(
         output_path_edf,
-        format='edf',  # Force EDF for this example
+        format="edf",  # Force EDF for this example
         bypass_analysis=True,
         verify=verify_export,
         verify_tolerance=verification_tolerance,
         # Example: verify_channel_map={'Original Name 1': 'Reloaded Name A', 'Original Name 2': 'Reloaded Name B'}
         # If verify_channel_map is None (default), it tries exact name match, then order-based match.
-        verify_channel_map=None  # Using automatic matching for this run
+        verify_channel_map=None,  # Using automatic matching for this run
     )
 
     logging.info(f"Successfully exported to {output_path_edf}")
@@ -70,7 +73,9 @@ except Exception as e:
 
 # --- Export to BDF with Verification ---
 # BDF is often better for high-precision data like Trigno
-logging.info(f"\n--- Exporting to BDF ({output_file_bdf}) --- Example using explicit channel map ---")
+logging.info(
+    f"\n--- Exporting to BDF ({output_file_bdf}) --- Example using explicit channel map ---"
+)
 try:
     # Example: Create a dummy channel map (mapping names to themselves here,
     # but could map to different names if needed)
@@ -81,12 +86,12 @@ try:
 
     verification_results_bdf = emg_only.to_edf(
         output_path_bdf,
-        format='bdf',  # Force BDF for this example
+        format="bdf",  # Force BDF for this example
         bypass_analysis=True,
         verify=verify_export,
         verify_tolerance=verification_tolerance,
         verify_channel_map=explicit_map,  # Pass the explicit map
-        verify_plot=True  # Plot comparison
+        verify_plot=True,  # Plot comparison
     )
     logging.info(f"Successfully exported to {output_path_bdf}")
     if verify_export and verification_results_bdf:

--- a/examples/wfdb_example.py
+++ b/examples/wfdb_example.py
@@ -1,5 +1,7 @@
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
+
 from emgio.core.emg import EMG
 
 
@@ -7,12 +9,14 @@ def main():
     # Define the path to the example WFDB file
     # This example uses record 100 from PhysioNet's MIT-BIH Arrhythmia Database
     # https://physionet.org/content/mitdb/1.0.0/
-    file_path = 'examples/100.hea'
+    file_path = "examples/100.hea"
 
     if not os.path.exists(file_path):
         print(f"Error: Example file not found at {file_path}")
-        print("Please ensure the MIT-BIH Arrhythmia database record 100 files "
-              "(100.hea, 100.dat, 100.atr) are in the examples/ directory.")
+        print(
+            "Please ensure the MIT-BIH Arrhythmia database record 100 files "
+            "(100.hea, 100.dat, 100.atr) are in the examples/ directory."
+        )
         return
 
     # --- Loading WFDB Data with Annotations ---
@@ -20,7 +24,7 @@ def main():
     # The importer automatically looks for a corresponding .atr file (e.g., 100.atr)
     # and loads annotations into the emg.events DataFrame if found.
     try:
-        emg = EMG.from_file(file_path, importer='wfdb')
+        emg = EMG.from_file(file_path, importer="wfdb")
     except ValueError as e:
         print(f"Error loading file: {e}")
         print("Ensure the 'wfdb' package is installed ('pip install wfdb')")
@@ -38,17 +42,19 @@ def main():
     print(f"Record Name: {emg.get_metadata('record_name')}")
     print(f"Sampling Frequency: {emg.get_metadata('sampling_frequency')} Hz")
     print(f"Source File: {emg.get_metadata('source_file')}")
-    start_date = emg.get_metadata('startdate')
-    start_time = emg.get_metadata('starttime')
+    start_date = emg.get_metadata("startdate")
+    start_time = emg.get_metadata("starttime")
     if start_date or start_time:
         print(f"Recording Start: {start_date} {start_time}")
-    if emg.get_metadata('comments'):
+    if emg.get_metadata("comments"):
         print(f"Comments:\n{emg.get_metadata('comments')}")
 
     print("\nChannels:")
     print("-" * 50)
     for name, info in emg.channels.items():
-        print(f"- {name}: Type={info.get('channel_type', 'N/A')}, Unit={info.get('physical_dimension', 'N/A')}")
+        print(
+            f"- {name}: Type={info.get('channel_type', 'N/A')}, Unit={info.get('physical_dimension', 'N/A')}"
+        )
 
     # --- Accessing Loaded Annotations ---
     print("\nAnnotations (Events):")
@@ -63,9 +69,9 @@ def main():
     else:
         print("No annotations found or loaded.")
         # Check metadata for reasons if annotations were expected
-        if emg.get_metadata('annotation_status'):
+        if emg.get_metadata("annotation_status"):
             print(f"Status: {emg.get_metadata('annotation_status')}")
-        if emg.get_metadata('annotation_error'):
+        if emg.get_metadata("annotation_error"):
             print(f"Error: {emg.get_metadata('annotation_error')}")
         annotations_present = False
 
@@ -74,20 +80,22 @@ def main():
     print("\nPlotting first 10 seconds of the first channel...")
     try:
         first_channel = list(emg.channels.keys())[0]
-        emg.plot_signals(channels=[first_channel], time_range=(0, 10), title=f'{first_channel} (First 10s)')
+        emg.plot_signals(
+            channels=[first_channel], time_range=(0, 10), title=f"{first_channel} (First 10s)"
+        )
         plt.show()
     except Exception as e:
         print(f"Could not plot signals: {e}")
 
     # --- Exporting to EDF/BDF (demonstrating annotation preservation) ---
     print("\nExporting data to EDF and BDF formats...")
-    output_base = 'examples/100_exported'
+    output_base = "examples/100_exported"
 
     try:
         # Export to EDF
         print("Exporting to EDF...")
         edf_path = f"{output_base}.edf"
-        emg.to_edf(edf_path, format='edf')
+        emg.to_edf(edf_path, format="edf")
         print(f"Exported to {edf_path}")
         if annotations_present:
             print("(Annotations included in EDF+)")
@@ -95,7 +103,7 @@ def main():
         # Export to BDF
         print("\nExporting to BDF...")
         bdf_path = f"{output_base}.bdf"
-        emg.to_edf(bdf_path, format='bdf')
+        emg.to_edf(bdf_path, format="bdf")
         print(f"Exported to {bdf_path}")
         if annotations_present:
             print("(Annotations included in BDF+)")
@@ -106,5 +114,5 @@ def main():
     print("\nExample script finished.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
+    "ty",
 ]
 docs = [
     "mkdocs>=1.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
-    "ruff>=0.1.0",
+    "ruff>=0.14",
     "ty",
 ]
 docs = [


### PR DESCRIPTION
Fixes #41

## Summary

Closes the CI gap found during the #40 review: workflows used UV but ran no linting or type checking. Adds a fast, production-ready lint pipeline and clears the existing lint debt. Also fixes a pandas-dtype bug that had started failing the test suite under current pandas.

## Changes

**Lint debt cleared**
- Fixed all 48 ruff lint errors: PEP 585/604 typing modernization, import sorting, `zip(..., strict=True)` (equal-length inputs), removed unused loop vars / variable.
- Applied `ruff format` across the repo. `ruff check` and `ruff format --check` are clean.

**Bug fix (was turning CI red)**
- `EMG.add_event` produced an `object`-dtype `onset` column because it concatenated onto the empty, object-dtype events frame. Recent pandas flags this (`test_emg_add_event`). Now coerces `onset`/`duration` to float and starts from the typed frame when empty. **Test suite: 117 passed, 3 skipped, 0 failed.**

**CI**
- New `.github/workflows/lint.yml` with two independent, parallel jobs:
  - `ruff` — **blocking** `ruff check` + `ruff format --check`.
  - `ty` — **non-blocking** (`continue-on-error: true`) type check. `ty` currently reports 115 pre-existing diagnostics; driving them to zero and flipping it blocking is tracked separately.
- Added `ty` to the `dev` optional-dependency group.
- Speed/production hardening across `tests.yml`, `docs.yml`, `lint.yml`: enabled the uv cache and `cancel-in-progress` concurrency so superseded runs are cancelled.

## Verification
- `uv run --extra dev ruff check .` -> clean
- `uv run --extra dev ruff format --check .` -> clean
- `uv run --extra dev pytest` -> 117 passed, 3 skipped, 0 failed
- All four workflow YAML files parse.

## Notes
- `codespell.yml` is intentionally untouched here to avoid conflicting with #40 (which modernizes it to `uvx`).