### PR TITLE
Add biosigio CLI: convert/verify/info (#49)

### DIFF
--- a/emgio/bids.py
+++ b/emgio/bids.py
@@ -19,15 +19,15 @@ if TYPE_CHECKING:
     from .core.emg import EMG
 
 
-def find_channels_tsv(data_filepath: str) -> str | None:
-    """Return the sibling BIDS ``_channels.tsv`` path for a data file, or None.
+def _find_sidecar(data_filepath: str, kind: str) -> str | None:
+    """Return the sibling BIDS ``_<kind>.tsv`` path for a data file, or None.
 
-    BIDS names the sidecar with the data file's entities but the ``channels``
-    suffix, e.g. ``sub-01_task-rest_ieeg.edf`` ->
-    ``sub-01_task-rest_channels.tsv``.
+    BIDS names a sidecar with the data file's entities but a different suffix,
+    e.g. ``sub-01_task-rest_ieeg.edf`` -> ``sub-01_task-rest_channels.tsv``.
 
     Args:
         data_filepath: Path to a (BIDS) data file.
+        kind: Sidecar kind, e.g. ``"channels"`` or ``"events"``.
 
     Returns:
         The sidecar path if it exists next to the data file, else ``None``.
@@ -37,15 +37,25 @@ def find_channels_tsv(data_filepath: str) -> str | None:
     candidates = []
     # BIDS-correct: drop the trailing _<suffix> entity (e.g. _ieeg, _eeg, _meg).
     if "_" in stem:
-        candidates.append(f"{stem.rsplit('_', 1)[0]}_channels.tsv")
+        candidates.append(f"{stem.rsplit('_', 1)[0]}_{kind}.tsv")
     # Fallback: the full-stem form emgio's own EDF exporter currently writes,
     # so a to_edf -> from_file round-trip also finds the sidecar.
-    candidates.append(f"{stem}_channels.tsv")
+    candidates.append(f"{stem}_{kind}.tsv")
     for name in candidates:
         path = os.path.join(directory, name)
         if os.path.isfile(path):
             return path
     return None
+
+
+def find_channels_tsv(data_filepath: str) -> str | None:
+    """Return the sibling BIDS ``_channels.tsv`` path for a data file, or None."""
+    return _find_sidecar(data_filepath, "channels")
+
+
+def find_events_tsv(data_filepath: str) -> str | None:
+    """Return the sibling BIDS ``_events.tsv`` path for a data file, or None."""
+    return _find_sidecar(data_filepath, "events")
 
 
 def apply_channels_tsv(emg: EMG, channels_tsv_path: str) -> int:

--- a/emgio/cli.py
+++ b/emgio/cli.py
@@ -1,0 +1,354 @@
+"""Command-line interface for emgio / biosigIO.
+
+A THIN wrapper over the public API: ``convert`` (import -> EDF/BDF export),
+``verify`` (compare two recordings), and ``info`` (summarize a recording). It
+contains no signal math or format-decision logic; those live in the core.
+
+Diagnostics (including the chatty per-importer/exporter ``print`` output) go to
+stderr; a ``--json`` payload is written alone to stdout so it can be piped.
+
+Exit-code contract:
+    0  success (verify passed)
+    1  verify FAILED (signals differ beyond tolerance)
+    2  usage / argument error (bad args, unknown --modality, unsupported format)
+    3  input file not found or unreadable
+    4  conversion runtime error
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+from collections.abc import Sequence
+
+from . import __version__
+from .analysis.verification import compare_signals
+from .bids import find_events_tsv
+from .core.emg import EMG
+from .core.modality import VALID_MODALITIES, infer_modality_from_channel_type
+
+logger = logging.getLogger("emgio.cli")
+
+# Exit codes (see module docstring).
+EXIT_OK = 0
+EXIT_VERIFY_FAILED = 1
+EXIT_USAGE = 2
+EXIT_INPUT = 3
+EXIT_RUNTIME = 4
+
+# A channel whose modality resolves to one of these is "unknown": --modality
+# may fill it, and info/verify warn-list it.
+_UNKNOWN_MODALITIES = frozenset({"OTHER", "MISC", "", None})
+
+
+class CliError(Exception):
+    """A CLI failure carrying the exit code to return."""
+
+    def __init__(self, code: int, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+@contextlib.contextmanager
+def _quiet_stdout():
+    """Route library ``print`` chatter to stderr so stdout stays clean."""
+    with contextlib.redirect_stdout(sys.stderr):
+        yield
+
+
+def _load_emg(path: str) -> EMG:
+    """Load a recording, mapping failures onto the exit-code contract."""
+    if not os.path.exists(path):
+        raise CliError(EXIT_INPUT, f"input not found: {path}")
+    if not os.path.isfile(path):
+        raise CliError(EXIT_INPUT, f"input is not a file: {path}")
+    try:
+        with _quiet_stdout():
+            return EMG.from_file(path)
+    except ValueError as e:
+        if "unsupported" in str(e).lower():
+            raise CliError(EXIT_USAGE, str(e)) from e
+        raise CliError(EXIT_RUNTIME, f"failed to read {path}: {e}") from e
+    except CliError:
+        raise
+    except Exception as e:  # importer/runtime failure
+        raise CliError(EXIT_RUNTIME, f"failed to read {path}: {e}") from e
+
+
+def _is_unknown(info: dict) -> bool:
+    return info.get("modality") in _UNKNOWN_MODALITIES or info.get("channel_type") == "OTHER"
+
+
+def _unknown_channels(emg: EMG) -> list[str]:
+    return [name for name, info in emg.channels.items() if _is_unknown(info)]
+
+
+def _apply_modality(emg: EMG, modality: str) -> None:
+    """Fill the modality of UNKNOWN channels only; never override detected ones.
+
+    Source-detected modalities win; omitting --modality (this is not called)
+    never injects anything. An unknown --modality is a usage error.
+    """
+    canonical = modality.strip().upper()
+    if canonical not in VALID_MODALITIES:
+        raise CliError(
+            EXIT_USAGE,
+            f"unknown --modality '{modality}'; choose one of {sorted(VALID_MODALITIES)}",
+        )
+    for info in emg.channels.values():
+        if _is_unknown(info):
+            info["modality"] = canonical
+
+
+def _parse_channel_map(spec: str | None) -> dict[str, str] | None:
+    """Parse ``A=B,C=D`` into a channel map, or None."""
+    if not spec:
+        return None
+    mapping: dict[str, str] = {}
+    for pair in spec.split(","):
+        if "=" not in pair:
+            raise CliError(EXIT_USAGE, f"invalid --channel-map entry '{pair}'; expected A=B")
+        original, reloaded = pair.split("=", 1)
+        mapping[original.strip()] = reloaded.strip()
+    return mapping
+
+
+def _all_identical(results: dict) -> bool:
+    compared = [v for k, v in results.items() if k != "channel_summary"]
+    return bool(compared) and all(v["is_identical"] for v in compared)
+
+
+def _written_path(requested: str) -> str:
+    """The path the exporter actually wrote (auto format may switch .edf/.bdf)."""
+    if os.path.exists(requested):
+        return requested
+    base = os.path.splitext(requested)[0]
+    for ext in (".bdf", ".edf"):
+        if os.path.exists(base + ext):
+            return base + ext
+    return requested
+
+
+# --------------------------------------------------------------------------- #
+# Subcommands
+# --------------------------------------------------------------------------- #
+
+
+def cmd_convert(args: argparse.Namespace) -> int:
+    emg = _load_emg(args.input)
+    if args.modality:
+        _apply_modality(emg, args.modality)
+
+    unknown = _unknown_channels(emg)
+    if unknown:
+        logger.warning("channels with unknown modality: %s", ", ".join(unknown))
+
+    try:
+        with _quiet_stdout():
+            emg.to_edf(
+                args.output,
+                format=args.format,
+                create_channels_tsv=not args.no_channels_tsv,
+                bypass_analysis=args.bypass_analysis,
+            )
+    except CliError:
+        raise
+    except Exception as e:
+        raise CliError(EXIT_RUNTIME, f"conversion failed: {e}") from e
+
+    written = _written_path(args.output)
+    if not os.path.exists(written):
+        raise CliError(EXIT_RUNTIME, f"conversion produced no output for {args.output}")
+    logger.info("wrote %s", written)
+
+    if args.verify:
+        with _quiet_stdout():
+            reloaded = EMG.from_file(written)
+        results = compare_signals(emg, reloaded, tolerance=args.verify_tolerance)
+        if not _all_identical(results):
+            differing = [
+                k for k, v in results.items() if k != "channel_summary" and not v["is_identical"]
+            ]
+            logger.error("verify FAILED; channels differ: %s", ", ".join(differing))
+            return EXIT_VERIFY_FAILED
+        logger.info("verify passed: all channels identical within tolerance")
+    return EXIT_OK
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    original = _load_emg(args.original)
+    reloaded = _load_emg(args.reloaded)
+    channel_map = _parse_channel_map(args.channel_map)
+    try:
+        results = compare_signals(
+            original, reloaded, tolerance=args.tolerance, channel_map=channel_map
+        )
+    except ValueError as e:  # e.g. channel-map names not present
+        raise CliError(EXIT_USAGE, str(e)) from e
+
+    passed = _all_identical(results)
+    if args.json:
+        payload = {
+            "passed": passed,
+            "tolerance": args.tolerance,
+            "channels": {
+                k: {
+                    "nrmse": v["nrmse"],
+                    "max_norm_abs_diff": v["max_norm_abs_diff"],
+                    "is_identical": v["is_identical"],
+                }
+                for k, v in results.items()
+                if k != "channel_summary"
+            },
+            "summary": results.get("channel_summary", {}),
+        }
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        for name, v in results.items():
+            if name == "channel_summary":
+                continue
+            status = "ok" if v["is_identical"] else "DIFF"
+            print(
+                f"  [{status}] {name}: nrmse={v['nrmse']:.3e} maxdiff={v['max_norm_abs_diff']:.3e}"
+            )
+        print(f"verify {'passed' if passed else 'FAILED'} (tolerance {args.tolerance})")
+    return EXIT_OK if passed else EXIT_VERIFY_FAILED
+
+
+def cmd_info(args: argparse.Namespace) -> int:
+    emg = _load_emg(args.input)
+    rates = sorted({float(i["sample_frequency"]) for i in emg.channels.values()})
+    n_samples = int(emg.signals.shape[0]) if emg.signals is not None else 0
+    max_rate = max(rates) if rates else 0.0
+    duration = round(n_samples / max_rate, 6) if max_rate else 0.0
+    n_events = int(len(emg.events)) if emg.events is not None else 0
+    events_tsv = find_events_tsv(args.input)
+    unknown = _unknown_channels(emg)
+
+    channels = [
+        {
+            "name": name,
+            "type": info.get("channel_type"),
+            "modality": info.get("modality")
+            or infer_modality_from_channel_type(info.get("channel_type", "OTHER")),
+            "sample_frequency": float(info["sample_frequency"]),
+            "unit": info.get("physical_dimension"),
+        }
+        for name, info in emg.channels.items()
+    ]
+
+    if unknown:
+        logger.warning("channels with unknown modality: %s", ", ".join(unknown))
+
+    if args.json:
+        payload = {
+            "file": args.input,
+            "n_channels": len(channels),
+            "sampling_rates": rates,
+            "duration_s": duration,
+            "n_events": n_events,
+            "events_tsv": events_tsv,
+            "unknown_channels": unknown,
+            "channels": channels,
+        }
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        print(f"file: {args.input}")
+        print(f"channels: {len(channels)} | sampling rates: {rates} Hz | duration: {duration}s")
+        print(f"events: {n_events} | sibling events.tsv: {events_tsv or 'none'}")
+        if unknown:
+            print(f"unknown-modality channels: {', '.join(unknown)}")
+        for ch in channels:
+            print(
+                f"  {ch['name']}: type={ch['type']} modality={ch['modality']} "
+                f"fs={ch['sample_frequency']}Hz unit={ch['unit']}"
+            )
+    return EXIT_OK
+
+
+# --------------------------------------------------------------------------- #
+# Parser
+# --------------------------------------------------------------------------- #
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="biosigio",
+        description="Convert, verify, and inspect biosignal recordings (EMG/EEG/iEEG/MEG).",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="increase verbosity (repeatable)"
+    )
+    parser.add_argument("-q", "--quiet", action="store_true", help="only report errors")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_convert = sub.add_parser("convert", help="import a recording and export EDF/BDF")
+    p_convert.add_argument("input", help="input recording (any supported format)")
+    p_convert.add_argument("output", help="output .edf/.bdf path")
+    p_convert.add_argument("--format", choices=["auto", "edf", "bdf"], default="auto")
+    p_convert.add_argument("--modality", help="fill UNKNOWN channels' modality (never overrides)")
+    p_convert.add_argument(
+        "--no-channels-tsv", action="store_true", help="do not write a BIDS channels.tsv"
+    )
+    p_convert.add_argument("--verify", action="store_true", help="reload and compare after export")
+    p_convert.add_argument("--verify-tolerance", type=float, default=1e-4)
+    p_convert.add_argument(
+        "--bypass-analysis",
+        action="store_true",
+        help="skip signal analysis (requires --format edf|bdf)",
+    )
+    p_convert.set_defaults(func=cmd_convert)
+
+    p_verify = sub.add_parser("verify", help="compare two recordings channel-by-channel")
+    p_verify.add_argument("original", help="reference recording")
+    p_verify.add_argument("reloaded", help="recording to compare against the reference")
+    p_verify.add_argument("--tolerance", type=float, default=1e-4)
+    p_verify.add_argument("--channel-map", help="map original->reloaded names, e.g. A=B,C=D")
+    p_verify.add_argument("--json", action="store_true", help="emit JSON to stdout")
+    p_verify.set_defaults(func=cmd_verify)
+
+    p_info = sub.add_parser("info", help="summarize a recording's channels and metadata")
+    p_info.add_argument("input", help="input recording (any supported format)")
+    p_info.add_argument("--json", action="store_true", help="emit JSON to stdout")
+    p_info.set_defaults(func=cmd_info)
+
+    return parser
+
+
+def _configure_logging(verbose: int, quiet: bool) -> None:
+    if quiet:
+        level = logging.ERROR
+    elif verbose >= 2:
+        level = logging.DEBUG
+    elif verbose == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level, stream=sys.stderr, format="%(levelname)s: %(message)s")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point. Returns the process exit code (does not raise SystemExit)."""
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as e:  # argparse exits 2 on bad args / 0 on --help/--version
+        return int(e.code) if e.code is not None else EXIT_USAGE
+
+    _configure_logging(args.verbose, args.quiet)
+    try:
+        return args.func(args)
+    except CliError as e:
+        logger.error("%s", e)
+        return e.code
+    except KeyboardInterrupt:  # pragma: no cover
+        return EXIT_RUNTIME
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/emgio/cli.py
+++ b/emgio/cli.py
@@ -40,9 +40,10 @@ EXIT_USAGE = 2
 EXIT_INPUT = 3
 EXIT_RUNTIME = 4
 
-# A channel whose modality resolves to one of these is "unknown": --modality
-# may fill it, and info/verify warn-list it.
-_UNKNOWN_MODALITIES = frozenset({"OTHER", "MISC", "", None})
+# A channel is "unknown" when its type is the importer's unrecognized default
+# (``OTHER``): --modality may fill it, and info/verify warn-list it. Modality is
+# NOT a usable marker here -- ECG/EOG/ACC/TRIG all legitimately resolve to MISC.
+_UNKNOWN_CHANNEL_TYPES = frozenset({"OTHER", "", None})
 
 
 class CliError(Exception):
@@ -80,7 +81,7 @@ def _load_emg(path: str) -> EMG:
 
 
 def _is_unknown(info: dict) -> bool:
-    return info.get("modality") in _UNKNOWN_MODALITIES or info.get("channel_type") == "OTHER"
+    return info.get("channel_type", "OTHER") in _UNKNOWN_CHANNEL_TYPES
 
 
 def _unknown_channels(emg: EMG) -> list[str]:
@@ -166,9 +167,12 @@ def cmd_convert(args: argparse.Namespace) -> int:
     logger.info("wrote %s", written)
 
     if args.verify:
-        with _quiet_stdout():
-            reloaded = EMG.from_file(written)
-        results = compare_signals(emg, reloaded, tolerance=args.verify_tolerance)
+        try:
+            with _quiet_stdout():
+                reloaded = EMG.from_file(written)
+            results = compare_signals(emg, reloaded, tolerance=args.verify_tolerance)
+        except Exception as e:
+            raise CliError(EXIT_RUNTIME, f"verify reload failed: {e}") from e
         if not _all_identical(results):
             differing = [
                 k for k, v in results.items() if k != "channel_summary" and not v["is_identical"]
@@ -329,7 +333,12 @@ def _configure_logging(verbose: int, quiet: bool) -> None:
         level = logging.INFO
     else:
         level = logging.WARNING
-    logging.basicConfig(level=level, stream=sys.stderr, format="%(levelname)s: %(message)s")
+    # force=True overrides any root config already installed at import time
+    # (e.g. emgio.core.emg calls basicConfig on import), so -v/-q actually apply
+    # and CLI diagnostics reach stderr.
+    logging.basicConfig(
+        level=level, stream=sys.stderr, format="%(levelname)s: %(message)s", force=True
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/emgio/tests/test_cli.py
+++ b/emgio/tests/test_cli.py
@@ -11,14 +11,18 @@ import pathlib
 import shutil
 import subprocess
 
+import numpy as np
 import pytest
 
-from emgio import __version__
+from emgio import EMG, __version__
 from emgio.cli import (
     EXIT_INPUT,
     EXIT_OK,
+    EXIT_RUNTIME,
     EXIT_USAGE,
     EXIT_VERIFY_FAILED,
+    _apply_modality,
+    _is_unknown,
     main,
 )
 
@@ -94,9 +98,16 @@ def test_verify_identical_passes():
 @requires_emg
 def test_verify_mismatch_fails(tmp_path):
     out = tmp_path / "eeg.edf"
-    main(["convert", str(EEG), str(out)])
+    assert main(["convert", str(EEG), str(out)]) == EXIT_OK
     written = out if out.exists() else out.with_suffix(".bdf")
     assert main(["verify", str(EMG_EDF), str(written)]) == EXIT_VERIFY_FAILED
+
+
+def test_corrupt_file_is_runtime_error(tmp_path):
+    """A file with a known extension but invalid content -> runtime error (4)."""
+    bad = tmp_path / "f.edf"
+    bad.write_bytes(b"\x00" * 16)  # valid extension, garbage content
+    assert main(["info", str(bad)]) == EXIT_RUNTIME
 
 
 @requires_emg
@@ -105,6 +116,23 @@ def test_verify_json_payload(capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["passed"] is True
     assert "channels" in payload and payload["channels"]
+
+
+def test_is_unknown_uses_channel_type_not_modality():
+    """Only an OTHER type is unknown; ECG/EOG/ACC are detected though MISC-modality."""
+    assert _is_unknown({"channel_type": "OTHER", "modality": "MISC"}) is True
+    assert _is_unknown({"channel_type": "ECG", "modality": "MISC"}) is False
+    assert _is_unknown({"channel_type": "EEG", "modality": "EEG"}) is False
+
+
+def test_apply_modality_fills_only_unknown_channels():
+    """--modality fills OTHER-typed channels but leaves detected ones untouched."""
+    emg = EMG()
+    emg.add_channel("X", np.zeros(100), 100, "uV", "OTHER")
+    emg.add_channel("ECG1", np.zeros(100), 100, "uV", "ECG")
+    _apply_modality(emg, "EEG")
+    assert emg.channels["X"]["modality"] == "EEG"  # unknown -> filled
+    assert emg.channels["ECG1"]["modality"] == "MISC"  # detected -> untouched
 
 
 def test_missing_input_is_input_error():

--- a/emgio/tests/test_cli.py
+++ b/emgio/tests/test_cli.py
@@ -1,0 +1,180 @@
+"""Smoke tests for the biosigio CLI (issue #49).
+
+Exercises each subcommand in-process via ``cli.main(argv)`` (always) and via the
+installed ``biosigio`` entry point through a subprocess (skipped with a clear
+reason if not installed). Asserts the exit-code contract, file creation, and
+``--json`` shape. NO MOCKS: real fixtures and real conversions.
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+from emgio import __version__
+from emgio.cli import (
+    EXIT_INPUT,
+    EXIT_OK,
+    EXIT_USAGE,
+    EXIT_VERIFY_FAILED,
+    main,
+)
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EEG = _REPO / "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
+EMG_EDF = _REPO / "examples/bids/emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
+
+requires_eeg = pytest.mark.skipif(not EEG.exists(), reason="EEG fixture missing")
+requires_emg = pytest.mark.skipif(not EMG_EDF.exists(), reason="EMG fixture missing")
+
+
+# ------------------------------- in-process -------------------------------- #
+
+
+def test_version_returns_ok(capsys):
+    assert main(["--version"]) == EXIT_OK
+    assert __version__ in capsys.readouterr().out
+
+
+def test_help_lists_subcommands(capsys):
+    assert main(["--help"]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "convert" in out and "verify" in out and "info" in out
+
+
+def test_no_subcommand_is_usage_error():
+    assert main([]) == EXIT_USAGE
+
+
+@requires_emg
+def test_info_json_shape_and_no_fabricated_emg(capsys):
+    assert main(["info", str(EMG_EDF), "--json"]) == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["n_channels"] == len(payload["channels"])
+    assert payload["n_channels"] > 0
+    assert isinstance(payload["sampling_rates"], list)
+    for ch in payload["channels"]:
+        assert {"name", "type", "modality", "sample_frequency", "unit"} <= ch.keys()
+
+
+@requires_eeg
+def test_info_eeg_never_injects_emg_when_modality_omitted(capsys):
+    """A non-EMG recording must not report fabricated EMG channels."""
+    assert main(["info", str(EEG), "--json"]) == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert not any(ch["modality"] == "EMG" for ch in payload["channels"])
+    assert not any(ch["type"] == "EMG" for ch in payload["channels"])
+
+
+@requires_eeg
+def test_convert_creates_file_and_verifies(tmp_path):
+    out = tmp_path / "out.edf"
+    assert main(["convert", str(EEG), str(out), "--format", "auto", "--verify"]) == EXIT_OK
+    written = out if out.exists() else out.with_suffix(".bdf")
+    assert written.exists()
+    assert written.with_name(written.stem + "_channels.tsv").exists()
+
+
+@requires_eeg
+def test_convert_no_channels_tsv(tmp_path):
+    out = tmp_path / "out.edf"
+    assert main(["convert", str(EEG), str(out), "--no-channels-tsv"]) == EXIT_OK
+    written = out if out.exists() else out.with_suffix(".bdf")
+    assert not written.with_name(written.stem + "_channels.tsv").exists()
+
+
+@requires_emg
+def test_verify_identical_passes():
+    assert main(["verify", str(EMG_EDF), str(EMG_EDF)]) == EXIT_OK
+
+
+@requires_eeg
+@requires_emg
+def test_verify_mismatch_fails(tmp_path):
+    out = tmp_path / "eeg.edf"
+    main(["convert", str(EEG), str(out)])
+    written = out if out.exists() else out.with_suffix(".bdf")
+    assert main(["verify", str(EMG_EDF), str(written)]) == EXIT_VERIFY_FAILED
+
+
+@requires_emg
+def test_verify_json_payload(capsys):
+    assert main(["verify", str(EMG_EDF), str(EMG_EDF), "--json"]) == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is True
+    assert "channels" in payload and payload["channels"]
+
+
+def test_missing_input_is_input_error():
+    assert main(["info", "/no/such/file.edf"]) == EXIT_INPUT
+
+
+@requires_eeg
+def test_unknown_modality_is_usage_error(tmp_path):
+    assert main(["convert", str(EEG), str(tmp_path / "x.edf"), "--modality", "BOGUS"]) == EXIT_USAGE
+
+
+def test_unsupported_extension_is_usage_error(tmp_path):
+    bad = tmp_path / "f.zzz"
+    bad.write_text("not a signal file")
+    assert main(["info", str(bad)]) == EXIT_USAGE
+
+
+@requires_eeg
+def test_modality_fills_only_unknown_channels(capsys, tmp_path):
+    """--modality fills channels that resolved to unknown, leaving detected ones."""
+    # Baseline: identify which channels are unknown without --modality.
+    main(["info", str(EEG), "--json"])
+    base = json.loads(capsys.readouterr().out)
+    unknown = set(base["unknown_channels"])
+    detected = {ch["name"]: ch["modality"] for ch in base["channels"] if ch["name"] not in unknown}
+    if not unknown:
+        pytest.skip("EEG fixture has no unknown channels to fill")
+
+    # convert with --modality EEG must not raise; detected channels keep their
+    # modality. (We re-check via a fresh info on the converted output below is
+    # not possible since modality is not stored in EDF, so assert via no-raise +
+    # exit 0; the unknown-fill logic is unit-tested in cli._apply_modality.)
+    out = tmp_path / "m.edf"
+    assert main(["convert", str(EEG), str(out), "--modality", "EEG"]) == EXIT_OK
+    assert detected  # detected channels existed and were left to win
+
+
+# -------------------------------- subprocess ------------------------------- #
+
+BIOSIGIO = shutil.which("biosigio")
+no_entry_point = pytest.mark.skipif(
+    BIOSIGIO is None, reason="biosigio entry point not installed on PATH"
+)
+
+
+@no_entry_point
+def test_subprocess_version():
+    assert BIOSIGIO is not None
+    result = subprocess.run([BIOSIGIO, "--version"], capture_output=True, text=True, check=False)
+    assert result.returncode == EXIT_OK
+    assert __version__ in result.stdout
+
+
+@requires_emg
+@no_entry_point
+def test_subprocess_info_json_alone_on_stdout():
+    """stdout must be JSON only; importer chatter goes to stderr."""
+    assert BIOSIGIO is not None
+    result = subprocess.run(
+        [BIOSIGIO, "info", str(EMG_EDF), "--json"], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == EXIT_OK
+    payload = json.loads(result.stdout)  # parses cleanly => stdout is JSON alone
+    assert payload["n_channels"] > 0
+
+
+@no_entry_point
+def test_subprocess_missing_file_exit_code():
+    assert BIOSIGIO is not None
+    result = subprocess.run(
+        [BIOSIGIO, "info", "/no/such/file.edf"], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == EXIT_INPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
     "pyxdf>=1.16.0",
 ]
 
+[project.scripts]
+biosigio = "emgio.cli:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",


### PR DESCRIPTION
## Summary
Fixes #49: net-new `emgio/cli.py` exposed as `biosigio` via `[project.scripts]`. A THIN argparse wrapper over the public API (no signal math or format-decision logic).

### Subcommands
- `convert IN OUT [--format auto|edf|bdf] [--modality M] [--no-channels-tsv] [--verify] [--verify-tolerance F] [--bypass-analysis]`
- `verify ORIG RELOADED [--tolerance F] [--channel-map A=B,...] [--json]`
- `info FILE [--json]` — per-channel type/modality, sampling rates, duration, event count, detected sibling `_events.tsv`; warn-lists unknown-modality channels.
- Global `-v/--verbose` (repeatable), `-q/--quiet`, `--version`.

### Contract
- Exit codes: **0** ok / **1** verify failed / **2** usage (bad args, unknown `--modality`, unsupported format) / **3** input not found/unreadable / **4** conversion runtime error.
- Diagnostics + importer/exporter `print` chatter routed to **stderr**; a `--json` payload is written **alone to stdout** (verified parseable).
- `--modality` fills only UNKNOWN channels (source-detected types win; omitting it never injects EMG).

### Supporting
- `bids.py`: DRY the sidecar lookup into `_find_sidecar` and add `find_events_tsv` (used by `info`); `find_channels_tsv` behavior unchanged.

## Tests (NO MOCKS)
`test_cli.py`: each command in-process via `cli.main(argv)` (always) and via the installed `biosigio` entry point through subprocess (skips with a clear reason if absent). Asserts the full exit-code contract, file + channels.tsv creation, `--json` shape, JSON-alone-on-stdout, and that a non-EMG recording never reports fabricated EMG.

Full suite: 319 passed, 3 skipped; ruff + ty clean.