### PR TITLE
Remove silent EMG default; explicit modality model (0.3.0)

### DIFF
--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -8,6 +8,11 @@ import pandas as pd
 from ..analysis.verification import compare_signals, report_verification_results
 from ..visualization.static import plot_comparison
 from ..visualization.static import plot_signals as static_plot_signals
+from .modality import (
+    infer_modality_from_channel_type,
+    validate_channel_type,
+    validate_modality,
+)
 
 # --- Configuration ---
 enable_logging = False  # Set to False to disable most logging
@@ -178,6 +183,8 @@ class EMG:
         channels: str | list[str] | None = None,
         channel_type: str | None = None,
         inplace: bool = False,
+        *,
+        modality: str | None = None,
     ) -> "EMG":
         """
         Select specific channels from the data and return a new EMG object.
@@ -205,13 +212,15 @@ class EMG:
         if self.signals is None:
             raise ValueError("No signals loaded")
 
-        # If channel_type specified but no channels, select all of that type
+        # If type/modality specified but no channels, select all matching channels
         if channels is None and channel_type is not None:
-            channels = [
-                ch for ch, info in self.channels.items() if info["channel_type"] == channel_type
-            ]
+            channels = self.get_channels_by_type(channel_type)
             if not channels:
                 raise ValueError(f"No channels found of type: {channel_type}")
+        elif channels is None and modality is not None:
+            channels = self.get_channels_by_modality(modality)
+            if not channels:
+                raise ValueError(f"No channels found of modality: {modality}")
         elif isinstance(channels, str):
             channels = [channels]
 
@@ -225,6 +234,15 @@ class EMG:
             channels = [ch for ch in channels if self.channels[ch]["channel_type"] == channel_type]
             if not channels:
                 raise ValueError(f"None of the selected channels are of type: {channel_type}")
+
+        # Filter by modality if specified
+        if modality is not None:
+            canonical_modality = validate_modality(modality)
+            channels = [
+                ch for ch in channels if self.channels[ch].get("modality") == canonical_modality
+            ]
+            if not channels:
+                raise ValueError(f"None of the selected channels are of modality: {modality}")
 
         # Create new EMG object
         new_emg = EMG()
@@ -264,6 +282,32 @@ class EMG:
             List of channel names of the specified type
         """
         return [ch for ch, info in self.channels.items() if info["channel_type"] == channel_type]
+
+    def get_modalities(self) -> list[str]:
+        """
+        Get the list of unique modalities present in the data.
+
+        Returns:
+            List of modalities (e.g., ['EEG', 'EMG', 'MISC']).
+        """
+        return list(
+            {info.get("modality") for info in self.channels.values() if info.get("modality")}
+        )
+
+    def get_channels_by_modality(self, modality: str) -> list[str]:
+        """
+        Get the channels belonging to a given modality.
+
+        Args:
+            modality: Modality to filter by ('EEG', 'EMG', 'IEEG', 'MEG', 'BEH', 'MISC').
+
+        Returns:
+            List of channel names of the specified modality.
+        """
+        canonical_modality = validate_modality(modality)
+        return [
+            ch for ch, info in self.channels.items() if info.get("modality") == canonical_modality
+        ]
 
     def to_edf(
         self,
@@ -448,8 +492,10 @@ class EMG:
         data: np.ndarray,
         sample_frequency: float,
         physical_dimension: str,
+        channel_type: str,
+        *,
+        modality: str | None = None,
         prefilter: str = "n/a",
-        channel_type: str = "EMG",
     ) -> None:
         """
         Add a new channel to the EMG data.
@@ -459,9 +505,20 @@ class EMG:
             data: Channel data
             sample_frequency: Sampling frequency in Hz (as per EDF specification)
             physical_dimension: Physical dimension/unit of measurement (as per EDF specification)
-            prefilter: Pre-filtering applied to the channel
-            channel_type: Channel type ('EMG', 'ACC', 'GYRO', etc.)
+            channel_type: BIDS channel type ('EEG', 'EMG', 'ECG', 'ACC', 'SEEG', ...).
+                Required; validated against the modality vocabulary. There is no
+                default (a missing type must be explicit, e.g. 'OTHER'/'MISC').
+            modality: Coarse modality ('EEG', 'EMG', 'IEEG', 'MEG', 'BEH', 'MISC').
+                If None, it is inferred from ``channel_type``.
+            prefilter: Pre-filtering applied to the channel (keyword-only).
         """
+        canonical_type = validate_channel_type(channel_type)
+        canonical_modality = (
+            infer_modality_from_channel_type(canonical_type)
+            if modality is None
+            else validate_modality(modality)
+        )
+
         if self.signals is None:
             # Create DataFrame with time index
             time = np.arange(len(data)) / sample_frequency
@@ -472,8 +529,47 @@ class EMG:
             "sample_frequency": sample_frequency,
             "physical_dimension": physical_dimension,
             "prefilter": prefilter,
-            "channel_type": channel_type,
+            "channel_type": canonical_type,
+            "modality": canonical_modality,
         }
+
+    def set_channel(
+        self,
+        label: str,
+        *,
+        channel_type: str | None = None,
+        modality: str | None = None,
+        physical_dimension: str | None = None,
+        prefilter: str | None = None,
+    ) -> None:
+        """
+        Update metadata of an existing channel (the supported relabel path).
+
+        Args:
+            label: Existing channel label.
+            channel_type: New BIDS channel type (validated). When given without an
+                explicit ``modality``, the modality is re-derived from it.
+            modality: New coarse modality (validated).
+            physical_dimension: New physical unit.
+            prefilter: New prefilter string.
+
+        Raises:
+            KeyError: If ``label`` is not an existing channel.
+            ValueError: If ``channel_type``/``modality`` are not in the vocabulary.
+        """
+        if label not in self.channels:
+            raise KeyError(f"Channel not found: {label}")
+        info = self.channels[label]
+        if channel_type is not None:
+            info["channel_type"] = validate_channel_type(channel_type)
+            if modality is None:
+                info["modality"] = infer_modality_from_channel_type(info["channel_type"])
+        if modality is not None:
+            info["modality"] = validate_modality(modality)
+        if physical_dimension is not None:
+            info["physical_dimension"] = physical_dimension
+        if prefilter is not None:
+            info["prefilter"] = prefilter
 
     def add_event(self, onset: float, duration: float, description: str) -> None:
         """

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -212,6 +212,9 @@ class EMG:
         if self.signals is None:
             raise ValueError("No signals loaded")
 
+        if channels is None and channel_type is None and modality is None:
+            raise ValueError("Specify at least one of: channels, channel_type, or modality.")
+
         # If type/modality specified but no channels, select all matching channels
         if channels is None and channel_type is not None:
             channels = self.get_channels_by_type(channel_type)
@@ -555,7 +558,8 @@ class EMG:
 
         Raises:
             KeyError: If ``label`` is not an existing channel.
-            ValueError: If ``channel_type``/``modality`` are not in the vocabulary.
+            ValueError: If ``channel_type`` or ``modality`` is not in the
+                modality vocabulary.
         """
         if label not in self.channels:
             raise KeyError(f"Channel not found: {label}")

--- a/emgio/core/modality.py
+++ b/emgio/core/modality.py
@@ -120,6 +120,49 @@ def validate_modality(modality: str) -> str:
     return m
 
 
+# Channel types valid for the BIDS ``channels.tsv`` ``type`` column
+# (electrophysiology + physiology). Device-domain types (ACC/GYRO/...) and
+# ``OTHER`` are reported as ``MISC`` there since they are not BIDS channel types.
+_BIDS_CHANNELS_TSV_TYPES: frozenset[str] = frozenset(
+    {
+        "EEG",
+        "SEEG",
+        "ECOG",
+        "DBS",
+        "MEGMAG",
+        "MEGGRADAXIAL",
+        "MEGGRADPLANAR",
+        "MEGREFMAG",
+        "MEGREFGRADAXIAL",
+        "MEGREFGRADPLANAR",
+        "EMG",
+        "ECG",
+        "EKG",
+        "EOG",
+        "VEOG",
+        "HEOG",
+        "REF",
+        "TRIG",
+        "MISC",
+        "RESP",
+        "GSR",
+        "TEMP",
+        "PPG",
+        "SYSCLOCK",
+    }
+)
+
+
+def to_bids_channels_tsv_type(channel_type: str) -> str:
+    """Map an emgio channel type to a BIDS ``channels.tsv`` ``type`` value.
+
+    Genuine BIDS electrophysiology/physiology types pass through; device-domain
+    types (ACC, GYRO, QUAT, CTRL, MAGN) and ``OTHER`` map to ``MISC``.
+    """
+    ct = validate_channel_type(channel_type)
+    return ct if ct in _BIDS_CHANNELS_TSV_TYPES else "MISC"
+
+
 def infer_modality_from_channel_type(channel_type: str) -> str:
     """Derive the coarse modality for a channel type.
 

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -8,6 +8,7 @@ import pyedflib
 
 from ..analysis.signal import analyze_signal, determine_format_suitability
 from ..core.emg import EMG
+from ..core.modality import to_bids_channels_tsv_type
 
 
 def _format_physical_value(value: float, max_chars: int) -> tuple:
@@ -524,31 +525,11 @@ class EDFExporter:
                 # Add to BIDS-compliant channels.tsv data
                 channels_tsv_data["name"].append(ch_name)
 
-                # Map channel type to BIDS-compliant uppercase values
-                ch_type = ch_info.get("channel_type", "Unknown").upper()
-                # Map common channel types to BIDS standard values
-                if ch_type in [
-                    "EMG",
-                    "EEG",
-                    "MEG",
-                    "ECG",
-                    "EOG",
-                    "VEOG",
-                    "HEOG",
-                    "REF",
-                    "TRIG",
-                    "MISC",
-                ]:
-                    bids_type = ch_type
-                elif "EMG" in ch_type:
-                    bids_type = "EMG"
-                elif "ACC" in ch_type or "ACCEL" in ch_type:
-                    bids_type = "MISC"
-                elif "GYRO" in ch_type:
-                    bids_type = "MISC"
-                else:
-                    bids_type = "MISC"
-
+                # Channels carry a validated channel_type from the modality
+                # vocabulary, so use it directly for channels.tsv. This preserves
+                # genuine BIDS types (EEG/SEEG/ECOG/...) instead of flattening
+                # everything but a short whitelist to MISC.
+                bids_type = to_bids_channels_tsv_type(ch_info.get("channel_type", "OTHER"))
                 channels_tsv_data["type"].append(bids_type)
                 channels_tsv_data["units"].append(ch_info["physical_dimension"])
                 channels_tsv_data["sampling_frequency"].append(ch_info["sample_frequency"])

--- a/emgio/importers/csv.py
+++ b/emgio/importers/csv.py
@@ -404,7 +404,10 @@ class CSVImporter(BaseImporter):
         elif any(keyword in name_lower for keyword in ["gyro"]):
             return "GYRO"
         elif any(keyword in name_lower for keyword in ["time", "second"]):
-            return "TIME"  # Might be redundant if used as index, but useful for metadata
+            # A time column is normally consumed as the index. If one still
+            # reaches here it is not a signal channel; classify it as MISC
+            # ("TIME" is not a valid BIDS/modality channel type).
+            return "MISC"
         else:
             return "OTHER"
 

--- a/emgio/importers/edf.py
+++ b/emgio/importers/edf.py
@@ -24,6 +24,12 @@ class EDFImporter(BaseImporter):
 
         if "EMG" in label or "EMG" in transducer:
             return "EMG"
+        elif "EEG" in label or "EEG" in transducer:
+            return "EEG"
+        elif "ECG" in label or "EKG" in label or "ECG" in transducer:
+            return "ECG"
+        elif "EOG" in label or "EOG" in transducer:
+            return "EOG"
         elif "ACC" in label or "ACCELEROMETER" in transducer:
             return "ACC"
         elif "GYRO" in label or "GYROSCOPE" in transducer:

--- a/emgio/importers/eeglab.py
+++ b/emgio/importers/eeglab.py
@@ -5,6 +5,7 @@ import pandas as pd
 from scipy.io import loadmat
 
 from ..core.emg import EMG
+from ..core.modality import infer_modality_from_channel_type
 from .base import BaseImporter
 
 
@@ -89,8 +90,9 @@ class EEGLABImporter(BaseImporter):
         ch_type = channel_info.get("type")
         if ch_type:
             ch_type_upper = ch_type.upper()
-            if ch_type_upper == "EMG":
-                return "EMG"
+            # Neural/physiological BIDS types pass straight through.
+            if ch_type_upper in ("EEG", "EMG", "ECG", "EKG", "EOG", "SEEG", "ECOG"):
+                return ch_type_upper
             elif ch_type_upper in ["ACC", "ACCELEROMETER"]:
                 return "ACC"
             elif ch_type_upper in ["GYRO", "GYROSCOPE"]:
@@ -104,6 +106,10 @@ class EEGLABImporter(BaseImporter):
             label_upper = label.upper()
             if "EMG" in label_upper:
                 return "EMG"
+            elif "ECG" in label_upper or "EKG" in label_upper:
+                return "ECG"
+            elif "EOG" in label_upper:
+                return "EOG"
             elif "ACC" in label_upper:
                 return "ACC"
             elif "GYRO" in label_upper:
@@ -111,8 +117,9 @@ class EEGLABImporter(BaseImporter):
             elif "TRIG" in label_upper:
                 return "TRIG"
 
-        # Default to EMG if we can't determine the type
-        return "EMG"
+        # No reliable type info: do NOT assume EMG (avoids modality creep onto
+        # EEG/other data). Caller-supplied BIDS channels.tsv types can refine this.
+        return "OTHER"
 
     def _process_channel_info(self, chanlocs: np.ndarray) -> list[dict[str, Any]]:
         """
@@ -238,7 +245,7 @@ class EEGLABImporter(BaseImporter):
                 # If no channel locations, create default channel info
                 channel_info_list = []
                 for i in range(metadata.get("nbchan", 0)):
-                    channel_info_list.append({"label": f"Channel{i + 1}", "channel_type": "EMG"})
+                    channel_info_list.append({"label": f"Channel{i + 1}", "channel_type": "OTHER"})
 
             # Process event information
             if "event" in data and data["event"].size > 0:
@@ -280,12 +287,14 @@ class EEGLABImporter(BaseImporter):
                     if i < signal_data.shape[0]:  # Make sure we have data for this channel
                         channel_label = channel_info.get("label", f"Channel{i + 1}")
 
-                        # Add channel info
+                        # Add channel info (no silent EMG default; carry modality)
+                        ch_type = channel_info.get("channel_type", "OTHER")
                         emg.channels[channel_label] = {
                             "sample_frequency": srate,
                             "physical_dimension": "uV",  # Default unit for EEG/EMG
                             "prefilter": "n/a",
-                            "channel_type": channel_info.get("channel_type", "EMG"),
+                            "channel_type": ch_type,
+                            "modality": infer_modality_from_channel_type(ch_type),
                         }
 
                         # Add additional channel metadata

--- a/emgio/importers/xdf.py
+++ b/emgio/importers/xdf.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 
 from ..core.emg import EMG
+from ..core.modality import infer_modality_from_channel_type, validate_channel_type
 from .base import BaseImporter
 
 logger = logging.getLogger(__name__)
@@ -846,11 +847,20 @@ class XDFImporter(BaseImporter):
 
             df[label] = ch_data
 
+            # Validate the stream-derived type against the modality vocabulary;
+            # arbitrary LSL type strings (e.g. "Markers", "Kinematics") map to
+            # OTHER rather than being stored unvalidated (which would later fail
+            # at export) or silently assumed to be EMG.
+            try:
+                ch_type = validate_channel_type(ch_info["type"])
+            except ValueError:
+                ch_type = "OTHER"
             emg.channels[label] = {
                 "sample_frequency": ch_info["srate"] if ch_info["srate"] else base_srate,
                 "physical_dimension": ch_info["unit"],
                 "prefilter": "n/a",
-                "channel_type": ch_info["type"],
+                "channel_type": ch_type,
+                "modality": infer_modality_from_channel_type(ch_type),
             }
 
         # Add timestamp channels if requested
@@ -876,6 +886,7 @@ class XDFImporter(BaseImporter):
                     "physical_dimension": "s",  # seconds
                     "prefilter": "n/a",
                     "channel_type": "MISC",  # Miscellaneous channel type
+                    "modality": "MISC",
                 }
 
         emg.signals = df

--- a/emgio/importers/xdf.py
+++ b/emgio/importers/xdf.py
@@ -440,7 +440,7 @@ class XDFImporter(BaseImporter):
         stream_types: list[str] | None = None,
         stream_ids: list[int] | None = None,
         sync_streams: bool = True,
-        default_channel_type: str = "EMG",
+        default_channel_type: str = "OTHER",
         include_timestamps: bool = False,
         reference_stream: str | None = None,
         max_memory_gb: float | None = None,
@@ -469,7 +469,8 @@ class XDFImporter(BaseImporter):
             sync_streams: If True, synchronize streams to common timestamps.
                          If False, streams are loaded without synchronization.
             default_channel_type: Default channel type for channels without
-                                 explicit type info (default: "EMG")
+                                 explicit type info (default: "OTHER"; no silent
+                                 EMG assumption)
             include_timestamps: If True, add a timestamp channel for each stream
                                named "{stream_name}_LSL_timestamps" containing
                                the original LSL timestamps. Useful for preserving

--- a/emgio/tests/test_core.py
+++ b/emgio/tests/test_core.py
@@ -153,7 +153,7 @@ def test_add_channel_validation(empty_emg):
 
     # Test with float data
     data_float = np.array([1.1, 2.2, 3.3])
-    empty_emg.add_channel("FLOAT", data_float, 1000, "mV")
+    empty_emg.add_channel("FLOAT", data_float, 1000, "mV", "EMG")
     assert np.array_equal(empty_emg.signals["FLOAT"].values, data_float)
 
     # Test channel info storage
@@ -581,7 +581,7 @@ def test_to_edf_export(sample_emg, mock_edf_exporter):
 
     # Test exporting with no events in the EMG object
     empty_event_emg = EMG()
-    empty_event_emg.add_channel("CH1", np.array([1, 2, 3]), 100, "V")
+    empty_event_emg.add_channel("CH1", np.array([1, 2, 3]), 100, "V", "EMG")
     empty_event_emg.to_edf(filepath, format="edf")
     assert "events_df" in mock_edf_exporter.last_export["kwargs"]
     assert mock_edf_exporter.last_export["kwargs"]["events_df"].empty
@@ -671,7 +671,7 @@ def test_add_channel_with_prefilter(empty_emg):
     """Test adding channel with prefilter specification."""
     data = np.array([1, 2, 3])
     prefilter = "HP 20Hz"
-    empty_emg.add_channel("EMG1", data, 1000, "mV", prefilter=prefilter)
+    empty_emg.add_channel("EMG1", data, 1000, "mV", "EMG", prefilter=prefilter)
 
     assert empty_emg.channels["EMG1"]["prefilter"] == prefilter
 

--- a/emgio/tests/test_exporters.py
+++ b/emgio/tests/test_exporters.py
@@ -27,8 +27,8 @@ def sample_emg():
     acc_data = np.cos(2 * np.pi * 5 * time) * 1.5  # Use a non-unity amplitude
 
     # Add channels
-    emg.add_channel("EMG1", emg_data, 1000, "mV", "n/a", "EMG")
-    emg.add_channel("ACC1", acc_data, 1000, "g", "n/a", "ACC")
+    emg.add_channel("EMG1", emg_data, 1000, "mV", "EMG")
+    emg.add_channel("ACC1", acc_data, 1000, "g", "ACC")
 
     return emg
 
@@ -663,12 +663,12 @@ def test_high_dynamic_range():
     hdr_signal, actual_dr = generate_high_dynamic_range_signal(dynamic_range_db=85)
     assert actual_dr > 75, f"Generated signal has {actual_dr:.1f} dB DR, expected >75 dB"
     print(f"Successfully generated test signal with {actual_dr:.1f} dB dynamic range")
-    emg.add_channel("HDR_EMG", hdr_signal, 1000, "uV", "n/a", "EMG")
+    emg.add_channel("HDR_EMG", hdr_signal, 1000, "uV", "EMG")
 
     # Add a regular channel for comparison - this has high dynamic range
     time = np.linspace(0, 1, 1000)
     regular_signal = np.sin(2 * np.pi * 10 * time) * 1000
-    emg.add_channel("REG_EMG", regular_signal, 1000, "uV", "n/a", "EMG")
+    emg.add_channel("REG_EMG", regular_signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         edf_path = f.name

--- a/emgio/tests/test_modality_integration.py
+++ b/emgio/tests/test_modality_integration.py
@@ -1,0 +1,61 @@
+"""Integration tests for the explicit-modality model (issue #46).
+
+Verifies that channel_type is required (no silent EMG default), that modality is
+derived/validated, the new selectors/mutator work, and that real EEG data no
+longer creeps to EMG on import. NO MOCKS.
+"""
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from emgio import EMG
+
+EEG_SET = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
+)
+
+
+def test_add_channel_requires_channel_type():
+    emg = EMG()
+    with pytest.raises(TypeError):
+        emg.add_channel("C", np.zeros(10), 100, "uV")  # channel_type omitted
+
+
+def test_add_channel_validates_and_infers_modality():
+    emg = EMG()
+    emg.add_channel("E1", np.zeros(10), 100, "uV", "eeg")  # case-insensitive
+    assert emg.channels["E1"]["channel_type"] == "EEG"
+    assert emg.channels["E1"]["modality"] == "EEG"
+
+    emg.add_channel("S1", np.zeros(10), 100, "uV", "ECOG")
+    assert emg.channels["S1"]["modality"] == "IEEG"
+
+    with pytest.raises(ValueError):
+        emg.add_channel("X", np.zeros(10), 100, "uV", "BOGUS")
+
+
+def test_set_channel_and_modality_selectors():
+    emg = EMG()
+    emg.add_channel("a", np.zeros(10), 100, "uV", "EEG")
+    emg.add_channel("b", np.zeros(10), 100, "mV", "EMG")
+
+    assert set(emg.get_modalities()) == {"EEG", "EMG"}
+    assert emg.get_channels_by_modality("EEG") == ["a"]
+    assert emg.select_channels(modality="EMG").signals.columns.tolist() == ["b"]
+
+    emg.set_channel("b", channel_type="ECG")
+    assert emg.channels["b"]["channel_type"] == "ECG"
+    assert emg.channels["b"]["modality"] == "MISC"  # re-derived from new type
+
+
+@pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
+def test_real_eeg_does_not_creep_to_emg():
+    emg = EMG.from_file(str(EEG_SET), importer="eeglab")
+    types = {info["channel_type"] for info in emg.channels.values()}
+    # The headline bug: EEG data must not be silently relabelled EMG.
+    assert "EMG" not in types
+    # Every channel carries a modality after the explicit-modality migration.
+    assert all("modality" in info for info in emg.channels.values())

--- a/emgio/tests/test_modality_integration.py
+++ b/emgio/tests/test_modality_integration.py
@@ -11,11 +11,12 @@ import numpy as np
 import pytest
 
 from emgio import EMG
+from emgio.core.modality import VALID_CHANNEL_TYPES
+from emgio.importers.csv import CSVImporter
 
-EEG_SET = (
-    pathlib.Path(__file__).resolve().parents[2]
-    / "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
-)
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EEG_SET = _REPO / "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
+XDF_FILE = _REPO / "examples/multi_stream_test.xdf"
 
 
 def test_add_channel_requires_channel_type():
@@ -49,6 +50,23 @@ def test_set_channel_and_modality_selectors():
     emg.set_channel("b", channel_type="ECG")
     assert emg.channels["b"]["channel_type"] == "ECG"
     assert emg.channels["b"]["modality"] == "MISC"  # re-derived from new type
+
+
+def test_csv_time_column_is_not_an_invalid_type():
+    """A time-named column must classify as a valid type (not the bogus 'TIME')."""
+    ct = CSVImporter()._infer_channel_type("timestamp")
+    assert ct in VALID_CHANNEL_TYPES
+
+
+@pytest.mark.skipif(not XDF_FILE.exists(), reason="XDF fixture missing")
+def test_xdf_channels_carry_valid_type_and_modality():
+    emg = EMG.from_file(str(XDF_FILE))
+    assert len(emg.channels) > 0
+    for info in emg.channels.values():
+        # No raw/unvalidated LSL type strings leak through, and every channel
+        # carries a modality (so the modality selectors work for XDF data).
+        assert info["channel_type"] in VALID_CHANNEL_TYPES
+        assert info.get("modality") is not None
 
 
 @pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")

--- a/emgio/tests/test_verification.py
+++ b/emgio/tests/test_verification.py
@@ -170,8 +170,8 @@ def test_compare_signals_empty_intersection():
     time = np.linspace(0, 1, 1000)
     signal = np.sin(2 * np.pi * 10 * time)
 
-    emg1.add_channel("CH1", signal, 1000, "mV")
-    emg2.add_channel("CH2", signal, 1000, "mV")
+    emg1.add_channel("CH1", signal, 1000, "mV", "EMG")
+    emg2.add_channel("CH2", signal, 1000, "mV", "EMG")
 
     result = compare_signals(emg1, emg2)
 
@@ -190,8 +190,8 @@ def test_compare_signals_invalid_channel_map():
     time = np.linspace(0, 1, 1000)
     signal = np.sin(2 * np.pi * 10 * time)
 
-    emg1.add_channel("CH1", signal, 1000, "mV")
-    emg2.add_channel("CH2", signal, 1000, "mV")
+    emg1.add_channel("CH1", signal, 1000, "mV", "EMG")
+    emg2.add_channel("CH2", signal, 1000, "mV", "EMG")
 
     # Channel map with non-existent original channel
     channel_map = {"NONEXISTENT": "CH2"}
@@ -207,8 +207,8 @@ def test_compare_signals_with_constant_signal():
 
     # Add constant signals to both
     const_signal = np.ones(1000)
-    emg1.add_channel("CONST", const_signal, 1000, "mV")
-    emg2.add_channel("CONST", const_signal + 1e-6, 1000, "mV")  # Tiny difference
+    emg1.add_channel("CONST", const_signal, 1000, "mV", "EMG")
+    emg2.add_channel("CONST", const_signal + 1e-6, 1000, "mV", "EMG")  # Tiny difference
 
     result = compare_signals(emg1, emg2)
 

--- a/emgio/tests/test_visualization.py
+++ b/emgio/tests/test_visualization.py
@@ -167,7 +167,7 @@ def test_plot_signals_options(sample_emg):
 def test_plot_signals_with_constant(sample_emg):
     """Test plot_signals with constant signals (zero range)."""
     # Add a constant signal
-    sample_emg.add_channel("CONST", np.ones(1000), 1000, "mV")
+    sample_emg.add_channel("CONST", np.ones(1000), 1000, "mV", "EMG")
 
     mock_plt = MockPlt()
     # This should not raise any errors despite the constant signal
@@ -220,8 +220,8 @@ def test_plot_comparison_with_channel_map(emg_pair):
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
 
-    emg_renamed.add_channel("Channel1", signal1, 1000, "mV")
-    emg_renamed.add_channel("Channel2", signal2, 1000, "mV")
+    emg_renamed.add_channel("Channel1", signal1, 1000, "mV", "EMG")
+    emg_renamed.add_channel("Channel2", signal2, 1000, "mV", "EMG")
 
     # Define channel mapping
     channel_map = {"EMG1": "Channel1", "EMG2": "Channel2"}
@@ -243,8 +243,8 @@ def test_plot_comparison_no_common_channels():
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
 
-    emg1.add_channel("CH1", signal1, 1000, "mV")
-    emg2.add_channel("CH2", signal2, 1000, "mV")
+    emg1.add_channel("CH1", signal1, 1000, "mV", "EMG")
+    emg2.add_channel("CH2", signal2, 1000, "mV", "EMG")
 
     # This should not raise errors, but will print a warning
     with patch("builtins.print") as mock_print:
@@ -266,8 +266,8 @@ def test_plot_comparison_different_lengths():
     signal1 = np.sin(2 * np.pi * 10 * time1)
     signal2 = np.sin(2 * np.pi * 10 * time2)
 
-    emg1.add_channel("CH1", signal1, 1000, "mV")
-    emg2.add_channel("CH1", signal2, 1000, "mV")
+    emg1.add_channel("CH1", signal1, 1000, "mV", "EMG")
+    emg2.add_channel("CH1", signal2, 1000, "mV", "EMG")
 
     mock_plt = MockPlt()
     # This should handle different length signals
@@ -284,11 +284,11 @@ def test_plot_comparison_order_based():
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
 
-    emg1.add_channel("CH1", signal1, 1000, "mV")
-    emg1.add_channel("CH2", signal2, 1000, "mV")
+    emg1.add_channel("CH1", signal1, 1000, "mV", "EMG")
+    emg1.add_channel("CH2", signal2, 1000, "mV", "EMG")
 
-    emg2.add_channel("Channel1", signal1, 1000, "mV")
-    emg2.add_channel("Channel2", signal2, 1000, "mV")
+    emg2.add_channel("Channel1", signal1, 1000, "mV", "EMG")
+    emg2.add_channel("Channel2", signal2, 1000, "mV", "EMG")
 
     # No common names, should fall back to order-based
     with patch("builtins.print") as mock_print:

--- a/emgio/version.py
+++ b/emgio/version.py
@@ -1,7 +1,7 @@
 """Version information for EMGIO."""
 
-__version__ = "0.2.2"
-__version_info__ = (0, 2, 2)
+__version__ = "0.3.0"
+__version_info__ = (0, 3, 0)
 
 
 def get_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emgio"
-version = "0.2.2"
+version = "0.3.0"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
Closes #46. PR into the biosigIO epic branch. **Breaking change** (the headline modality-creep bug).

## What changed
- **`EMG.add_channel` now requires `channel_type`** (no silent `'EMG'` default). It is validated against the BIDS modality vocabulary (`core/modality.py`) and a coarse `modality` is derived (or validated if passed) and stored per channel.
- New API: `set_channel(...)` mutator, `get_modalities()`, `get_channels_by_modality()`, and `select_channels(modality=...)`.
- **Importers no longer creep to EMG:** `eeglab` and `xdf` defaults `EMG -> OTHER` (eeglab also classifies EEG/ECG/EOG and carries `modality`); `edf`/`wfdb`/`csv`/`trigno`/`otb` already fell back to `OTHER`.
- **Exporter** writes `channels.tsv` `type` via `to_bids_channels_tsv_type` — preserves genuine BIDS types (EEG/SEEG/ECOG/...) instead of flattening everything but a short whitelist; device types (ACC/GYRO/...) and OTHER map to MISC (BIDS-correct).
- Version bumped to **0.3.0** (breaking).

## Verification (NO MOCKS)
- New `test_modality_integration.py`: `add_channel` without type raises `TypeError`; invalid type raises `ValueError`; modality inferred (ECOG->IEEG); `set_channel`/selectors work; **real EEG fixture imports with NO channel typed EMG** (the bug) and every channel carries a modality.
- Updated ~22 existing call sites to pass explicit `channel_type`.
- Full suite: **225 passed / 3 skipped / 0 failed**; ruff + format clean.

## Follow-up (next)
- **#57** — read the BIDS `channels.tsv` `type` column on import to assign accurate per-channel types (SEEG/ECG/EEG) from the sidecar rather than label-guessing. The maintainer flagged that a good chunk of real data relies on `channels.tsv` for per-channel types.
- Rich per-modality label classification (EEG montage names, MEG) remains Phase 3.