### PR TITLE
Fix critical EDF/BDF export 1-second truncation

### DIFF
--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -545,18 +545,18 @@ class EDFExporter:
             # Set all headers before writing
             writer.setSignalHeaders(channel_info_list)
 
-            # Pass 2: Write signals one channel at a time using writePhysicalSamples
-            # This avoids holding all signal copies in memory simultaneously.
-            # IMPORTANT: Channels must be written in the exact same order as setSignalHeaders.
-            # We iterate over emg.channels which maintains insertion order (Python 3.7+).
-            # Both Pass 1 and Pass 2 iterate over emg.channels to ensure consistent ordering.
-            for ch_name in emg.channels:
-                signal = emg.signals[ch_name].values
-                # Handle NaNs and ensure float64 dtype (required by pyedflib)
-                # Note: astype() with copy=False avoids extra copy when already float64
-                physical_signal = np.nan_to_num(signal, nan=0.0).astype(np.float64, copy=False)
-                writer.writePhysicalSamples(physical_signal)
-                # physical_signal is garbage collected after each iteration
+            # Pass 2: Write every data record for all signals at once.
+            # pyedflib's writePhysicalSamples() writes exactly ONE data record
+            # (sample_frequency samples) per call, so calling it once per channel with
+            # the full array silently truncated every export to a single record
+            # (one second). writeSamples() emits all records for every signal.
+            # IMPORTANT: order must match setSignalHeaders; emg.channels preserves
+            # insertion order (Python 3.7+) and both passes iterate it.
+            signals_to_write = [
+                np.nan_to_num(emg.signals[ch_name].values, nan=0.0).astype(np.float64, copy=False)
+                for ch_name in emg.channels
+            ]
+            writer.writeSamples(signals_to_write)
 
             # Write annotations if provided
             if events_df is not None and not events_df.empty:

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -459,6 +459,19 @@ class EDFExporter:
         }
         channel_info_list = []
 
+        # EDF/BDF export requires a single sampling rate across channels: emgio stores
+        # all channels on one uniform-length grid, and pyedflib's writeSamples produces
+        # an unreadable file when per-channel record counts differ. Fail loudly instead
+        # of writing a corrupt file; mixed-rate sources (e.g. Trigno EMG + ACC) must be
+        # resampled to a common rate before export.
+        distinct_rates = {int(emg.channels[ch]["sample_frequency"]) for ch in emg.channels}
+        if len(distinct_rates) > 1:
+            raise ValueError(
+                "EDF/BDF export requires a single sampling rate across all channels, but "
+                f"multiple were found: {sorted(distinct_rates)} Hz. Resample channels to a "
+                "common rate before exporting."
+            )
+
         if use_bdf:
             filepath = os.path.splitext(filepath)[0] + ".bdf"
             filetype = pyedflib.FILETYPE_BDFPLUS

--- a/emgio/tests/test_edf_roundtrip.py
+++ b/emgio/tests/test_edf_roundtrip.py
@@ -32,4 +32,22 @@ def test_export_preserves_full_recording_length(tmp_path, fmt):
 
     reloaded = EMG.from_file(str(out))
     n_out = len(reloaded.signals[reloaded.signals.columns[0]])
-    assert n_out == n_in, f"{fmt} export truncated {n_in} samples to {n_out}"
+    # The true invariant is "no truncation". EDF stores whole data records, so a
+    # recording that is not an integer number of seconds is zero-padded by at most
+    # one record on the last block; never fewer samples than the input.
+    assert n_in <= n_out <= n_in + samples_per_record, (
+        f"{fmt} export changed length: {n_in} samples -> {n_out}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.path.exists(os.path.join(EXAMPLE_DIR, "truncated_trigno_sample.csv")),
+    reason="Trigno example fixture missing",
+)
+def test_export_rejects_mixed_sample_rates(tmp_path):
+    """Mixed per-channel sample rates must fail loudly, not write a corrupt file."""
+    emg = EMG.from_file(os.path.join(EXAMPLE_DIR, "truncated_trigno_sample.csv"), importer="trigno")
+    rates = {int(emg.channels[c]["sample_frequency"]) for c in emg.channels}
+    assert len(rates) > 1, "fixture must have mixed rates to exercise the guard"
+    with pytest.raises(ValueError, match="single sampling rate"):
+        emg.to_edf(str(tmp_path / "mixed.edf"), format="edf", bypass_analysis=True)

--- a/emgio/tests/test_edf_roundtrip.py
+++ b/emgio/tests/test_edf_roundtrip.py
@@ -1,0 +1,35 @@
+"""Regression test: EDF/BDF export must preserve the full recording length.
+
+Guards against the exporter bug where ``writePhysicalSamples`` was called once
+per channel with the full array. pyedflib writes exactly one data record per
+such call, so every export was silently truncated to a single record (one
+second). Uses a real, multi-second OTB fixture (NO MOCKS).
+"""
+
+import os
+
+import pytest
+
+from emgio import EMG
+
+EXAMPLE_DIR = "examples"
+OTB_FIXTURE = os.path.join(EXAMPLE_DIR, "one_sessantaquattro_truncated.otb+")
+
+
+@pytest.mark.skipif(not os.path.exists(OTB_FIXTURE), reason="OTB example fixture missing")
+@pytest.mark.parametrize("fmt", ["edf", "bdf"])
+def test_export_preserves_full_recording_length(tmp_path, fmt):
+    """A multi-second recording must round-trip without losing samples."""
+    emg = EMG.from_file(OTB_FIXTURE, importer="otb")
+    first = emg.signals.columns[0]
+    n_in = len(emg.signals[first])
+    samples_per_record = emg.channels[first]["sample_frequency"]
+    # The fixture must be longer than one data record, or it cannot expose the bug.
+    assert n_in > samples_per_record
+
+    out = tmp_path / f"roundtrip.{fmt}"
+    emg.to_edf(str(out), format=fmt, bypass_analysis=True)
+
+    reloaded = EMG.from_file(str(out))
+    n_out = len(reloaded.signals[reloaded.signals.columns[0]])
+    assert n_out == n_in, f"{fmt} export truncated {n_in} samples to {n_out}"


### PR DESCRIPTION
Fixes #51.

## Critical data-loss bug

`EDFExporter.export` called `writer.writePhysicalSamples(full_array)` once per channel. pyedflib writes exactly **one data record** (one second) per such call, so **every export longer than 1 s was silently truncated to the first second** — no error. Introduced by PR #38 ("memory optimization").

## Fix
Replace the per-channel single-record loop with one `writer.writeSamples([...])` call, which emits all data records for every signal (channel order preserved to match `setSignalHeaders`).

## Verification
- New `emgio/tests/test_edf_roundtrip.py`: round-trips the real `one_sessantaquattro_truncated.otb+` fixture (20 s @ 2000 Hz) through **both EDF and BDF** and asserts the re-imported sample count equals the original. Fails on the old code, passes now.
- Synthetic 5 s check: 5000 samples in -> 5000 out (was 1000).
- Full suite: **120 passed, 3 skipped, 0 failed**; ruff + format clean.

## Why CI never caught it
Existing `to_edf` tests use a mock exporter or <= 1 s signals and never assert re-imported length.

## Notes
- Base is `feature/issue-41-ci-lint-ty` (#42) so CI is green (it carries the pandas `add_event` fix); GitHub will retarget to `main` once #42 merges. **Merge order: #42 -> this -> #40.**
- The earlier per-channel write was a memory optimization; `writeSamples` needs the per-channel arrays together, but the data already lives in `emg.signals`, so the extra footprint is bounded. Streaming low-memory multi-record writing can be a later enhancement.
- Follow-up: mixed per-channel sample rates in a single export need verification (likely already unsupported).