### PR TITLE
Add MNE-based MEG importer (.fif / CTF .ds) (#53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ site/
 
 # uv generates this on every `uv run`; this project pins via pyproject.toml only
 uv.lock
+
+# Claude Code agent worktrees (use ../ parent-dir worktrees instead)
+.claude/worktrees/

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -102,6 +102,8 @@ class EMG:
             return "wfdb"
         elif extension in {".xdf", ".xdfz"}:
             return "xdf"
+        elif extension in {".fif", ".ds"}:
+            return "meg"
         else:
             raise ValueError(f"Unsupported file extension: {extension}")
 
@@ -109,7 +111,8 @@ class EMG:
     def from_file(
         cls,
         filepath: str,
-        importer: Literal["trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf"] | None = None,
+        importer: Literal["trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg"]
+        | None = None,
         force_csv: bool = False,
         bids_channels: str = "auto",
         **kwargs,
@@ -127,6 +130,7 @@ class EMG:
                 - 'csv': Generic CSV (or TXT) files with columnar data
                 - 'wfdb': Waveform Database (WFDB)
                 - 'xdf': XDF format (multi-stream Lab Streaming Layer files)
+                - 'meg': MEG via MNE (.fif and CTF .ds; requires the 'meg' extra)
                 If None, the importer will be inferred from the file extension.
                 Automatic import is supported for CSV/TXT files.
             force_csv: If True and importer is 'csv', forces using the generic CSV
@@ -155,6 +159,7 @@ class EMG:
             "csv": "CSVImporter",  # Generic CSV/Text files
             "wfdb": "WFDBImporter",  # Waveform Database format
             "xdf": "XDFImporter",  # XDF multi-stream format
+            "meg": "MEGImporter",  # MEG via MNE (.fif, CTF .ds)
         }
 
         if importer not in importers:
@@ -167,7 +172,8 @@ class EMG:
                 "- eeglab: EEGLAB .set files\n"
                 "- csv: Generic CSV/Text files\n"
                 "- wfdb: Waveform Database\n"
-                "- xdf: XDF multi-stream format"
+                "- xdf: XDF multi-stream format\n"
+                "- meg: MEG via MNE (.fif, CTF .ds)"
             )
 
         # If using CSV importer and force_csv is set, pass it as force_generic

--- a/emgio/importers/meg.py
+++ b/emgio/importers/meg.py
@@ -116,8 +116,9 @@ class MEGImporter(BaseImporter):
         emg.set_metadata("number_of_signals", len(raw.ch_names))
 
         # MEG files routinely carry 300+ channels; adding them one at a time
-        # fragments the DataFrame (an expected, benign pandas PerformanceWarning),
-        # so suppress it here and de-fragment once after the bulk add.
+        # fragments the DataFrame (a pandas PerformanceWarning). Suppress it here
+        # and de-fragment after the bulk add; the root-cause add_channel perf
+        # drift is tracked in #66.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
             for i, name in enumerate(raw.ch_names):

--- a/emgio/importers/meg.py
+++ b/emgio/importers/meg.py
@@ -1,0 +1,140 @@
+"""MEG importer backed by MNE-Python (.fif and CTF .ds).
+
+MNE is an optional dependency (it is heavy), so it is imported lazily inside
+:meth:`MEGImporter.load` with a clear install hint rather than at module import.
+
+MEG recordings mix several sensor types in one file (magnetometers, gradiometers,
+reference sensors) alongside stim/EEG/EOG/ECG channels. Each MNE channel type is
+mapped to its own emgio/BIDS channel type so the distinctions are preserved
+(they are NOT collapsed into a single "MEG" type), and stim-channel triggers are
+read into ``EMG.events``.
+"""
+
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from ..core.emg import EMG
+from .base import BaseImporter
+
+# MNE channel type (raw.get_channel_types()) -> emgio/BIDS channel type.
+# Note: MNE reports CTF axial gradiometers as 'mag' and lumps all reference
+# sensors as 'ref_meg'; a coil-type-precise split (MEGGRADAXIAL / MEGREFGRAD*)
+# is a possible refinement, but the MNE channel type already preserves the
+# mag / ref / stim / EEG / EOG / ECG distinctions this importer must keep.
+_MNE_TYPE_TO_EMGIO = {
+    "mag": "MEGMAG",
+    "grad": "MEGGRADPLANAR",
+    "ref_meg": "MEGREFMAG",
+    "eeg": "EEG",
+    "seeg": "SEEG",
+    "ecog": "ECOG",
+    "dbs": "DBS",
+    "eog": "EOG",
+    "ecg": "ECG",
+    "emg": "EMG",
+    "stim": "TRIG",
+    "resp": "RESP",
+    "gsr": "GSR",
+    "temperature": "TEMP",
+    "bio": "MISC",
+    "misc": "MISC",
+    "syst": "MISC",
+    "chpi": "MISC",
+    "exci": "MISC",
+    "ias": "MISC",
+}
+
+# FIFF physical-unit code (raw.info['chs'][i]['unit']) -> dimension string.
+_FIFF_UNIT_TO_DIM = {107: "V", 112: "T", 201: "T/m"}
+
+
+class MEGImporter(BaseImporter):
+    """Importer for MEG recordings via MNE-Python (.fif and CTF .ds)."""
+
+    @staticmethod
+    def _require_mne():
+        try:
+            import mne
+        except ImportError as e:
+            raise ImportError(
+                "MEG import requires MNE-Python, an optional dependency. Install it with: "
+                "uv pip install 'emgio[meg]'  (or: pip install mne)."
+            ) from e
+        return mne
+
+    def _read_raw(self, mne, filepath: str):
+        """Read a .fif file or a CTF .ds directory into an MNE Raw object."""
+        ext = os.path.splitext(filepath)[1].lower()
+        if ext == ".ds":
+            return mne.io.read_raw_ctf(filepath, preload=True, verbose="ERROR")
+        return mne.io.read_raw_fif(filepath, preload=True, verbose="ERROR")
+
+    def _read_events(self, mne, raw, sfreq: float) -> pd.DataFrame:
+        """Read stim-channel triggers into an events DataFrame (onsets in seconds)."""
+        try:
+            events = mne.find_events(raw, verbose="ERROR")
+        except (ValueError, RuntimeError):
+            # No stim channel / no transitions: no events.
+            events = np.empty((0, 3), dtype=int)
+        first_samp = int(raw.first_samp)
+        rows = [
+            ((int(sample) - first_samp) / sfreq, 0.0, str(int(code)))
+            for sample, _prev, code in events
+        ]
+        evt = pd.DataFrame(rows, columns=["onset", "duration", "description"])
+        if not evt.empty:
+            evt = evt.sort_values("onset").reset_index(drop=True)
+            evt["onset"] = evt["onset"].astype("float64")
+            evt["duration"] = evt["duration"].astype("float64")
+        return evt
+
+    def load(self, filepath: str) -> EMG:
+        """Load a MEG recording into an EMG object.
+
+        Args:
+            filepath: Path to a ``.fif`` file or a CTF ``.ds`` directory.
+
+        Returns:
+            EMG: channels carry their MEG/EEG/stim type and physical unit; stim
+            triggers are read into ``EMG.events``.
+        """
+        mne = self._require_mne()
+        try:
+            raw = self._read_raw(mne, filepath)
+        except Exception as e:
+            raise ValueError(f"Error reading MEG file {filepath}: {e}") from e
+
+        emg = EMG()
+        sfreq = float(raw.info["sfreq"])
+        data = raw.get_data()  # (n_channels, n_samples) in SI units
+        mne_types = raw.get_channel_types()
+
+        emg.set_metadata("source_file", filepath)
+        emg.set_metadata("number_of_signals", len(raw.ch_names))
+
+        # MEG files routinely carry 300+ channels; adding them one at a time
+        # fragments the DataFrame (an expected, benign pandas PerformanceWarning),
+        # so suppress it here and de-fragment once after the bulk add.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
+            for i, name in enumerate(raw.ch_names):
+                channel_type = _MNE_TYPE_TO_EMGIO.get(mne_types[i], "OTHER")
+                unit_code = int(raw.info["chs"][i]["unit"])
+                emg.add_channel(
+                    label=name,
+                    data=data[i],
+                    sample_frequency=sfreq,
+                    physical_dimension=_FIFF_UNIT_TO_DIM.get(unit_code, "n/a"),
+                    channel_type=channel_type,
+                )
+        if emg.signals is not None:
+            emg.signals = emg.signals.copy()  # de-fragment after many inserts
+
+        events = self._read_events(mne, raw, sfreq)
+        if not events.empty:
+            emg.events = events
+
+        return emg

--- a/emgio/importers/meg.py
+++ b/emgio/importers/meg.py
@@ -61,7 +61,7 @@ class MEGImporter(BaseImporter):
         except ImportError as e:
             raise ImportError(
                 "MEG import requires MNE-Python, an optional dependency. Install it with: "
-                "uv pip install 'emgio[meg]'  (or: pip install mne)."
+                "uv sync --extra meg  (or, for an existing install, uv pip install 'emgio[meg]')."
             ) from e
         return mne
 

--- a/emgio/tests/test_meg_importer.py
+++ b/emgio/tests/test_meg_importer.py
@@ -1,0 +1,90 @@
+"""Tests for the MNE-backed MEG importer (issue #53).
+
+Uses the real CTF fixture (ds002908: 305 channels, 100 Hz, 30 s, 58 trigger
+events, Tesla-unit sensors). Verifies that the distinct MEG sensor types are
+preserved (not collapsed), units are carried, stim triggers become events, and
+the Tesla-magnitude signals survive an EDF/BDF round-trip. NO MOCKS.
+
+Skips cleanly if the optional ``meg`` extra (mne) is not installed.
+"""
+
+import pathlib
+from collections import Counter
+
+import numpy as np
+import pytest
+
+from emgio import EMG
+
+pytest.importorskip("mne", reason="MEG import requires the optional 'meg' extra (mne)")
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+MEG = _REPO / "examples/bids/meg/sub-01/meg/sub-01_task-mouse_meg.fif"
+
+pytestmark = pytest.mark.skipif(not MEG.exists(), reason="MEG fixture missing")
+
+
+@pytest.fixture(scope="module")
+def meg_emg():
+    return EMG.from_file(str(MEG))
+
+
+def test_meg_channel_types_preserved(meg_emg):
+    """Sensor types stay distinct (mag vs reference vs stim), not collapsed."""
+    types = Counter(i["channel_type"] for i in meg_emg.channels.values())
+    assert types["MEGMAG"] == 274
+    assert types["MEGREFMAG"] == 29
+    assert types["TRIG"] == 2
+    assert sum(types.values()) == 305
+    # No fabricated EMG on a MEG recording.
+    assert "EMG" not in types
+
+
+def test_meg_units_and_modalities(meg_emg):
+    by_type = {i["channel_type"]: i for i in meg_emg.channels.values()}
+    assert by_type["MEGMAG"]["physical_dimension"] == "T"  # Tesla magnetometers
+    assert by_type["MEGREFMAG"]["physical_dimension"] == "T"
+    assert by_type["TRIG"]["physical_dimension"] == "V"
+    assert by_type["MEGMAG"]["modality"] == "MEG"
+    assert by_type["TRIG"]["modality"] == "MISC"
+
+
+def test_meg_sampling_and_shape(meg_emg):
+    rates = {i["sample_frequency"] for i in meg_emg.channels.values()}
+    assert rates == {100.0}
+    assert meg_emg.signals.shape == (3000, 305)  # 30 s @ 100 Hz, 305 channels
+
+
+def test_meg_stim_events(meg_emg):
+    """Stim-channel triggers are read into events (onsets in seconds, sorted)."""
+    assert meg_emg.events is not None and len(meg_emg.events) == 58
+    onsets = meg_emg.events["onset"].to_numpy()
+    assert (onsets[:-1] <= onsets[1:]).all()  # sorted
+    assert onsets.min() >= 0.0 and onsets.max() <= 30.0  # within the recording
+    assert meg_emg.events["onset"].dtype == np.float64
+    # Descriptions are the stringified trigger codes.
+    assert all(d.isdigit() for d in meg_emg.events["description"])
+
+
+def test_meg_roundtrip_preserves_tesla_signals(meg_emg, tmp_path):
+    """Tesla-magnitude MEG channels survive EDF/BDF export+reimport (r > 0.99).
+
+    Magnetometer values are ~1e-12 T, exercising the exporter's small-magnitude
+    physical-bound path; BDF (auto-selected for the dynamic range) must keep them.
+    """
+    out = tmp_path / "meg.edf"
+    meg_emg.to_edf(str(out), format="bdf", bypass_analysis=True)
+    written = out if out.exists() else out.with_suffix(".bdf")
+    reloaded = EMG.from_file(str(written), bids_channels="off")
+    assert len(reloaded.channels) == len(meg_emg.channels)
+
+    # Check a handful of magnetometer channels on a 10 s window.
+    mag = [c for c, i in meg_emg.channels.items() if i["channel_type"] == "MEGMAG"][:5]
+    window = slice(0, 1000)  # 10 s @ 100 Hz
+    for ch in mag:
+        original = meg_emg.signals[ch].values[window].astype(float)
+        roundtripped = reloaded.signals[ch].values[window].astype(float)
+        if np.std(original) == 0:
+            continue
+        r = float(np.corrcoef(original, roundtripped)[0, 1])
+        assert r > 0.99, f"{ch}: round-trip correlation {r}"

--- a/emgio/tests/test_roundtrip.py
+++ b/emgio/tests/test_roundtrip.py
@@ -14,8 +14,7 @@ class of bug).
 
 Known limitations are asserted explicitly rather than skipped:
 - mixed per-channel sample rates (XDF, Trigno) must fail loudly on export;
-- MEG ``.fif`` is not importable yet (needs an MNE-based importer, #53);
-- event round-trip through EDF+ annotations is pending #47 (xfail).
+- MEG ``.fif`` imports via the MNE-backed importer (#53; needs the 'meg' extra).
 """
 
 import atexit
@@ -171,13 +170,16 @@ def test_mixed_rate_export_raises(case, tmp_path):
         emg.to_edf(str(tmp_path / f"{case.name}.edf"), format="edf", bypass_analysis=True)
 
 
-def test_meg_fif_import_unsupported():
+def test_meg_fif_imports_via_mne():
+    """MEG .fif now imports through the MNE-backed importer (#53)."""
     meg = BIDS / "meg/sub-01/meg/sub-01_task-mouse_meg.fif"
     if not meg.exists():
         pytest.skip("MEG fixture missing")
-    # Until an MNE-based MEG importer lands (#53), .fif is unsupported.
-    with pytest.raises(ValueError, match="Unsupported file extension"):
-        EMG.from_file(str(meg))
+    pytest.importorskip("mne", reason="MEG import requires the optional 'meg' extra (mne)")
+    emg = EMG.from_file(str(meg))
+    assert len(emg.channels) > 0
+    # No modality creep: a MEG file must not invent EMG channels.
+    assert not [c for c, i in emg.channels.items() if i["channel_type"] == "EMG"]
 
 
 def test_event_roundtrip_through_edf(tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ docs = [
     "mike>=2.1.0",
 ]
 all = [
-    "emgio[dev,docs]",
+    "emgio[dev,docs,meg]",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,17 @@ dependencies = [
 biosigio = "emgio.cli:main"
 
 [project.optional-dependencies]
+# MEG (.fif/CTF .ds) and BrainVision (.vhdr) import are backed by MNE, kept out
+# of the core deps (MNE is heavy). Install with `uv sync --extra meg`.
+meg = [
+    "mne>=1.6",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.14",
     "ty",
+    "mne>=1.6",
 ]
 docs = [
     "mkdocs>=1.6.0",


### PR DESCRIPTION
## Summary
Fixes #53: emgio could not read MEG. New `emgio/importers/meg.py` (`MEGImporter`), registered in `_infer_importer` (`.fif`/`.ds`) and the `from_file` map. MNE is an **optional** dependency: lazy-imported inside `load()` with a clear install hint (`uv pip install 'emgio[meg]'`); added to the `meg` extra and to `dev` so CI exercises it.

## Channel-type handling (the "couple streams per channel" concern)
MEG files mix sensor types in one recording. Each MNE channel type maps to its own emgio/BIDS type so the distinctions are **preserved, not collapsed**:
`mag→MEGMAG`, `ref_meg→MEGREFMAG`, `grad→MEGGRADPLANAR`, `stim→TRIG`, `eeg/eog/ecg/seeg/ecog/dbs/...`, else `OTHER`. FIFF units are carried (`T` for magnetometers, `V` for stim). Stim-channel triggers are read via `mne.find_events` into `EMG.events` (onsets in seconds).

## Verified on the real CTF fixture (ds002908)
305 channels → **274 MEGMAG + 29 MEGREFMAG + 2 TRIG**; 303 MEG + 2 MISC modalities; units T/T/V; 100 Hz; (3000, 305); **58 trigger events**. EDF/BDF round-trip: magnetometers (Tesla, ~1e-12) reload at **r > 0.99**, exercising the exporter's small-magnitude physical-bound path.

## Notes
- The 305-channel bulk add surfaces a pandas fragmentation `PerformanceWarning` (root cause in `EMG.add_channel`); locally suppressed + de-fragmented here, root fix tracked in **#66** (per the "don't dismiss drift" policy).
- CTF axial gradiometers are reported by MNE as `mag` and all references as `ref_meg`; a coil-type-precise MEGGRADAXIAL/MEGREFGRAD split is a possible future refinement (the MNE type already preserves the mag/ref/stim distinction this importer needs).
- The old `test_meg_fif_import_unsupported` is flipped to assert successful import.

Tests: `test_meg_importer.py` (types/units/modalities/shape/events/round-trip), skip if the `meg` extra is absent. NO MOCKS.