### PR TITLE
Fix EEGLAB importer: chanlocs scalars and ms time index

### DIFF
--- a/emgio/importers/eeglab.py
+++ b/emgio/importers/eeglab.py
@@ -134,18 +134,24 @@ class EEGLABImporter(BaseImporter):
             for field in chanlocs.dtype.names:
                 # Get the field value for this channel
                 field_value = chanlocs[0][i][field]
+                if field_value.size == 0:
+                    continue
+                # scipy.io.loadmat returns scalar struct fields as nested
+                # (1, 1)-shaped arrays, so field_value[0] is still 1-D and
+                # float()/str() on it fails or mis-formats. Flatten to a scalar.
+                scalar = np.asarray(field_value).ravel()[0]
 
                 # Process based on field name
-                if field == "labels" and field_value.size > 0:
-                    channel_info["label"] = str(field_value[0])
-                elif field == "type" and field_value.size > 0:
-                    channel_info["type"] = str(field_value[0])
-                elif field == "X" and field_value.size > 0:
-                    channel_info["X"] = float(field_value[0])
-                elif field == "Y" and field_value.size > 0:
-                    channel_info["Y"] = float(field_value[0])
-                elif field == "Z" and field_value.size > 0:
-                    channel_info["Z"] = float(field_value[0])
+                if field == "labels":
+                    channel_info["label"] = str(scalar)
+                elif field == "type":
+                    channel_info["type"] = str(scalar)
+                elif field == "X":
+                    channel_info["X"] = float(scalar)
+                elif field == "Y":
+                    channel_info["Y"] = float(scalar)
+                elif field == "Z":
+                    channel_info["Z"] = float(scalar)
 
             # Determine channel type
             channel_info["channel_type"] = self._determine_channel_type(channel_info)
@@ -247,13 +253,11 @@ class EEGLABImporter(BaseImporter):
                 # Get sampling rate
                 srate = metadata.get("srate", 1000)
 
-                # Create time array for index
-                if "times" in data and data["times"].size > 0:
-                    time_index = data["times"][0] / srate
-                else:
-                    # Create time array based on number of points and sampling rate
-                    pnts = metadata.get("pnts", signal_data.shape[1])
-                    time_index = np.arange(pnts) / srate
+                # Derive the time index in seconds from the sample count. EEGLAB's
+                # `times` field is in milliseconds, so dividing it by srate (the old
+                # behavior) mis-scaled the index; sample_index / srate is correct and
+                # always matches the data length.
+                time_index = np.arange(signal_data.shape[1]) / srate
 
                 # Create DataFrame with time index
                 df = pd.DataFrame(index=time_index)

--- a/emgio/importers/eeglab.py
+++ b/emgio/importers/eeglab.py
@@ -83,25 +83,25 @@ class EEGLABImporter(BaseImporter):
         Returns:
             str: Channel type ('EMG', 'ACC', 'GYRO', etc.)
         """
-        # Check if type is explicitly specified
-        if "type" in channel_info and len(channel_info["type"]) > 0:
-            ch_type = str(channel_info["type"][0])
-
-            # Map EEGLAB channel types to emgio channel types
-            if ch_type.upper() == "EMG":
+        # Check if type is explicitly specified. After _process_channel_info,
+        # 'type' and 'label' are plain strings (scalar-flattened), so consume them
+        # as strings rather than indexing/.size like the old array form.
+        ch_type = channel_info.get("type")
+        if ch_type:
+            ch_type_upper = ch_type.upper()
+            if ch_type_upper == "EMG":
                 return "EMG"
-            elif ch_type.upper() in ["ACC", "ACCELEROMETER"]:
+            elif ch_type_upper in ["ACC", "ACCELEROMETER"]:
                 return "ACC"
-            elif ch_type.upper() in ["GYRO", "GYROSCOPE"]:
+            elif ch_type_upper in ["GYRO", "GYROSCOPE"]:
                 return "GYRO"
-            elif ch_type.upper() in ["TRIG", "TRIGGER"]:
+            elif ch_type_upper in ["TRIG", "TRIGGER"]:
                 return "TRIG"
 
-        # If type is not specified or not recognized, try to determine from label
-        if "labels" in channel_info and channel_info["labels"].size > 0:
-            label = str(channel_info["labels"][0])
+        # If type is not specified or not recognized, try to determine from label.
+        label = channel_info.get("label", "")
+        if label:
             label_upper = label.upper()
-
             if "EMG" in label_upper:
                 return "EMG"
             elif "ACC" in label_upper:

--- a/emgio/tests/test_eeglab_bids_fixture.py
+++ b/emgio/tests/test_eeglab_bids_fixture.py
@@ -1,0 +1,42 @@
+"""Regression test: the real EEGLAB BIDS EEG fixture imports cleanly.
+
+Guards the EEGLAB importer fixes:
+- chanlocs X/Y/Z were read with ``float(field_value[0])`` on ``(1, 1)``-shaped
+  scipy arrays, which crashed import of any real ``.set`` with electrode coords;
+- the time index was built from EEGLAB's millisecond ``times`` field divided by
+  the sampling rate, which mis-scaled it.
+
+Uses the real CC0 fixture under ``examples/bids/eeg`` (NO MOCKS).
+"""
+
+import os
+
+import pytest
+
+from emgio import EMG
+
+EEG_SET = "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
+
+
+@pytest.mark.skipif(not os.path.exists(EEG_SET), reason="EEG BIDS fixture missing")
+def test_eeglab_bids_eeg_fixture_imports():
+    emg = EMG.from_file(EEG_SET, importer="eeglab")
+
+    # All 64 channels imported with their real 10-10 montage labels.
+    assert len(emg.channels) == 64
+    assert "FP1" in emg.signals.columns
+
+    col = emg.signals.columns[0]
+    assert emg.channels[col]["sample_frequency"] == 250
+
+    # 60 s at 250 Hz.
+    n = len(emg.signals[col])
+    assert n == 15000
+
+    # Time index is seconds derived from the sample count, not the old
+    # milliseconds/srate mis-scaling (which gave ~240 s for a 60 s recording).
+    assert emg.signals.index[-1] == pytest.approx((n - 1) / 250, rel=1e-6)
+
+    # Events were parsed from the .set event struct.
+    events = emg.get_metadata("events")
+    assert events is not None and len(events) == 3

--- a/emgio/tests/test_eeglab_bids_fixture.py
+++ b/emgio/tests/test_eeglab_bids_fixture.py
@@ -9,18 +9,23 @@ Guards the EEGLAB importer fixes:
 Uses the real CC0 fixture under ``examples/bids/eeg`` (NO MOCKS).
 """
 
-import os
+import pathlib
 
 import pytest
 
 from emgio import EMG
 
-EEG_SET = "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
+# Anchor to the repo root (this file is at emgio/tests/) so the test does not
+# silently skip when pytest runs from a different working directory.
+EEG_SET = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
+)
 
 
-@pytest.mark.skipif(not os.path.exists(EEG_SET), reason="EEG BIDS fixture missing")
+@pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
 def test_eeglab_bids_eeg_fixture_imports():
-    emg = EMG.from_file(EEG_SET, importer="eeglab")
+    emg = EMG.from_file(str(EEG_SET), importer="eeglab")
 
     # All 64 channels imported with their real 10-10 montage labels.
     assert len(emg.channels) == 64


### PR DESCRIPTION
Closes #55. PR into the biosigIO epic branch.

Two pre-existing EEGLAB importer bugs that blocked importing any real `.set` with electrode coordinates:
- **chanlocs X/Y/Z** were read via `float(field_value[0])`, but `scipy.io.loadmat` returns those scalar struct fields as `(1, 1)`-shaped arrays, so `field_value[0]` is 1-D and `float()` raised. Now flattened via `np.asarray(field_value).ravel()[0]` for `label`/`type`/`X`/`Y`/`Z`.
- **time index** was `times[0] / srate`, but EEGLAB's `times` is in **milliseconds**; this mis-scaled the index (~240 s for a 60 s recording). Now derived as `arange(n_samples) / srate`.

## Verification (real data, NO MOCKS)
- New `test_eeglab_bids_fixture.py` imports `examples/bids/eeg/...eeg.set` (CC0, 64 ch @ 250 Hz, 60 s): 64 channels with real 10-10 labels (FP1, AF7, FPZ...), 15000 samples, correct seconds index, 3 events parsed.
- eeglab tests: 7 passed. Full suite: 221 passed / 3 skipped / 0 failed. ruff + format clean.

Unblocks the EEG fixture for the round-trip harness (#48) and multi-modality work.