### PR TITLE
Fix EDF/BDF exporter scaling corruption (#61)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ env/
 
 # MkDocs
 site/
+
+# uv generates this on every `uv run`; this project pins via pyproject.toml only
+uv.lock

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -344,6 +344,7 @@ class EMG:
         verify_plot: bool = False,
         events_df: pd.DataFrame | None = None,
         create_channels_tsv: bool = True,
+        clip_outliers: bool | str = "auto",
         **kwargs,
     ) -> str | None:
         """
@@ -377,6 +378,12 @@ class EMG:
             events_df: Optional DataFrame with events ('onset', 'duration', 'description').
                       If None, uses self.events. (This provides flexibility)
             create_channels_tsv: If True, create a BIDS-compliant channels.tsv file (default: True)
+            clip_outliers: Singularity handling for the per-channel physical window.
+                'auto' (default) keeps the full range losslessly but clips rare extreme
+                outliers to a robust window only when keeping them would crater the bulk
+                signal's resolution at the chosen format (with a warning); True always
+                clips to the robust window; False never clips. See EDFExporter.export for
+                the advanced ``outlier_sigmas`` / ``min_effective_bits`` knobs.
             **kwargs: Additional arguments for the EDF exporter
 
         Returns:
@@ -441,6 +448,7 @@ class EMG:
             "bypass_analysis": final_bypass_analysis,
             "events_df": events_to_export,  # Pass the events dataframe
             "create_channels_tsv": create_channels_tsv,
+            "clip_outliers": clip_outliers,
             **kwargs,
         }
 

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -1,5 +1,7 @@
+import math
 import os
 import warnings
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal, InvalidOperation
 from typing import Literal
 
 import numpy as np
@@ -10,230 +12,192 @@ from ..analysis.signal import analyze_signal, determine_format_suitability
 from ..core.emg import EMG
 from ..core.modality import to_bids_channels_tsv_type
 
+# EDF and BDF share the same 256-byte-per-signal header layout: physical_min and
+# physical_max each occupy an 8-character ASCII field in BOTH formats (BDF's gain
+# is the 24-bit digital sample, not a wider physical field). pyedflib truncates a
+# physical value whose str() exceeds this, so the character budget is always 8.
+_PHYS_FIELD_CHARS = 8
 
-def _format_physical_value(value: float, max_chars: int) -> tuple:
+
+def _fit_physical_bound(value: float, *, round_up: bool, max_chars: int = _PHYS_FIELD_CHARS):
+    """Round a physical bound OUTWARD to fit the EDF/BDF 8-char header field.
+
+    pyedflib stores physical_min/physical_max as short ASCII and truncates any
+    value whose ``str()`` exceeds 8 characters, while any sample outside
+    [physical_min, physical_max] is saturated (clipped) on write. To guarantee
+    the stored window always brackets the signal we round AWAY from the data:
+    ``round_up=True`` returns the smallest representable value ``>= value`` (use
+    for physical_max); ``round_up=False`` returns the largest ``<= value`` (use
+    for physical_min). The result's ``str()`` fits ``max_chars`` whenever the
+    magnitude is representable; an integer part with more than ``max_chars`` digits
+    (|value| >= 1e8, or >= 1e7 once a sign is added) cannot fit, so the tightest
+    outward value is returned and the exporter rejects it with a clear unit-rescale
+    error rather than letting pyedflib truncate it. Containment (the bracket) always
+    holds. Because the digital range is mapped onto [physical_min, physical_max],
+    outward rounding is an affine rescale of the reconstruction and barely affects
+    correlation; clipping (which this prevents) is what destroys signal fidelity.
     """
-    Format a physical value to fit within EDF character limits.
+    if value == 0 or not math.isfinite(value):
+        return 0.0
+    rounding = ROUND_CEILING if round_up else ROUND_FLOOR
+    dec = Decimal(repr(float(value)))
+    exponent = dec.adjusted()  # power of ten of the most-significant digit
+    # Prefer the most significant figures that still fit (tightest bracket),
+    # stepping down to coarser rounding until the str() fits the field.
+    for sig in range(max_chars, 0, -1):
+        quantum = Decimal(1).scaleb(exponent - sig + 1)
+        try:
+            rounded = dec.quantize(quantum, rounding=rounding)
+        except InvalidOperation:
+            continue
+        out = int(rounded) if rounded == rounded.to_integral_value() else float(rounded)
+        # float() can land one ULP on the wrong side of the decimal; if so, take
+        # one more whole quantum outward so the bracket invariant always holds.
+        if round_up and out < value:
+            out = float(rounded + quantum)
+        elif not round_up and out > value:
+            out = float(rounded - quantum)
+        if len(str(out)) <= max_chars:
+            return out
+    # Extreme magnitude (more integer digits than the field holds): fall back to
+    # a single significant figure, still rounded outward.
+    quantum = Decimal(1).scaleb(exponent)
+    rounded = dec.quantize(quantum, rounding=rounding)
+    return int(rounded) if rounded == rounded.to_integral_value() else float(rounded)
 
-    Args:
-        value: Physical value to format
-        max_chars: Maximum number of characters allowed
 
-    Returns:
-        tuple: (formatted_value, formatted_string)
+# Tight percentile band used as the robust window only for a (near-)constant
+# bulk, where the median absolute deviation is zero and cannot define a scale.
+_CONSTANT_BULK_PERCENTILES = (0.1, 99.9)
+
+
+def _resolve_physical_window(
+    signal: np.ndarray,
+    use_bdf: bool,
+    clip_outliers,
+    outlier_sigmas: float,
+    min_effective_bits: float,
+) -> tuple:
+    """Decide the physical window [lo, hi] the header bounds will bracket.
+
+    EDF/BDF map the whole digital range onto [physical_min, physical_max], so a
+    single extreme outlier inflates the range and starves the bulk signal of
+    quantization levels. The robust window is the min/max of the *inliers* -
+    samples within ``outlier_sigmas`` robust standard deviations
+    (1.4826 x median-absolute-deviation) of the median - so only genuine
+    singularities fall outside it, not a fixed fraction of legitimate samples.
+    For a (near-)constant bulk the MAD is zero, so a tight percentile band is
+    used instead, which still isolates sparse spikes on a flat channel.
+
+    - ``clip_outliers=False``: always the full data range (purely lossless).
+    - ``clip_outliers="auto"`` (default): the full range, UNLESS keeping it would
+      push the bulk below ``min_effective_bits`` of resolution at the chosen
+      format, in which case the singular outliers are clipped to the robust
+      window so the recording survives.
+    - ``clip_outliers=True``: clip to the robust window whenever any sample lies
+      outside it (a no-op when there are no outliers).
+
+    Returns ``(lo, hi, n_clipped, max_excursion)``; ``n_clipped`` counts the
+    samples that will saturate and ``max_excursion`` is how far the worst one
+    lies beyond the window (both only for the caller's warning/report).
     """
-    # Handle NaN values
-    if np.isnan(value):
-        return 0.0, "0"
+    finite = signal[np.isfinite(signal)]
+    if finite.size == 0:
+        return 0.0, 0.0, 0, 0.0
+    smin = float(np.min(finite))
+    smax = float(np.max(finite))
+    full_range = smax - smin
+    if clip_outliers is False or full_range <= 0.0:
+        return smin, smax, 0, 0.0
 
-    # For zero or very small values, return as is
-    if abs(value) < 1e-6:
-        return 0.0, "0"
-
-    # For values close to integers, handle as integers
-    try:
-        if abs((value - round(value)) / value) < 1e-6:
-            value = int(round(value))  # Convert to integer
-            scale = 1
-            while True:
-                value_str = str(value)
-                if len(value_str) <= max_chars:
-                    return value, value_str
-                # Integer division to reduce digits
-                scale *= 10
-                value = value // 10
-    except (ValueError, ZeroDivisionError):
-        # Handle any other numerical issues
-        return 0.0, "0"
-
-    # For decimal numbers
-    if abs(value) < 1:
-        # Use scientific notation with reduced precision
-        for precision in range(6, 0, -1):
-            formatted = f"{value:.{precision}e}"
-            if len(formatted) <= max_chars:
-                return float(formatted), formatted
-        # If still too long, return minimal representation
-        return float(f"{value:.1e}"), f"{value:.1e}"
+    median = float(np.median(finite))
+    mad = float(np.median(np.abs(finite - median)))
+    if mad > 0.0:
+        threshold = outlier_sigmas * 1.4826 * mad
+        inliers = finite[np.abs(finite - median) <= threshold]
+        if inliers.size == 0:
+            inliers = finite
+        lo, hi = float(np.min(inliers)), float(np.max(inliers))
     else:
-        # For larger decimals, try fixed point first
-        scale = 1
-        scaled_value = value
-        while True:
-            # Try without any changes
-            formatted = f"{scaled_value}"
-            if len(formatted) <= max_chars:
-                return float(formatted), formatted
-            # If that doesn't work, scale down
-            scale *= 10
-            scaled_value = value / scale
-            # If we've scaled down a lot and still not fitting, switch to scientific
-            if scale > 1e9:
-                for precision in range(4, 0, -1):
-                    formatted = f"{value:.{precision}e}"
-                    if len(formatted) <= max_chars:
-                        return float(formatted), formatted
-                return float(f"{value:.1e}"), f"{value:.1e}"
+        lo, hi = (float(v) for v in np.percentile(finite, _CONSTANT_BULK_PERCENTILES))
+    core_range = hi - lo
+    if core_range <= 0.0:
+        return smin, smax, 0, 0.0
+
+    bits = 24 if use_bdf else 16
+    # Effective bits the bulk would retain if the full range were kept: every
+    # doubling of full/core range costs one bit of bulk resolution.
+    eff_bits_full = bits - math.log2(full_range / core_range) if full_range > core_range else bits
+    if clip_outliers == "auto" and eff_bits_full >= min_effective_bits:
+        return smin, smax, 0, 0.0  # the format absorbs the range; stay lossless
+
+    n_clipped = int(np.count_nonzero((finite < lo) | (finite > hi)))
+    if n_clipped == 0:
+        return smin, smax, 0, 0.0  # nothing actually outside the window
+    max_excursion = max(smax - hi, lo - smin, 0.0)
+    return lo, hi, n_clipped, float(max_excursion)
 
 
 def _determine_scaling_factors(
     signal_min: float, signal_max: float, use_bdf: bool = False
 ) -> tuple:
-    """
-    Calculate optimal scaling factors for EDF/BDF signal conversion.
-    Automatically scales values to fit format character limits.
+    """Compute EDF/BDF header scaling for a physical window [signal_min, signal_max].
+
+    Returns ``(physical_min, physical_max, digital_min, digital_max,
+    scaling_factor)``. physical_min/physical_max are rounded OUTWARD to the
+    8-char header field so the stored window always brackets the input window;
+    this is what stops pyedflib from saturating (clipping) the signal, which was
+    the source of the per-channel corruption in issue #61. The caller chooses the
+    window (full range by default, or a robust window when clipping genuine
+    outliers via :func:`_resolve_physical_window`). ``scaling_factor`` is
+    informational only: pyedflib derives its own digitization from the
+    physical/digital ranges and ignores this value.
 
     Args:
-        signal_min: Minimum value of the signal
-        signal_max: Maximum value of the signal
-        use_bdf: Whether to use BDF (24-bit) format
+        signal_min: Minimum physical value the window must contain.
+        signal_max: Maximum physical value the window must contain.
+        use_bdf: Whether to use BDF (24-bit) digital range.
 
     Returns:
         tuple: (physical_min, physical_max, digital_min, digital_max, scaling_factor)
     """
-    # Handle NaN values
-    if np.isnan(signal_min) or np.isnan(signal_max):
-        signal_min = -1e-6 if np.isnan(signal_min) else signal_min
-        signal_max = 1e-6 if np.isnan(signal_max) else signal_max
-
+    if np.isnan(signal_min):
+        signal_min = -1e-6
+    if np.isnan(signal_max):
+        signal_max = 1e-6
     if signal_min > signal_max:
         signal_min, signal_max = signal_max, signal_min
 
-    # Set digital range based on format
     if use_bdf:
         digital_min, digital_max = -8388608, 8388607  # 24-bit
-        max_chars = 12
     else:
         digital_min, digital_max = -32768, 32767  # 16-bit
-        max_chars = 8
-
-    # Handle special cases
-    if np.isclose(signal_min, signal_max):
-        if np.isclose(signal_min, 0):
-            # For zero signal, use minimal range around zero
-            # Use small values that will scale well with typical EMG signals
-            signal_min, signal_max = -1e-6, 1e-6
-        else:
-            # For constant non-zero signal, create range around the value
-            # Use a percentage of the value to maintain scale
-            margin = abs(signal_min) * 0.01  # 1% margin
-            signal_min -= margin
-            signal_max += margin
-            # Don't normalize constant signals - this preserves test behavior
-            return signal_min, signal_max, digital_min, digital_max, digital_max * 1.0
-
-    # Ensure physical range is never too small
-    physical_range = signal_max - signal_min
-    if abs(physical_range) < np.finfo(float).eps * 1e3:
-        # If range is effectively zero, create a minimal range
-        # Scale it relative to the signal magnitude
-        base = max(abs(signal_min), abs(signal_max), 1e-6)
-        physical_range = base * 1e-6
-        signal_max = signal_min + physical_range
-        # Ensure we have a valid range for scaling
-        if physical_range == 0:
-            physical_range = 1e-6
-
-    # For high dynamic range signals, preserve the original range
-    # This is critical for maintaining the dynamic range in the exported file
-    if (signal_max - signal_min) > 1e5 or (signal_max / max(abs(signal_min), 1e-10)) > 1e5:
-        # High dynamic range detected - preserve it for BDF format
-        if use_bdf:
-            # For BDF, we can handle the full range directly
-            # Just ensure the values fit within character limits
-            signal_min, _ = _format_physical_value(signal_min, max_chars)
-            signal_max, _ = _format_physical_value(signal_max, max_chars)
-
-            digital_range = digital_max - digital_min
-            physical_range = signal_max - signal_min
-
-            # Calculate scaling factor to use full digital range
-            scaling_factor = digital_range / physical_range
-
-            return signal_min, signal_max, digital_min, digital_max, scaling_factor
-
-    # Only normalize extreme values that would cause problems with EDF/BDF format
-    # This preserves the original scaling for most signals while handling extreme cases
-    if (
-        abs(signal_min) > 1e6
-        or abs(signal_max) > 1e6
-        or abs(signal_min) < 1e-6
-        or abs(signal_max) < 1e-6
-    ):
-        # For extreme values, normalize to a reasonable range
-        # But preserve the original ratio between min and max
-        ratio = abs(signal_max / signal_min) if signal_min != 0 else 1.0
-
-        if ratio > 1e6 and not use_bdf:  # Very large ratio, use a more balanced range for EDF only
-            signal_min = -1.0
-            signal_max = 1.0
-        else:  # Preserve ratio but scale to reasonable values
-            if abs(signal_min) > 1e6 or abs(signal_max) > 1e6:  # Too large
-                scale_factor = max(abs(signal_min), abs(signal_max)) / 1000.0
-                signal_min /= scale_factor
-                signal_max /= scale_factor
-            elif abs(signal_min) < 1e-6 or abs(signal_max) < 1e-6:  # Too small
-                scale_factor = 1e-3 / max(abs(signal_min), abs(signal_max))
-                signal_min *= scale_factor
-                signal_max *= scale_factor
-
-    # Format values to fit character limits
-    signal_min, _ = _format_physical_value(signal_min, max_chars)
-    signal_max, _ = _format_physical_value(signal_max, max_chars)
-
     digital_range = digital_max - digital_min
-    physical_range = signal_max - signal_min
 
-    # Calculate scaling factor
-    # We use slightly less than the full range to prevent overflow at boundaries
-    scaling_factor = (digital_range - 1) / physical_range
+    if np.isclose(signal_min, signal_max):
+        if np.isclose(signal_min, 0.0):
+            # Zero signal: minimal symmetric range around zero.
+            phys_min, phys_max = -1e-6, 1e-6
+        else:
+            # Constant non-zero signal: a 1% margin on each side keeps a valid,
+            # signal-scaled range that brackets the value.
+            margin = abs(signal_min) * 0.01
+            phys_min = _fit_physical_bound(signal_min - margin, round_up=False)
+            phys_max = _fit_physical_bound(signal_max + margin, round_up=True)
+    else:
+        phys_min = _fit_physical_bound(signal_min, round_up=False)
+        phys_max = _fit_physical_bound(signal_max, round_up=True)
 
-    return signal_min, signal_max, digital_min, digital_max, scaling_factor
+    # Guarantee a strictly positive physical range (pyedflib requires
+    # physical_min != physical_max), widening outward if rounding collapsed it.
+    if not phys_min < phys_max:
+        bump = max(abs(phys_min), abs(phys_max), 1e-6) * 1e-3
+        phys_max = _fit_physical_bound(phys_min + bump, round_up=True)
+        if not phys_min < phys_max:
+            phys_max = phys_min + bump
 
-
-def _calculate_precision_loss(
-    signal: np.ndarray, scaling_factor: float, digital_min: int, digital_max: int
-) -> float:
-    """
-    Calculate precision loss when scaling signal to digital values.
-
-    Args:
-        signal: Original signal values
-        scaling_factor: Scaling factor to convert to digital values
-        digital_min: Minimum digital value
-        digital_max: Maximum digital value
-
-    Returns:
-        float: Maximum relative precision loss as percentage
-    """
-    # Convert to integers (simulating digitization)
-    scaled = np.round(signal * scaling_factor)
-    digital_values = np.clip(scaled, digital_min, digital_max)
-    reconstructed = digital_values / scaling_factor
-
-    # Calculate relative error
-    abs_diff = np.abs(signal - reconstructed)
-    abs_signal = np.abs(signal)
-
-    # Avoid division by zero and very small values
-    eps = np.finfo(np.float32).eps
-    nonzero_mask = abs_signal > eps * 1e3
-    if not np.any(nonzero_mask):
-        return 0.0
-    # Make the first and last five sample zero, to compensate for diff (technically, only first and last one is enough)
-    nonzero_mask[0:5] = False
-    nonzero_mask[-5:] = False
-
-    relative_errors = np.zeros_like(signal)
-    relative_errors[nonzero_mask] = abs_diff[nonzero_mask] / abs_signal[nonzero_mask]
-
-    # Convert to percentage and ensure we detect small losses
-    max_loss = float(np.max(relative_errors) * 100)
-    if max_loss < np.finfo(np.float32).eps and np.any(abs_diff > 0):
-        # If we have any difference but relative error is too small to measure,
-        # return a small but non-zero value
-        return 1e-6
-    return max_loss
+    scaling_factor = (digital_range - 1) / (phys_max - phys_min)
+    return phys_min, phys_max, digital_min, digital_max, scaling_factor
 
 
 def summarize_channels(channels: dict, signals: dict, analyses: dict) -> str:
@@ -321,6 +285,9 @@ class EDFExporter:
         bypass_analysis: bool = False,
         events_df: pd.DataFrame | None = None,
         create_channels_tsv: bool = True,
+        clip_outliers: bool | str = "auto",
+        outlier_sigmas: float = 8.0,
+        min_effective_bits: float = 10.0,
         **kwargs,
     ) -> None:
         """
@@ -347,6 +314,22 @@ class EDFExporter:
                      Columns should include 'onset', 'duration', 'description'.
                      If None or empty, no annotations are written.
             create_channels_tsv: If True, create a BIDS-compliant channels.tsv file (default: True)
+            clip_outliers: Singularity handling for the per-channel physical window.
+                'auto' (default): keep the full data range losslessly, but clip rare
+                extreme outliers to a robust percentile window ONLY when keeping them
+                would drop the bulk signal below ``min_effective_bits`` of resolution
+                at the chosen format (a loud warning reports what was clipped). True:
+                always clip to the robust window. False: never clip (full range,
+                lossless even if a single outlier starves the bulk of resolution).
+            outlier_sigmas: Robust z-score threshold for the inlier window: samples
+                within ``outlier_sigmas`` x 1.4826 x median-absolute-deviation of the
+                median are inliers; the window is their min/max so only genuine
+                singularities are clipped (default 8.0).
+            min_effective_bits: Resolution floor (in bits) the bulk signal must keep
+                under 'auto'; outliers are clipped only if the full range would push
+                it below this (default 10.0, ~60 dB). Kept low so BDF's 24-bit range
+                preserves moderate outliers losslessly and only true singularities
+                (or forced/low-res EDF) trigger clipping.
             **kwargs: Additional arguments for the exporter
         """
         if emg.signals is None:
@@ -358,7 +341,6 @@ class EDFExporter:
         # Initialize format decision variables
         use_bdf = False
         bdf_reason = ""
-        format_decision_made = False
 
         # --- Format Decision and Bypass Check ---
         if bypass_analysis and format.lower() == "auto":
@@ -366,7 +348,6 @@ class EDFExporter:
 
         if format.lower() == "bdf":
             use_bdf = True
-            format_decision_made = True
             if not bypass_analysis:
                 print("\nUser specified BDF format (24-bit).")
             else:
@@ -374,7 +355,6 @@ class EDFExporter:
                 pass  # logging.log(logging.CRITICAL, "Skipping analysis, using specified BDF format.")
         elif format.lower() == "edf":
             use_bdf = False
-            format_decision_made = True
             if not bypass_analysis:
                 print("\nUser specified EDF format (16-bit).")
             else:
@@ -489,24 +469,55 @@ class EDFExporter:
                 signal = emg.signals[ch_name].values
                 ch_info = emg.channels[ch_name]
 
-                # Get signal min/max for scaling factor calculation (no copy needed)
-                # Handle edge case of empty or all-NaN signals
+                # Resolve the physical window the bounds will bracket. Handle the
+                # empty/all-NaN edge case, then choose the window (full range, or a
+                # robust window when 'auto'/True clips genuine singularities).
                 if signal.size == 0 or np.all(np.isnan(signal)):
                     warnings.warn(
                         f"Channel '{ch_name}' has an empty or all-NaN signal. "
                         "Using default min/max of 0.0 for scaling.",
                         stacklevel=2,
                     )
-                    signal_min = 0.0
-                    signal_max = 0.0
+                    win_lo, win_hi, n_clipped, max_excursion = 0.0, 0.0, 0, 0.0
                 else:
-                    signal_min = float(np.nanmin(signal))
-                    signal_max = float(np.nanmax(signal))
+                    win_lo, win_hi, n_clipped, max_excursion = _resolve_physical_window(
+                        signal, use_bdf, clip_outliers, outlier_sigmas, min_effective_bits
+                    )
+                    if n_clipped > 0:
+                        unit = ch_info["physical_dimension"]
+                        warnings.warn(
+                            f"Channel '{ch_name}': {n_clipped} outlier sample(s) "
+                            f"({100.0 * n_clipped / signal.size:.4f}%) will saturate to the "
+                            f"robust window [{win_lo:.6g}, {win_hi:.6g}] {unit}, preserving "
+                            f"{24 if use_bdf else 16}-bit resolution for the bulk signal "
+                            f"(max excursion {max_excursion:.6g} {unit}). "
+                            "Pass clip_outliers=False to keep the full range instead.",
+                            stacklevel=2,
+                        )
 
-                # Calculate scaling factors for header based on the chosen format (use_bdf)
-                phys_min, phys_max, dig_min, dig_max, scale_factor = _determine_scaling_factors(
-                    signal_min, signal_max, use_bdf=use_bdf
+                # Calculate scaling factors for header based on the chosen format (use_bdf).
+                # physical_min/max are rounded outward to bracket the window, so pyedflib
+                # never silently clips the bulk signal (issue #61).
+                # scaling_factor is informational (pyedflib derives its own from the
+                # physical/digital ranges); the bounds are what matter for fidelity.
+                phys_min, phys_max, dig_min, dig_max, _scaling = _determine_scaling_factors(
+                    win_lo, win_hi, use_bdf=use_bdf
                 )
+
+                # EDF/BDF store physical_min/max as 8-char ASCII. A magnitude needing
+                # more digits (|value| >= 1e8, or >= 1e7 once a sign is added) cannot be
+                # represented: pyedflib would truncate it and silently scale the channel
+                # by powers of ten (reintroducing the #61 corruption) or abort the write.
+                # Fail loudly here instead, before any bytes are written, with the only
+                # real remedy - rescale the channel to a coarser unit.
+                if len(str(phys_min)) > _PHYS_FIELD_CHARS or len(str(phys_max)) > _PHYS_FIELD_CHARS:
+                    raise ValueError(
+                        f"Channel '{ch_name}': physical range [{phys_min}, {phys_max}] "
+                        f"{ch_info['physical_dimension']} needs more than {_PHYS_FIELD_CHARS} "
+                        "characters and cannot be stored in the EDF/BDF header without corrupting "
+                        "the values. Rescale this channel to a coarser unit (e.g. uV -> mV -> V) "
+                        "so the magnitude fits."
+                    )
 
                 # Prepare channel header dictionary
                 ch_dict = {

--- a/emgio/tests/test_core.py
+++ b/emgio/tests/test_core.py
@@ -432,49 +432,6 @@ def test_plot_signals_time_range(sample_emg, mock_plt):
         assert len(data) < len(sample_emg.signals)  # Should be subset of data
 
 
-@pytest.fixture
-def mock_edf_exporter(monkeypatch):
-    """Mock EDF exporter for testing export functionality."""
-
-    class MockEDFExporter:
-        last_export = {}
-
-        @staticmethod
-        def export(
-            emg_obj,
-            filepath,
-            method="both",
-            fft_noise_range=None,
-            svd_rank=None,
-            precision_threshold=0.01,
-            format="auto",
-            bypass_analysis=False,
-            **kwargs,
-        ):
-            if not filepath.endswith(".edf") and not filepath.endswith(".bdf"):
-                raise ValueError("File must have .edf or .bdf extension")
-            # Store export parameters for verification
-            MockEDFExporter.last_export = {
-                "filepath": filepath,
-                "channels": list(emg_obj.channels.keys()),
-                "format": format,
-                "bypass_analysis": bypass_analysis,
-                "kwargs": kwargs,  # Only store the custom kwargs, not the default ones
-            }
-            return filepath
-
-    # Directly patch the EDFExporter in the exporters.edf module
-    from ..exporters import edf
-
-    original_exporter = edf.EDFExporter
-    monkeypatch.setattr(edf, "EDFExporter", MockEDFExporter)
-
-    yield MockEDFExporter
-
-    # Restore the original exporter after the test
-    monkeypatch.setattr(edf, "EDFExporter", original_exporter)
-
-
 def test_emg_add_event(empty_emg):
     """Test adding events to the EMG object."""
     assert empty_emg.events.empty
@@ -525,146 +482,53 @@ def test_add_event_integer_inputs_coerced_to_float(empty_emg):
     assert empty_emg.events.loc[0, "duration"] == 0.0
 
 
-def test_to_edf_export(sample_emg, mock_edf_exporter):
-    """Test EDF export functionality, including event passing."""
-    # Add some events to the sample emg object
-    sample_emg.add_event(onset=0.1, duration=0, description="Marker 1")
-    sample_emg.add_event(onset=0.5, duration=0.2, description="Activity Period")
+def test_to_edf_writes_real_file_and_channels_tsv(sample_emg, tmp_path):
+    """to_edf writes a real EDF/BDF file plus a BIDS channels.tsv by default."""
+    out = tmp_path / "out.edf"
+    sample_emg.to_edf(str(out), format="bdf", bypass_analysis=True)
+    written = out if out.exists() else out.with_suffix(".bdf")
+    assert written.exists()
+    assert written.with_name(written.stem + "_channels.tsv").exists()
+    reloaded = EMG.from_file(str(written), bids_channels="off")
+    assert set(reloaded.signals.columns) == {"EMG1", "ACC1"}
 
-    # Test basic export (default format='auto')
-    filepath = "test.edf"
-    sample_emg.to_edf(filepath)
 
-    assert mock_edf_exporter.last_export["filepath"] == filepath
-    assert set(mock_edf_exporter.last_export["channels"]) == {"EMG1", "ACC1"}
-    assert mock_edf_exporter.last_export["format"] == "auto"
-    assert mock_edf_exporter.last_export["bypass_analysis"] is False
-    # Check that events_df kwarg is present and contains the added events
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    pd.testing.assert_frame_equal(
-        mock_edf_exporter.last_export["kwargs"]["events_df"], sample_emg.events
+def test_to_edf_bypass_analysis_defaulting(sample_emg, tmp_path, capsys):
+    """Forced format skips analysis by default; 'auto' always analyzes.
+
+    The decision is observable in the exporter's output ('Summary skipped...' when
+    analysis is bypassed, 'Recommended Format:' when it runs), so this verifies
+    the real to_edf -> EDFExporter behaviour without mocking the exporter.
+    """
+    # Forced format, bypass=None (default) -> analysis skipped.
+    sample_emg.to_edf(str(tmp_path / "a.edf"), format="edf", bypass_analysis=None)
+    assert "Summary skipped as signal analysis was bypassed." in capsys.readouterr().out
+
+    # Forced format, bypass=False -> analysis runs.
+    sample_emg.to_edf(str(tmp_path / "b.edf"), format="edf", bypass_analysis=False)
+    out = capsys.readouterr().out
+    assert "Recommended Format:" in out and "Summary skipped" not in out
+
+    # 'auto' -> analysis runs even when bypass=True is requested (and ignored).
+    sample_emg.to_edf(str(tmp_path / "c.edf"), format="auto", bypass_analysis=True)
+    assert "Summary skipped" not in capsys.readouterr().out
+
+
+def test_to_edf_external_events_do_not_mutate_object(sample_emg, tmp_path):
+    """An external events_df is exported without altering the EMG object's events."""
+    sample_emg.add_event(onset=0.1, duration=0.0, description="Marker 1")
+    sample_emg.add_event(onset=0.5, duration=0.2, description="Activity")
+    external = pd.DataFrame([{"onset": 0.3, "duration": 0.1, "description": "External"}])
+    sample_emg.to_edf(
+        str(tmp_path / "ev.edf"), format="edf", bypass_analysis=True, events_df=external
     )
-    assert len(mock_edf_exporter.last_export["kwargs"]["events_df"]) == 2
-    assert "create_channels_tsv" in mock_edf_exporter.last_export["kwargs"]
-    assert mock_edf_exporter.last_export["kwargs"]["create_channels_tsv"] is True  # Default value
-    assert len(mock_edf_exporter.last_export["kwargs"]) == 2  # events_df + create_channels_tsv
-
-    # Test with specific format and additional kwargs (format=bdf should bypass analysis by default)
-    custom_kwargs = {"patient_id": "TEST001"}
-    sample_emg.to_edf(filepath, format="bdf", **custom_kwargs)
-    assert mock_edf_exporter.last_export["filepath"] == filepath
-    assert mock_edf_exporter.last_export["format"] == "bdf"
-    assert mock_edf_exporter.last_export["bypass_analysis"] is True
-    # Check that events_df is still passed along with custom kwargs
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    pd.testing.assert_frame_equal(
-        mock_edf_exporter.last_export["kwargs"]["events_df"], sample_emg.events
-    )
-    assert len(mock_edf_exporter.last_export["kwargs"]["events_df"]) == 2
-    assert mock_edf_exporter.last_export["kwargs"]["patient_id"] == "TEST001"
-    assert "create_channels_tsv" in mock_edf_exporter.last_export["kwargs"]
-    assert (
-        len(mock_edf_exporter.last_export["kwargs"]) == 3
-    )  # events_df + create_channels_tsv + patient_id
-
-    # Test passing an external events DataFrame
-    external_events = pd.DataFrame(
-        [{"onset": 0.3, "duration": 0.1, "description": "External Event"}]
-    )
-    sample_emg.to_edf(filepath, format="edf", events_df=external_events)
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    pd.testing.assert_frame_equal(
-        mock_edf_exporter.last_export["kwargs"]["events_df"], external_events
-    )
-    # Ensure the EMG object's internal events were not modified
-    assert len(sample_emg.events) == 2
-
-    # Test exporting with no events in the EMG object
-    empty_event_emg = EMG()
-    empty_event_emg.add_channel("CH1", np.array([1, 2, 3]), 100, "V", "EMG")
-    empty_event_emg.to_edf(filepath, format="edf")
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    assert mock_edf_exporter.last_export["kwargs"]["events_df"].empty
-    pd.testing.assert_frame_equal(
-        mock_edf_exporter.last_export["kwargs"]["events_df"], empty_event_emg.events
-    )
-
-    # --- Test bypass_analysis logic (Ensure events are still passed) ---
-
-    # Format forced, bypass=None (default) -> should bypass (True)
-    sample_emg.to_edf(filepath, format="edf", bypass_analysis=None)
-    assert mock_edf_exporter.last_export["format"] == "edf"
-    assert mock_edf_exporter.last_export["bypass_analysis"] is True
-    assert (
-        "events_df" in mock_edf_exporter.last_export["kwargs"]
-    )  # Ensure events_df is still passed
-    pd.testing.assert_frame_equal(
-        mock_edf_exporter.last_export["kwargs"]["events_df"], sample_emg.events
-    )
-
-    sample_emg.to_edf(filepath, format="bdf", bypass_analysis=None)
-    assert mock_edf_exporter.last_export["format"] == "bdf"
-    assert mock_edf_exporter.last_export["bypass_analysis"] is True
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    pd.testing.assert_frame_equal(
-        mock_edf_exporter.last_export["kwargs"]["events_df"], sample_emg.events
-    )
-
-    # Format forced, bypass=True -> should bypass (True)
-    sample_emg.to_edf(filepath, format="edf", bypass_analysis=True)
-    assert mock_edf_exporter.last_export["bypass_analysis"] is True
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    sample_emg.to_edf(filepath, format="bdf", bypass_analysis=True)
-    assert mock_edf_exporter.last_export["bypass_analysis"] is True
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-
-    # Format forced, bypass=False -> should NOT bypass (False)
-    sample_emg.to_edf(filepath, format="edf", bypass_analysis=False)
-    assert mock_edf_exporter.last_export["bypass_analysis"] is False
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    sample_emg.to_edf(filepath, format="bdf", bypass_analysis=False)
-    assert mock_edf_exporter.last_export["bypass_analysis"] is False
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-
-    # Format auto, bypass=None -> should NOT bypass (False)
-    sample_emg.to_edf(filepath, format="auto", bypass_analysis=None)
-    assert mock_edf_exporter.last_export["format"] == "auto"
-    assert mock_edf_exporter.last_export["bypass_analysis"] is False
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-
-    # Format auto, bypass=True -> should NOT bypass (False)
-    sample_emg.to_edf(filepath, format="auto", bypass_analysis=True)
-    assert mock_edf_exporter.last_export["bypass_analysis"] is False
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-
-    # Format auto, bypass=False -> should NOT bypass (False)
-    sample_emg.to_edf(filepath, format="auto", bypass_analysis=False)
-    assert mock_edf_exporter.last_export["bypass_analysis"] is False
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-
-    # --- End bypass_analysis tests ---
-
-    # Rerun test with specific format and additional kwargs to ensure final state is correct
-    custom_kwargs = {"patient_id": "TEST001"}
-    sample_emg.to_edf(filepath, format="bdf", **custom_kwargs)
-    assert mock_edf_exporter.last_export["filepath"] == filepath
-    assert mock_edf_exporter.last_export["format"] == "bdf"
-    assert mock_edf_exporter.last_export["bypass_analysis"] is True
-    assert "events_df" in mock_edf_exporter.last_export["kwargs"]
-    pd.testing.assert_frame_equal(
-        mock_edf_exporter.last_export["kwargs"]["events_df"], sample_emg.events
-    )
-    assert mock_edf_exporter.last_export["kwargs"]["patient_id"] == "TEST001"
-    assert "create_channels_tsv" in mock_edf_exporter.last_export["kwargs"]
-    assert (
-        len(mock_edf_exporter.last_export["kwargs"]) == 3
-    )  # events_df + create_channels_tsv + patient_id
+    assert len(sample_emg.events) == 2  # self.events untouched
 
 
-def test_to_edf_empty(empty_emg, mock_edf_exporter):
-    """Test EDF export with empty EMG object."""
+def test_to_edf_empty_raises(empty_emg, tmp_path):
+    """Exporting an EMG object with no signals raises ValueError."""
     with pytest.raises(ValueError):
-        empty_emg.to_edf("test.edf")
+        empty_emg.to_edf(str(tmp_path / "test.edf"))
 
 
 def test_add_channel_with_prefilter(empty_emg):

--- a/emgio/tests/test_core.py
+++ b/emgio/tests/test_core.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pyedflib
 import pytest
 
 from ..core.emg import EMG
@@ -513,16 +514,32 @@ def test_to_edf_bypass_analysis_defaulting(sample_emg, tmp_path, capsys):
     sample_emg.to_edf(str(tmp_path / "c.edf"), format="auto", bypass_analysis=True)
     assert "Summary skipped" not in capsys.readouterr().out
 
+    # Forced BDF mirrors forced EDF: bypass by default, analyze when bypass=False.
+    sample_emg.to_edf(str(tmp_path / "d.bdf"), format="bdf", bypass_analysis=None)
+    assert "Summary skipped as signal analysis was bypassed." in capsys.readouterr().out
+    sample_emg.to_edf(str(tmp_path / "e.bdf"), format="bdf", bypass_analysis=False)
+    assert "Recommended Format:" in capsys.readouterr().out
 
-def test_to_edf_external_events_do_not_mutate_object(sample_emg, tmp_path):
-    """An external events_df is exported without altering the EMG object's events."""
+
+def test_to_edf_external_events_are_written_and_object_untouched(sample_emg, tmp_path):
+    """The external events_df (not self.events) is what reaches the file, and the
+    EMG object's own events are left intact.
+
+    Forwarding is verified by reading the EDF+ annotations back with pyedflib
+    directly (emgio's own annotation read-back is pending #47).
+    """
     sample_emg.add_event(onset=0.1, duration=0.0, description="Marker 1")
     sample_emg.add_event(onset=0.5, duration=0.2, description="Activity")
     external = pd.DataFrame([{"onset": 0.3, "duration": 0.1, "description": "External"}])
-    sample_emg.to_edf(
-        str(tmp_path / "ev.edf"), format="edf", bypass_analysis=True, events_df=external
-    )
+    out = tmp_path / "ev.edf"
+    sample_emg.to_edf(str(out), format="edf", bypass_analysis=True, events_df=external)
+
     assert len(sample_emg.events) == 2  # self.events untouched
+
+    with pyedflib.EdfReader(str(out)) as reader:
+        descriptions = list(reader.readAnnotations()[2])
+    assert "External" in descriptions
+    assert "Marker 1" not in descriptions and "Activity" not in descriptions
 
 
 def test_to_edf_empty_raises(empty_emg, tmp_path):

--- a/emgio/tests/test_edf_scaling.py
+++ b/emgio/tests/test_edf_scaling.py
@@ -1,0 +1,294 @@
+"""Soundness + edge-case tests for EDF/BDF physical-window scaling (issue #61).
+
+The exporter must never silently clip the bulk signal: physical_min/physical_max
+have to bracket whatever is written, fit the 8-char EDF/BDF header field, and a
+genuine singularity must be handled deliberately (auto-protect) rather than
+corrupting the recording. These tests pin those invariants directly on the
+scaling helpers and end-to-end on real fixtures with controlled perturbations.
+NO MOCKS: real signal arrays and real EDF/BDF round-trips.
+"""
+
+import pathlib
+
+import numpy as np
+import pyedflib
+import pytest
+
+from emgio import EMG
+from emgio.exporters.edf import (
+    _PHYS_FIELD_CHARS,
+    _determine_scaling_factors,
+    _fit_physical_bound,
+    _resolve_physical_window,
+)
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EX = _REPO / "examples"
+EMG_FIXTURE = EX / "bids/emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
+
+# A diverse set of bound values: integers, decimals, scientific-scale, both signs,
+# tiny and large magnitudes; the invariants below must hold for every one.
+_BOUND_VALUES = [
+    0.0,
+    1.0,
+    -1.0,
+    0.5,
+    -0.5,
+    12.57,
+    -357.512,
+    2325.4321,
+    -2325.4321,
+    616.7234,
+    0.0001234,
+    -0.0002587,
+    1e-6,
+    -1e-6,
+    1e5,
+    -1e5,
+    999999.9,
+    -999999.9,
+    0.01698,
+    1.4730512e4,
+    3.0,
+    -360.0,
+    22254.7,
+    -7481.3,
+    130.0,
+]
+
+
+@pytest.mark.parametrize("value", _BOUND_VALUES)
+def test_fit_physical_bound_brackets_and_fits(value):
+    """A fitted bound always rounds outward and fits the 8-char header field."""
+    up = _fit_physical_bound(value, round_up=True)
+    down = _fit_physical_bound(value, round_up=False)
+    assert np.isfinite(up) and np.isfinite(down)
+    assert len(str(up)) <= _PHYS_FIELD_CHARS, f"{up!r} exceeds {_PHYS_FIELD_CHARS} chars"
+    assert len(str(down)) <= _PHYS_FIELD_CHARS, f"{down!r} exceeds {_PHYS_FIELD_CHARS} chars"
+    if value != 0.0:
+        assert up >= value, f"round_up({value}) -> {up} did not bracket above"
+        assert down <= value, f"round_down({value}) -> {down} did not bracket below"
+
+
+def test_fit_physical_bound_random_sweep():
+    """Containment + field-fit over a randomized magnitude sweep (deterministic)."""
+    rng = np.random.default_rng(1234)
+    mags = 10.0 ** rng.uniform(-6, 6, size=2000)
+    signs = rng.choice([-1.0, 1.0], size=2000)
+    for v in (mags * signs).tolist():
+        up = _fit_physical_bound(v, round_up=True)
+        down = _fit_physical_bound(v, round_up=False)
+        assert up >= v and down <= v, f"bracket failed for {v}: [{down}, {up}]"
+        assert len(str(up)) <= _PHYS_FIELD_CHARS
+        assert len(str(down)) <= _PHYS_FIELD_CHARS
+
+
+def test_fit_physical_bound_zero():
+    assert _fit_physical_bound(0.0, round_up=True) == 0.0
+    assert _fit_physical_bound(0.0, round_up=False) == 0.0
+
+
+@pytest.mark.parametrize("use_bdf", [False, True])
+def test_determine_scaling_factors_brackets(use_bdf):
+    """physical_min <= signal_min < signal_max <= physical_max for every window."""
+    rng = np.random.default_rng(7)
+    cases = [
+        (-1.0, 1.0),
+        (0.0, 12.57),
+        (-357.5, 616.7),
+        (-2325.0, -1243.0),
+        (584.3, 12250.0),
+        (-1e4, 3026.0),
+        (1e-5, 2e-5),
+        (-1e6, 1e6),
+    ]
+    cases += [tuple(sorted(rng.uniform(-5e4, 5e4, size=2))) for _ in range(200)]
+    for smin, smax in cases:
+        pmin, pmax, dmin, dmax, _ = _determine_scaling_factors(smin, smax, use_bdf=use_bdf)
+        assert pmin <= smin, f"pmin {pmin} > smin {smin}"
+        assert pmax >= smax, f"pmax {pmax} < smax {smax}"
+        assert pmin < pmax, f"degenerate window [{pmin}, {pmax}] for [{smin}, {smax}]"
+        assert len(str(pmin)) <= _PHYS_FIELD_CHARS
+        assert len(str(pmax)) <= _PHYS_FIELD_CHARS
+        if use_bdf:
+            assert (dmin, dmax) == (-8388608, 8388607)
+        else:
+            assert (dmin, dmax) == (-32768, 32767)
+
+
+def test_determine_scaling_factors_special_cases():
+    """Zero, constant, NaN and tiny-range windows stay valid (pmin < pmax)."""
+    pmin, pmax, *_ = _determine_scaling_factors(0.0, 0.0)
+    assert (pmin, pmax) == (-1e-6, 1e-6)
+
+    pmin, pmax, *_ = _determine_scaling_factors(1.0, 1.0)
+    assert pmin <= 1.0 <= pmax and pmin < pmax
+
+    pmin, pmax, *_ = _determine_scaling_factors(np.nan, np.nan)
+    assert pmin < pmax
+
+    # Extremely narrow range must not collapse to a zero-width window.
+    pmin, pmax, *_ = _determine_scaling_factors(1.0000001, 1.0000002)
+    assert pmin < pmax and pmin <= 1.0000001 and pmax >= 1.0000002
+
+
+def _sine(n=4000, amp=1.0, off=0.0, seed=0):
+    rng = np.random.default_rng(seed)
+    t = np.linspace(0, 1, n)
+    return amp * np.sin(2 * np.pi * 10 * t) + 0.05 * amp * rng.standard_normal(n) + off
+
+
+def test_resolve_window_clean_signal_is_full_range():
+    x = _sine()
+    lo, hi, n_clip, _ = _resolve_physical_window(x, False, "auto", 8.0, 10.0)
+    assert n_clip == 0
+    assert lo <= x.min() and hi >= x.max()
+
+
+def test_resolve_window_auto_clips_single_spike_in_edf():
+    """One huge spike on a small bulk: auto+EDF clips ONLY the spike."""
+    x = _sine(amp=0.5)
+    x[2000] = 500.0  # singular outlier ~1000x the bulk
+    lo, hi, n_clip, exc = _resolve_physical_window(x, False, "auto", 8.0, 10.0)
+    assert n_clip == 1, f"expected exactly one clipped sample, got {n_clip}"
+    assert hi < 500.0 and exc > 1.0
+    assert lo <= -0.4 and hi >= 0.4  # bulk fully inside the window
+
+
+def test_resolve_window_bdf_absorbs_outlier_that_edf_cannot():
+    """An outlier ~500x the bulk: 24-bit BDF keeps it; 16-bit EDF must clip it.
+
+    24-bit leaves the bulk ~16 effective bits (above the 10-bit floor), so BDF
+    stays lossless; 16-bit would drop the bulk to ~8 bits, so EDF clips the spike.
+    """
+    x = _sine(amp=1.0)
+    x[2000] = 500.0
+    _, _, n_clip_bdf, _ = _resolve_physical_window(x, True, "auto", 8.0, 10.0)
+    _, _, n_clip_edf, _ = _resolve_physical_window(x, False, "auto", 8.0, 10.0)
+    assert n_clip_bdf == 0, "BDF should absorb the outlier losslessly"
+    assert n_clip_edf == 1, "16-bit EDF cannot, so the spike is clipped"
+
+
+def test_resolve_window_false_never_clips():
+    x = _sine(amp=0.5)
+    x[2000] = 1e4
+    lo, hi, n_clip, _ = _resolve_physical_window(x, False, False, 8.0, 10.0)
+    assert n_clip == 0 and lo <= x.min() and hi >= x.max()
+
+
+def test_resolve_window_constant_bulk_with_spikes():
+    """Marker/status channel: constant level with sparse glitch spikes (CH75-like)."""
+    x = np.full(6000, 199.0)
+    x[1000:1006] = -7481.0  # six singular glitches
+    lo, hi, n_clip, _ = _resolve_physical_window(x, False, "auto", 8.0, 10.0)
+    assert n_clip == 6
+    assert lo >= -10.0 and hi <= 210.0  # window snaps to the constant level, not the glitches
+
+
+def test_resolve_window_true_is_noop_without_outliers():
+    x = _sine()
+    lo, hi, n_clip, _ = _resolve_physical_window(x, False, True, 8.0, 10.0)
+    assert n_clip == 0 and lo <= x.min() and hi >= x.max()
+
+
+# ----------------------------- end-to-end on files -----------------------------
+
+
+def _export_reload(emg, tmp_path, **kw):
+    out = tmp_path / "case.edf"
+    emg.to_edf(str(out), **kw)
+    written = out if out.exists() else out.with_suffix(".bdf")
+    return EMG.from_file(str(written), bids_channels="off"), written
+
+
+@pytest.mark.parametrize(
+    "amp,off,fmt",
+    [(0.5, 0.0, "edf"), (1e6, 0.0, "bdf"), (1e-5, 0.0, "bdf"), (1.0, 5000.0, "edf")],
+)
+def test_export_never_clips_within_header_window(tmp_path, amp, off, fmt):
+    """Every reloaded sample lies inside the stored physical window (no overflow)."""
+    emg = EMG()
+    emg.add_channel("S", _sine(amp=amp, off=off), 1000, "uV", "EMG")
+    reloaded, written = _export_reload(emg, tmp_path, format=fmt, bypass_analysis=True)
+    with pyedflib.EdfReader(str(written)) as r:
+        h = r.getSignalHeaders()[0]
+    vals = reloaded.signals["S"].values
+    eps = (h["physical_max"] - h["physical_min"]) * 1e-6
+    assert vals.min() >= h["physical_min"] - eps
+    assert vals.max() <= h["physical_max"] + eps
+
+
+@pytest.mark.parametrize("constant", [0.0, 1.0, -3.5])
+def test_export_constant_and_zero_channels(tmp_path, constant):
+    emg = EMG()
+    emg.add_channel("C", np.full(2000, constant), 1000, "uV", "EMG")
+    reloaded, _ = _export_reload(emg, tmp_path, format="bdf", bypass_analysis=True)
+    assert np.allclose(reloaded.signals["C"].values, constant, atol=1e-3)
+
+
+@pytest.mark.skipif(not EMG_FIXTURE.exists(), reason="EMG fixture missing")
+def test_singularity_protection_recovers_bulk(tmp_path):
+    """Auto-protect on a real channel + injected spike: bulk correlation survives.
+
+    With clip_outliers='auto' the lone spike is clipped so the bulk keeps full
+    16-bit resolution (r ~ 1.0); with clip_outliers=False the spike inflates the
+    range and the bulk loses resolution. Auto must do at least as well, and meet
+    the >0.99 bar that clipping is meant to protect.
+    """
+    emg = EMG.from_file(str(EMG_FIXTURE))
+    ch = list(emg.channels)[0]
+    base = emg.signals[ch].values.astype(float).copy()
+    spike_idx = len(base) // 2
+    emg.signals.iloc[spike_idx, emg.signals.columns.get_loc(ch)] = base.max() * 500.0
+    bulk = np.ones(len(base), bool)
+    bulk[spike_idx] = False
+
+    def bulk_r(clip):
+        reloaded, _ = _export_reload(
+            emg, tmp_path, format="edf", bypass_analysis=True, clip_outliers=clip
+        )
+        rel = reloaded.signals[ch].values.astype(float)[: len(base)]
+        return float(np.corrcoef(base[bulk], rel[bulk])[0, 1])
+
+    r_auto = bulk_r("auto")
+    r_none = bulk_r(False)
+    assert r_auto > 0.99, f"auto-protect bulk correlation too low: {r_auto}"
+    assert r_auto >= r_none - 1e-6, f"auto ({r_auto}) worse than no-clip ({r_none})"
+
+
+# ---- magnitude limit: EDF/BDF physical fields are 8 chars (audit finding) ----
+
+
+@pytest.mark.parametrize("value", [1e7, -1e7, 1e8, -1e8, 1.2e8, -1.2e8, 1e9, -1e9, 1e10])
+def test_fit_physical_bound_brackets_extreme_magnitudes(value):
+    """Containment must hold even when a magnitude is too wide for the 8-char field.
+
+    The bracket invariant is unconditional; only the 8-char fit is conditional
+    (the exporter enforces representability separately).
+    """
+    assert _fit_physical_bound(value, round_up=True) >= value
+    assert _fit_physical_bound(value, round_up=False) <= value
+
+
+@pytest.mark.parametrize("fmt", ["edf", "bdf"])
+def test_export_rejects_unrepresentable_magnitude(tmp_path, fmt):
+    """A bulk spanning +/-2e7 needs a 9-char physical_min (sign + 8 digits).
+
+    pyedflib would silently truncate it (e.g. -20000000 -> -2000000, a 10x error
+    that re-creates the #61 corruption), so the exporter must reject it loudly
+    before writing, for BOTH formats (the physical field is 8 chars in each).
+    """
+    emg = EMG()
+    emg.add_channel("BIG", _sine(amp=2e7), 1000, "uV", "EMG")
+    with pytest.raises(ValueError, match="cannot be stored in the EDF/BDF header"):
+        emg.to_edf(str(tmp_path / "big.edf"), format=fmt, bypass_analysis=True, clip_outliers=False)
+
+
+def test_export_rejects_huge_positive_offset(tmp_path):
+    """A large positive DC offset (~1.2e8) also overflows the 8-char field."""
+    emg = EMG()
+    emg.add_channel("OFF", _sine(amp=1000.0) + 1.2e8, 1000, "uV", "EMG")
+    with pytest.raises(ValueError, match="cannot be stored"):
+        emg.to_edf(
+            str(tmp_path / "off.bdf"), format="bdf", bypass_analysis=True, clip_outliers=False
+        )

--- a/emgio/tests/test_exporters.py
+++ b/emgio/tests/test_exporters.py
@@ -13,7 +13,7 @@ from ..analysis.signal import analyze_signal_fft as _analyze_signal_fft
 from ..analysis.signal import analyze_signal_svd as _analyze_signal_svd
 from ..analysis.signal import find_elbow_point as _find_elbow_point
 from ..core.emg import EMG
-from ..exporters.edf import EDFExporter, _calculate_precision_loss, _determine_scaling_factors
+from ..exporters.edf import EDFExporter, _determine_scaling_factors
 
 
 @pytest.fixture
@@ -164,27 +164,6 @@ def test_determine_scaling_factors():
     phys_min, phys_max, dig_min, dig_max, scaling = _determine_scaling_factors(0.0, 0.0)
     assert phys_min == -1.0e-6  # Small range around zero
     assert phys_max == 1.0e-6
-
-
-def test_calculate_precision_loss():
-    """Test precision loss calculation."""
-    # Create test signal
-    signal = np.array([-1.0, -0.5, 0.0, 0.5, 1.0])
-
-    # Test with scaling that maps to full 16-bit range
-    scaling_factor = (32767 - (-32768) - 1) / (1.0 - (-1.0))
-    loss = _calculate_precision_loss(signal, scaling_factor, -32768, 32767)
-    assert loss < 0.01  # Minimal loss expected
-
-    # Test with reduced scaling (some loss)
-    scaling_factor_half = scaling_factor / 2.0
-    loss = _calculate_precision_loss(signal, scaling_factor_half, -32768, 32767)
-    assert loss > 0.0  # Should have some loss
-
-    # Test with zero signal
-    signal = np.zeros(5)
-    loss = _calculate_precision_loss(signal, scaling_factor, -32768, 32767)
-    assert loss == 0.0
 
 
 def test_edf_export(sample_emg):

--- a/emgio/tests/test_roundtrip.py
+++ b/emgio/tests/test_roundtrip.py
@@ -146,7 +146,10 @@ def test_roundtrip_preserves_signal_values(case):
         compared += 1
         ptp = float(np.ptp(original))
         if ptp <= _CONST_PTP or np.std(original) == 0.0:
-            nrmse = float(np.sqrt(np.mean((original - roundtripped) ** 2)) / (ptp or 1.0))
+            # Near-constant channel: normalize by 1.0 (raw RMSE), never by the
+            # tiny ptp, which would blow a single-LSB error up past tolerance.
+            divisor = ptp if ptp > _CONST_PTP else 1.0
+            nrmse = float(np.sqrt(np.mean((original - roundtripped) ** 2)) / divisor)
             assert nrmse < case.tolerance, f"{case.name}:{ch} near-constant nrmse {nrmse:.3g}"
             continue
         corr = float(np.corrcoef(original, roundtripped)[0, 1])

--- a/emgio/tests/test_roundtrip.py
+++ b/emgio/tests/test_roundtrip.py
@@ -1,9 +1,16 @@
 """Real-data round-trip harness (issue #48).
 
 Imports every real fixture, exports it to EDF/BDF, reimports, and checks signal
-integrity with the real ``compare_signals`` metrics. This is the grounding
-backbone the mock-based ``to_edf`` tests lacked (a mock exporter never wrote
-real bytes, which is how the 1-second truncation bug shipped). NO MOCKS.
+integrity. This is the grounding backbone the mock-based ``to_edf`` tests lacked
+(a mock exporter never wrote real bytes, which is how the 1-second truncation bug
+shipped). NO MOCKS.
+
+Fidelity is judged on a random 10-second window with per-channel Pearson
+correlation > 0.99, the exemplar metric a conversion must meet; near-constant
+channels (markers/flat references) have undefined correlation and are checked by
+NRMSE instead. This is stricter than amplitude-relative NRMSE alone, which can
+stay small even when quantization has destroyed a channel's waveform (the #61
+class of bug).
 
 Known limitations are asserted explicitly rather than skipped:
 - mixed per-channel sample rates (XDF, Trigno) must fail loudly on export;
@@ -18,10 +25,10 @@ import shutil
 import tempfile
 from dataclasses import dataclass
 
+import numpy as np
 import pytest
 
 from emgio import EMG
-from emgio.analysis.verification import compare_signals
 
 # Round-trips are expensive; compute each fixture's once and share it across the
 # structural and value-integrity tests.
@@ -33,6 +40,10 @@ _REPO = pathlib.Path(__file__).resolve().parents[2]
 EX = _REPO / "examples"
 BIDS = EX / "bids"
 
+_RNG = np.random.default_rng(0)
+_WINDOW_S = 10.0  # exemplar fidelity window
+_CONST_PTP = 1e-9  # below this peak-to-peak a channel has no defined correlation
+
 
 @dataclass(frozen=True)
 class Case:
@@ -40,50 +51,32 @@ class Case:
     path: pathlib.Path
     importer: str | None
     has_emg: bool  # whether EMG channels are legitimately present at import
-    # Whether per-channel signal VALUES round-trip cleanly. emg/ieeg currently
-    # do not, due to the exporter per-channel scaling bug (#61); their value
-    # check is xfailed below until that is fixed.
-    value_clean: bool = False
-    tolerance: float = 0.05
+    tolerance: float = 0.05  # NRMSE tolerance for near-constant channels
 
 
-# Single-rate fixtures. Structural integrity (no sample loss, channel count,
-# no modality creep) holds for all; signal-VALUE integrity is xfailed for the
-# ones hitting the exporter scaling bug (#61).
+# Single-rate fixtures spanning EMG / iEEG / EEG / OTB. Structural integrity and
+# per-channel waveform fidelity (r > 0.99) must hold for all after the #61 fix.
 ROUNDTRIP_CASES = [
     Case(
         "emg",
         BIDS / "emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf",
         None,
         has_emg=True,
-        value_clean=False,
     ),
     Case(
         "ieeg",
         BIDS / "ieeg/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-stim_run-08_ieeg.edf",
         None,
         has_emg=False,
-        value_clean=False,
     ),
     Case(
         "eeg",
         BIDS / "eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set",
         "eeglab",
         has_emg=False,
-        value_clean=True,
     ),
-    Case("otb", EX / "one_sessantaquattro_truncated.otb+", "otb", has_emg=True, value_clean=True),
+    Case("otb", EX / "one_sessantaquattro_truncated.otb+", "otb", has_emg=True),
 ]
-
-
-def _value_param(case):
-    """Parametrize value-integrity, xfailing fixtures blocked by the #61 bug."""
-    if case.value_clean:
-        return case
-    return pytest.param(
-        case,
-        marks=pytest.mark.xfail(reason="exporter per-channel scaling corruption, #61", strict=True),
-    )
 
 
 # Mixed per-channel sample rate -> EDF export must raise (one rate per file).
@@ -124,20 +117,43 @@ def test_roundtrip_preserves_structure(case):
         assert not reloaded_emg, f"{case.name}: EMG channels appeared after round-trip"
 
 
-@pytest.mark.parametrize("case", [_value_param(c) for c in ROUNDTRIP_CASES], ids=lambda c: c.name)
+@pytest.mark.parametrize("case", ROUNDTRIP_CASES, ids=lambda c: c.name)
 def test_roundtrip_preserves_signal_values(case):
-    """Every channel's values survive the round-trip within tolerance.
+    """Per-channel waveform fidelity on a random 10 s window (r > 0.99).
 
-    xfail for emg/ieeg pending the exporter per-channel scaling fix (#61).
+    Channels with meaningful variance must reach Pearson r > 0.99 after the real
+    EDF/BDF round-trip; near-constant channels have undefined correlation, so
+    their value is checked by NRMSE instead. Proves the #61 corruption is gone
+    (corrupted channels collapse to r ~ 0 even when amplitude-relative NRMSE
+    stays small).
     """
     if not case.path.exists():
         pytest.skip(f"fixture missing: {case.path}")
     emg, reloaded = _roundtrip(case)
-    results = compare_signals(emg, reloaded, tolerance=case.tolerance)
-    compared = {k: v for k, v in results.items() if k != "channel_summary"}
+
+    rate = max(int(c["sample_frequency"]) for c in emg.channels.values())
+    n = emg.signals.shape[0]
+    width = min(int(_WINDOW_S * rate), n)
+    start = int(_RNG.integers(0, n - width + 1)) if n > width else 0
+    window = slice(start, start + width)
+
+    compared = 0
+    low_corr = []
+    for ch in emg.channels:
+        assert ch in reloaded.signals.columns, f"{case.name}: channel '{ch}' lost on reload"
+        original = emg.signals[ch].values[window].astype(float)
+        roundtripped = reloaded.signals[ch].values[window].astype(float)
+        compared += 1
+        ptp = float(np.ptp(original))
+        if ptp <= _CONST_PTP or np.std(original) == 0.0:
+            nrmse = float(np.sqrt(np.mean((original - roundtripped) ** 2)) / (ptp or 1.0))
+            assert nrmse < case.tolerance, f"{case.name}:{ch} near-constant nrmse {nrmse:.3g}"
+            continue
+        corr = float(np.corrcoef(original, roundtripped)[0, 1])
+        if not corr > 0.99:
+            low_corr.append((ch, round(corr, 4)))
     assert compared, "no channels were compared"
-    not_identical = [k for k, v in compared.items() if not v["is_identical"]]
-    assert not not_identical, f"{case.name}: channels differ after round-trip: {not_identical}"
+    assert not low_corr, f"{case.name}: channels below r>0.99: {low_corr}"
 
 
 @pytest.mark.parametrize("case", MIXED_RATE_CASES, ids=lambda c: c.name)


### PR DESCRIPTION
## Summary
Fixes #61: the EDF/BDF exporter set `physical_min/max` **narrower** than the signal (inward rounding + a normalization that divided a bound by up to 12000x), so pyedflib silently saturated the bulk. Real fixtures round-tripped at r~0.04-0.83. Discovered by the #48 round-trip harness.

## Fix
- **Containment:** `physical_min/max` round **outward** to bracket the data and fit the 8-char header field (8 chars for **both** EDF and BDF; fixes the latent `max_chars=12` BDF bug). No silent clipping; correlation is affine-invariant so bound rounding is ~free.
- **Auto-protect singularities:** a true outlier (robust MAD-based detection) is clipped to the inlier window **only when** keeping it would push the bulk below `min_effective_bits` at the chosen format, always with a warning + report. 24-bit BDF preserves moderate outliers losslessly. New knobs: `clip_outliers` (default `"auto"`), `outlier_sigmas`, `min_effective_bits`.
- **Magnitude guard:** physical values that cannot fit the 8-char field (|v|>=1e7 negative / >=1e8) are rejected with a clear unit-rescale error instead of being silently truncated ~10x by pyedflib.
- **Dead code removed:** `_calculate_precision_loss`, `_format_physical_value`, `format_decision_made`.

## Verification (real data, NO MOCKS)
Random 10s-window per-channel Pearson r after import->auto->reimport:

| fixture | format | worst r |
|---|---|---|
| EMG (BIDS) | EDF | 1.00000 |
| iEEG (BIDS) | EDF | 1.00000 |
| EEG (EEGLAB) | EDF | 0.99999 |
| OTB | BDF | 1.00000 |

Injected-spike bulk: r=1.0 with auto-protect vs 0.99992 unclipped. Near-constant marker channels handled by NRMSE.

## Soundness audit
Ran a multi-agent adversarial audit (5 lenses x verify). 7 confirmed findings -> 2 distinct defects, both fixed here: (1) the 8-char magnitude overflow (silent 10x truncation for negative 1e7-1e8), (2) dead `format_decision_made`. The 5 not-a-bug verdicts confirmed the auto-protect/MAD logic is lossless-optimal.

## Tests
- New `test_edf_scaling.py`: containment property sweeps, MAD window resolver, singularity protection, edge cases (zero/constant/NaN/huge/tiny), magnitude rejection.
- `test_roundtrip.py`: fidelity gate upgraded to 10s-window r>0.99; #61 xfails removed.
- Retired brittle mock `to_edf` tests for real ones (finishes #48 mock retirement).

Full suite: 298 passed, 3 skipped, 1 xfailed (annotation read-back, #47).