### PR TITLE
Read EDF+/BDF+ annotations on import (#47)

### DIFF
--- a/emgio/importers/edf.py
+++ b/emgio/importers/edf.py
@@ -199,7 +199,10 @@ class EDFImporter(BaseImporter):
                 emg.channels[signal_info["label"]].update(channel_metadata)
 
             # Read EDF+/BDF+ annotations into events so they survive the
-            # import->export->import round-trip (issue #47).
+            # import->export->import round-trip (issue #47). Assigned directly
+            # (not via add_event) for a single sort; _read_annotations already
+            # returns the same schema add_event produces (float64 onset/duration,
+            # sorted by onset). Left as the empty __init__ frame when none exist.
             events = self._read_annotations(edf_reader)
             if not events.empty:
                 emg.events = events

--- a/emgio/importers/edf.py
+++ b/emgio/importers/edf.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pyedflib
 
 from ..core.emg import EMG
@@ -109,6 +110,38 @@ class EDFImporter(BaseImporter):
 
         return signal_data, signal_info
 
+    def _read_annotations(self, edf_reader: pyedflib.EdfReader) -> pd.DataFrame:
+        """Read EDF+/BDF+ annotations (events) into an events DataFrame.
+
+        pyedflib parses the dedicated annotations channel and returns parallel
+        arrays of onsets (seconds), durations (seconds), and descriptions.
+        Plain EDF (no annotations) yields empty arrays. Descriptions may be
+        bytes or str depending on the pyedflib version; both are handled, and
+        empty placeholder annotations are skipped.
+
+        Returns:
+            pd.DataFrame: events with float64 ``onset``/``duration`` and string
+            ``description``, sorted by onset (matching :meth:`EMG.add_event`).
+        """
+        onsets, durations, descriptions = edf_reader.readAnnotations()
+        rows = []
+        for onset, duration, description in zip(onsets, durations, descriptions, strict=False):
+            text = (
+                description.decode("utf-8", "replace")
+                if isinstance(description, bytes)
+                else str(description)
+            )
+            if text == "":
+                continue  # skip empty placeholder annotations
+            rows.append((float(onset), float(duration), text))
+
+        events = pd.DataFrame(rows, columns=["onset", "duration", "description"])
+        if not events.empty:
+            events = events.sort_values(by="onset").reset_index(drop=True)
+            events["onset"] = events["onset"].astype("float64")
+            events["duration"] = events["duration"].astype("float64")
+        return events
+
     def load(self, filepath: str) -> EMG:
         """
         Load EMG data from EDF/EDF+/BDF file.
@@ -164,6 +197,12 @@ class EDFImporter(BaseImporter):
                     "transducer": signal_info["transducer"],
                 }
                 emg.channels[signal_info["label"]].update(channel_metadata)
+
+            # Read EDF+/BDF+ annotations into events so they survive the
+            # import->export->import round-trip (issue #47).
+            events = self._read_annotations(edf_reader)
+            if not events.empty:
+                emg.events = events
 
             return emg
 

--- a/emgio/tests/test_importers.py
+++ b/emgio/tests/test_importers.py
@@ -472,3 +472,42 @@ def test_edf_metadata_extraction(sample_edf_file):
         key in emg.metadata
         for key in ["startdate", "equipment", "technician", "recording_additional"]
     )
+
+
+def test_edf_no_annotations_yields_empty_events(sample_edf_file):
+    """A plain EDF with no annotations imports with an empty events frame (#47)."""
+    emg = EDFImporter().load(sample_edf_file)
+    assert emg.events is not None
+    assert emg.events.empty
+
+
+def test_edf_annotation_readback(tmp_path):
+    """EDF+ annotations are read back into events, sorted, with exact text (#47)."""
+    path = str(tmp_path / "annotated.edf")
+    writer = pyedflib.EdfWriter(path, 1, file_type=pyedflib.FILETYPE_EDFPLUS)
+    writer.setSignalHeaders(
+        [
+            {
+                "label": "EMG1",
+                "dimension": "uV",
+                "sample_frequency": 100,
+                "physical_max": 1.0,
+                "physical_min": -1.0,
+                "digital_max": 32767,
+                "digital_min": -32768,
+                "prefilter": "n/a",
+                "transducer": "EMG sensor",
+            }
+        ]
+    )
+    writer.writeSamples([np.sin(2 * np.pi * 5 * np.arange(500) / 100)])
+    # Write out of order to prove the importer sorts by onset.
+    writer.writeAnnotation(2.0, 0.5, "stim_offset")
+    writer.writeAnnotation(0.5, 0.0, "stim_onset")
+    writer.close()
+
+    emg = EDFImporter().load(path)
+    assert list(emg.events["description"]) == ["stim_onset", "stim_offset"]
+    assert np.allclose(emg.events["onset"].to_numpy(), [0.5, 2.0], atol=1e-3)
+    assert np.allclose(emg.events["duration"].to_numpy(), [0.0, 0.5], atol=1e-3)
+    assert emg.events["onset"].dtype == np.float64

--- a/emgio/tests/test_importers.py
+++ b/emgio/tests/test_importers.py
@@ -475,9 +475,38 @@ def test_edf_metadata_extraction(sample_edf_file):
 
 
 def test_edf_no_annotations_yields_empty_events(sample_edf_file):
-    """A plain EDF with no annotations imports with an empty events frame (#47)."""
+    """An EDF+ file with no annotations imports with an empty events frame (#47).
+
+    (``sample_edf_file`` is EDF+: pyedflib's EdfWriter defaults to FILETYPE_EDFPLUS.)
+    """
     emg = EDFImporter().load(sample_edf_file)
     assert emg.events is not None
+    assert emg.events.empty
+
+
+def test_edf_plain_format_has_no_events(tmp_path):
+    """A true plain EDF (FILETYPE_EDF, no annotation channel) yields empty events."""
+    path = str(tmp_path / "plain.edf")
+    writer = pyedflib.EdfWriter(path, 1, file_type=pyedflib.FILETYPE_EDF)
+    writer.setSignalHeaders(
+        [
+            {
+                "label": "EMG1",
+                "dimension": "uV",
+                "sample_frequency": 100,
+                "physical_max": 1.0,
+                "physical_min": -1.0,
+                "digital_max": 32767,
+                "digital_min": -32768,
+                "prefilter": "n/a",
+                "transducer": "EMG sensor",
+            }
+        ]
+    )
+    writer.writeSamples([np.sin(2 * np.pi * 5 * np.arange(500) / 100)])
+    writer.close()
+
+    emg = EDFImporter().load(path)
     assert emg.events.empty
 
 

--- a/emgio/tests/test_roundtrip.py
+++ b/emgio/tests/test_roundtrip.py
@@ -180,14 +180,12 @@ def test_meg_fif_import_unsupported():
         EMG.from_file(str(meg))
 
 
-@pytest.mark.xfail(reason="EDF+ annotation read-back pending #47", strict=True)
 def test_event_roundtrip_through_edf(tmp_path):
-    """Events exported as EDF+ annotations should survive reimport.
+    """Events exported as EDF+ annotations survive a real reimport (issue #47).
 
-    Events are added explicitly here (rather than relying on import, which does
-    not yet read EDF+ annotations) so this exercises export-write -> reimport.
-    It fails today because the EDF importer drops annotations on read; #47 adds
-    read-back and flips this to pass.
+    Events are added explicitly (the source fixture has none) so this exercises
+    export-write -> annotation read-back. Onset/duration are checked within EDF+'s
+    representable precision; descriptions must match exactly.
     """
     fixture = BIDS / "emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
     if not fixture.exists():
@@ -197,5 +195,9 @@ def test_event_roundtrip_through_edf(tmp_path):
     emg.add_event(onset=1.0, duration=0.2, description="m2")
     out = tmp_path / "ev.edf"
     emg.to_edf(str(out), format="edf", bypass_analysis=True)
+
     reloaded = EMG.from_file(str(out), bids_channels="off")
     assert len(reloaded.events) == 2
+    assert list(reloaded.events["description"]) == ["m1", "m2"]
+    assert np.allclose(reloaded.events["onset"].to_numpy(), [0.5, 1.0], atol=1e-3)
+    assert np.allclose(reloaded.events["duration"].to_numpy(), [0.0, 0.2], atol=1e-3)


### PR DESCRIPTION
## Summary
Fixes #47 (and the read-back half of #56): the EDF importer ignored the EDF+/BDF+ annotations channel, so events were dropped on read and could not round-trip. Now `readAnnotations()` is parsed into `emg.events` (float64 onset/duration, string description, sorted by onset; bytes descriptions decoded, empty placeholders skipped). Export already wrote events as annotations, so the full import -> export -> import event cycle now works.

## Tests (real data, NO MOCKS)
- `test_roundtrip.py::test_event_roundtrip_through_edf`: previously xfail pending #47, now a real pass asserting onset/duration survive within EDF+ precision and descriptions match exactly.
- `test_importers.py::test_edf_annotation_readback`: writes an EDF+ with out-of-order annotations, imports, asserts sorted events with correct onset/duration/description and float64 dtype.
- `test_importers.py::test_edf_no_annotations_yields_empty_events`: a plain EDF imports with an empty events frame (no crash).

Full suite: 301 passed, 3 skipped, 0 xfailed.