### PR TITLE
Real-data round-trip harness (and it found a corruption bug)

### DIFF
--- a/emgio/tests/test_roundtrip.py
+++ b/emgio/tests/test_roundtrip.py
@@ -11,8 +11,10 @@ Known limitations are asserted explicitly rather than skipped:
 - event round-trip through EDF+ annotations is pending #47 (xfail).
 """
 
+import atexit
 import os
 import pathlib
+import shutil
 import tempfile
 from dataclasses import dataclass
 
@@ -25,6 +27,7 @@ from emgio.analysis.verification import compare_signals
 # structural and value-integrity tests.
 _RT_DIR = tempfile.mkdtemp(prefix="emgio_roundtrip_")
 _RT_CACHE: dict = {}
+atexit.register(shutil.rmtree, _RT_DIR, ignore_errors=True)
 
 _REPO = pathlib.Path(__file__).resolve().parents[2]
 EX = _REPO / "examples"
@@ -95,7 +98,9 @@ def _roundtrip(case):
     if case.name not in _RT_CACHE:
         emg = EMG.from_file(str(case.path), importer=case.importer)
         out = os.path.join(_RT_DIR, f"{case.name}.edf")
-        emg.to_edf(out, format="auto", bypass_analysis=True)
+        # format="auto" exercises the real EDF/BDF selection (and ignores
+        # bypass_analysis by design), which is what a round-trip harness wants.
+        emg.to_edf(out, format="auto")
         written = out if os.path.exists(out) else os.path.splitext(out)[0] + ".bdf"
         _RT_CACHE[case.name] = (emg, EMG.from_file(written))
     return _RT_CACHE[case.name]
@@ -156,16 +161,22 @@ def test_meg_fif_import_unsupported():
         EMG.from_file(str(meg))
 
 
-@pytest.mark.xfail(reason="EDF+ annotation round-trip pending #47", strict=True)
+@pytest.mark.xfail(reason="EDF+ annotation read-back pending #47", strict=True)
 def test_event_roundtrip_through_edf(tmp_path):
-    """Events written to EDF+ should survive reimport (enabled by #47)."""
-    ieeg = BIDS / "ieeg/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-stim_run-08_ieeg.edf"
-    if not ieeg.exists():
-        pytest.skip("iEEG fixture missing")
-    emg = EMG.from_file(str(ieeg))
-    n_events = len(emg.events)
-    assert n_events > 0
+    """Events exported as EDF+ annotations should survive reimport.
+
+    Events are added explicitly here (rather than relying on import, which does
+    not yet read EDF+ annotations) so this exercises export-write -> reimport.
+    It fails today because the EDF importer drops annotations on read; #47 adds
+    read-back and flips this to pass.
+    """
+    fixture = BIDS / "emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
+    if not fixture.exists():
+        pytest.skip("EMG fixture missing")
+    emg = EMG.from_file(str(fixture))
+    emg.add_event(onset=0.5, duration=0.0, description="m1")
+    emg.add_event(onset=1.0, duration=0.2, description="m2")
     out = tmp_path / "ev.edf"
     emg.to_edf(str(out), format="edf", bypass_analysis=True)
     reloaded = EMG.from_file(str(out), bids_channels="off")
-    assert len(reloaded.events) == n_events
+    assert len(reloaded.events) == 2

--- a/emgio/tests/test_roundtrip.py
+++ b/emgio/tests/test_roundtrip.py
@@ -1,0 +1,171 @@
+"""Real-data round-trip harness (issue #48).
+
+Imports every real fixture, exports it to EDF/BDF, reimports, and checks signal
+integrity with the real ``compare_signals`` metrics. This is the grounding
+backbone the mock-based ``to_edf`` tests lacked (a mock exporter never wrote
+real bytes, which is how the 1-second truncation bug shipped). NO MOCKS.
+
+Known limitations are asserted explicitly rather than skipped:
+- mixed per-channel sample rates (XDF, Trigno) must fail loudly on export;
+- MEG ``.fif`` is not importable yet (needs an MNE-based importer, #53);
+- event round-trip through EDF+ annotations is pending #47 (xfail).
+"""
+
+import os
+import pathlib
+import tempfile
+from dataclasses import dataclass
+
+import pytest
+
+from emgio import EMG
+from emgio.analysis.verification import compare_signals
+
+# Round-trips are expensive; compute each fixture's once and share it across the
+# structural and value-integrity tests.
+_RT_DIR = tempfile.mkdtemp(prefix="emgio_roundtrip_")
+_RT_CACHE: dict = {}
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EX = _REPO / "examples"
+BIDS = EX / "bids"
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    path: pathlib.Path
+    importer: str | None
+    has_emg: bool  # whether EMG channels are legitimately present at import
+    # Whether per-channel signal VALUES round-trip cleanly. emg/ieeg currently
+    # do not, due to the exporter per-channel scaling bug (#61); their value
+    # check is xfailed below until that is fixed.
+    value_clean: bool = False
+    tolerance: float = 0.05
+
+
+# Single-rate fixtures. Structural integrity (no sample loss, channel count,
+# no modality creep) holds for all; signal-VALUE integrity is xfailed for the
+# ones hitting the exporter scaling bug (#61).
+ROUNDTRIP_CASES = [
+    Case(
+        "emg",
+        BIDS / "emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf",
+        None,
+        has_emg=True,
+        value_clean=False,
+    ),
+    Case(
+        "ieeg",
+        BIDS / "ieeg/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-stim_run-08_ieeg.edf",
+        None,
+        has_emg=False,
+        value_clean=False,
+    ),
+    Case(
+        "eeg",
+        BIDS / "eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set",
+        "eeglab",
+        has_emg=False,
+        value_clean=True,
+    ),
+    Case("otb", EX / "one_sessantaquattro_truncated.otb+", "otb", has_emg=True, value_clean=True),
+]
+
+
+def _value_param(case):
+    """Parametrize value-integrity, xfailing fixtures blocked by the #61 bug."""
+    if case.value_clean:
+        return case
+    return pytest.param(
+        case,
+        marks=pytest.mark.xfail(reason="exporter per-channel scaling corruption, #61", strict=True),
+    )
+
+
+# Mixed per-channel sample rate -> EDF export must raise (one rate per file).
+MIXED_RATE_CASES = [
+    Case("xdf", EX / "multi_stream_test.xdf", None, has_emg=True),
+    Case("trigno", EX / "truncated_trigno_sample.csv", "trigno", has_emg=True),
+]
+
+
+def _roundtrip(case):
+    """Import -> export (auto) -> reimport once per fixture (cached)."""
+    if case.name not in _RT_CACHE:
+        emg = EMG.from_file(str(case.path), importer=case.importer)
+        out = os.path.join(_RT_DIR, f"{case.name}.edf")
+        emg.to_edf(out, format="auto", bypass_analysis=True)
+        written = out if os.path.exists(out) else os.path.splitext(out)[0] + ".bdf"
+        _RT_CACHE[case.name] = (emg, EMG.from_file(written))
+    return _RT_CACHE[case.name]
+
+
+@pytest.mark.parametrize("case", ROUNDTRIP_CASES, ids=lambda c: c.name)
+def test_roundtrip_preserves_structure(case):
+    """No sample loss, channel count preserved, no modality creep (all fixtures)."""
+    if not case.path.exists():
+        pytest.skip(f"fixture missing: {case.path}")
+    emg, reloaded = _roundtrip(case)
+
+    # No samples lost (modulo one EDF data-record of zero padding).
+    rate = max(int(c["sample_frequency"]) for c in emg.channels.values())
+    assert emg.signals.shape[0] <= reloaded.signals.shape[0] <= emg.signals.shape[0] + rate
+    assert len(reloaded.channels) == len(emg.channels)
+
+    # No modality creep: a fixture with no EMG must not gain EMG channels.
+    if not case.has_emg:
+        reloaded_emg = [c for c, i in reloaded.channels.items() if i["channel_type"] == "EMG"]
+        assert not reloaded_emg, f"{case.name}: EMG channels appeared after round-trip"
+
+
+@pytest.mark.parametrize("case", [_value_param(c) for c in ROUNDTRIP_CASES], ids=lambda c: c.name)
+def test_roundtrip_preserves_signal_values(case):
+    """Every channel's values survive the round-trip within tolerance.
+
+    xfail for emg/ieeg pending the exporter per-channel scaling fix (#61).
+    """
+    if not case.path.exists():
+        pytest.skip(f"fixture missing: {case.path}")
+    emg, reloaded = _roundtrip(case)
+    results = compare_signals(emg, reloaded, tolerance=case.tolerance)
+    compared = {k: v for k, v in results.items() if k != "channel_summary"}
+    assert compared, "no channels were compared"
+    not_identical = [k for k, v in compared.items() if not v["is_identical"]]
+    assert not not_identical, f"{case.name}: channels differ after round-trip: {not_identical}"
+
+
+@pytest.mark.parametrize("case", MIXED_RATE_CASES, ids=lambda c: c.name)
+def test_mixed_rate_export_raises(case, tmp_path):
+    if not case.path.exists():
+        pytest.skip(f"fixture missing: {case.path}")
+    emg = EMG.from_file(str(case.path), importer=case.importer)
+    rates = {int(c["sample_frequency"]) for c in emg.channels.values()}
+    if len(rates) <= 1:
+        pytest.skip(f"{case.name}: fixture is single-rate, guard not exercised")
+    with pytest.raises(ValueError, match="single sampling rate"):
+        emg.to_edf(str(tmp_path / f"{case.name}.edf"), format="edf", bypass_analysis=True)
+
+
+def test_meg_fif_import_unsupported():
+    meg = BIDS / "meg/sub-01/meg/sub-01_task-mouse_meg.fif"
+    if not meg.exists():
+        pytest.skip("MEG fixture missing")
+    # Until an MNE-based MEG importer lands (#53), .fif is unsupported.
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        EMG.from_file(str(meg))
+
+
+@pytest.mark.xfail(reason="EDF+ annotation round-trip pending #47", strict=True)
+def test_event_roundtrip_through_edf(tmp_path):
+    """Events written to EDF+ should survive reimport (enabled by #47)."""
+    ieeg = BIDS / "ieeg/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-stim_run-08_ieeg.edf"
+    if not ieeg.exists():
+        pytest.skip("iEEG fixture missing")
+    emg = EMG.from_file(str(ieeg))
+    n_events = len(emg.events)
+    assert n_events > 0
+    out = tmp_path / "ev.edf"
+    emg.to_edf(str(out), format="edf", bypass_analysis=True)
+    reloaded = EMG.from_file(str(out), bids_channels="off")
+    assert len(reloaded.events) == n_events


### PR DESCRIPTION
Part of #48. PR into the biosigIO epic branch.

A reusable **real-data round-trip harness** (`emgio/tests/test_roundtrip.py`): import each real fixture → export EDF/BDF → reimport → check integrity with the real `compare_signals`. This is the grounding backbone the mock `to_edf` tests lacked (a mock exporter never wrote real bytes — how the truncation bug shipped). **NO MOCKS.**

## Coverage (real fixtures)
- **Structural integrity (strict, all):** no sample loss, channel count preserved, no modality creep — EMG/iEEG/EEG/OTB all pass.
- **Signal-value integrity:** EEG + OTB pass strictly; **emg + iEEG are `xfail(strict=True)` because the harness surfaced a real exporter bug** — see below.
- **Known limitations asserted (not skipped):** mixed-rate (XDF/Trigno) export must raise; MEG `.fif` is unsupported (#53); event round-trip is `xfail` pending #47.

## It found a bug: #61
In **24-bit BDF** (near-lossless), iEEG `chan4`/`chan1` round-trip with **errors ≈ their full amplitude**, and emg `Ch130` is catastrophic in EDF (NRMSE 0.72) but clean in BDF — the exporter corrupts some channels via per-channel scaling. Filed as **#61** (high priority); the harness xfails those cases (linked) so fixing #61 flips them to pass.

## Notes
- Round-trips are cached per fixture (~90 s for the whole harness).
- This is the harness half of #48. **Retiring the mock `to_edf` tests** (`test_to_edf_export`/`test_to_edf_empty`, which test kwarg-forwarding) is deferred to a focused follow-up — they need real-export replacements for that plumbing coverage, and the harness already provides the real safety net. **#48 stays open** for that.