### PR TITLE
Fix genuine ty type-annotation bugs (toward #43)

### DIFF
--- a/emgio/analysis/signal.py
+++ b/emgio/analysis/signal.py
@@ -32,10 +32,10 @@ def find_elbow_point(singular_values: np.ndarray) -> int:
     elbow_idx = np.argmax(np.abs(second_derivative)) + 2
 
     # Ensure we don't return too small a value (at least 1)
-    return max(1, min(elbow_idx, len(singular_values) - 1))
+    return int(max(1, min(elbow_idx, len(singular_values) - 1)))
 
 
-def analyze_signal_svd(detrended: np.ndarray, svd_rank: int = None) -> float:
+def analyze_signal_svd(detrended: np.ndarray, svd_rank: int | None = None) -> float:
     """
     Estimate noise floor using SVD-based method with automatic elbow detection.
 
@@ -109,7 +109,7 @@ def analyze_signal_svd(detrended: np.ndarray, svd_rank: int = None) -> float:
 
 
 # FFT-based analysis functions
-def analyze_signal_fft(detrended: np.ndarray, fft_noise_range: tuple = None) -> float:
+def analyze_signal_fft(detrended: np.ndarray, fft_noise_range: tuple | None = None) -> float:
     """
     Estimate noise floor using enhanced FFT-based method.
 
@@ -165,7 +165,10 @@ def analyze_signal_fft(detrended: np.ndarray, fft_noise_range: tuple = None) -> 
 
 # High-level analysis functions
 def analyze_signal(
-    signal: np.ndarray, method: str = "svd", fft_noise_range: tuple = None, svd_rank: int = None
+    signal: np.ndarray,
+    method: str = "svd",
+    fft_noise_range: tuple | None = None,
+    svd_rank: int | None = None,
 ) -> dict:
     """
     Analyze signal characteristics including noise floor and dynamic range.

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -22,6 +22,9 @@ if enable_logging:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 else:
     logging.basicConfig(level=logging.CRITICAL)  # Effectively turns off most logging
+
+# Supported importer names (extension-inferred or passed explicitly to from_file).
+ImporterName = Literal["trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision"]
 
 
 class EMG:
@@ -85,7 +88,7 @@ class EMG:
         )
 
     @classmethod
-    def _infer_importer(cls, filepath: str) -> str:
+    def _infer_importer(cls, filepath: str) -> ImporterName:
         """
         Infer the importer to use based on the file extension.
         """
@@ -113,10 +116,7 @@ class EMG:
     def from_file(
         cls,
         filepath: str,
-        importer: Literal[
-            "trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision"
-        ]
-        | None = None,
+        importer: ImporterName | None = None,
         force_csv: bool = False,
         bids_channels: str = "auto",
         **kwargs,
@@ -462,8 +462,8 @@ class EMG:
         self,
         filepath: str,
         method: str = "both",
-        fft_noise_range: tuple = None,
-        svd_rank: int = None,
+        fft_noise_range: tuple | None = None,
+        svd_rank: int | None = None,
         precision_threshold: float = 0.01,
         format: Literal["auto", "edf", "bdf"] = "auto",
         bypass_analysis: bool | None = None,
@@ -475,7 +475,7 @@ class EMG:
         create_channels_tsv: bool = True,
         clip_outliers: bool | str = "auto",
         **kwargs,
-    ) -> str | None:
+    ) -> dict | None:
         """
         Export EMG data to EDF/BDF format, optionally including events.
 
@@ -621,7 +621,7 @@ class EMG:
 
         return verification_report_dict
 
-    def set_metadata(self, key: str, value: any) -> None:
+    def set_metadata(self, key: str, value: Any) -> None:
         """
         Set metadata value.
 
@@ -631,7 +631,7 @@ class EMG:
         """
         self.metadata[key] = value
 
-    def get_metadata(self, key: str) -> any:
+    def get_metadata(self, key: str) -> Any:
         """
         Get metadata value.
 

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -279,8 +279,8 @@ class EDFExporter:
         filepath: str,
         precision_threshold: float = 0.01,
         method: str = "both",
-        fft_noise_range: tuple = None,
-        svd_rank: int = None,
+        fft_noise_range: tuple | None = None,
+        svd_rank: int | None = None,
         format: Literal["auto", "edf", "bdf"] = "auto",
         bypass_analysis: bool = False,
         events_df: pd.DataFrame | None = None,
@@ -289,7 +289,7 @@ class EDFExporter:
         outlier_sigmas: float = 8.0,
         min_effective_bits: float = 10.0,
         **kwargs,
-    ) -> None:
+    ) -> str:
         """
         Export EMG data to EDF/BDF format with optional BIDS-compliant channels.tsv file.
 

--- a/emgio/importers/trigno.py
+++ b/emgio/importers/trigno.py
@@ -7,7 +7,7 @@ from .base import BaseImporter
 class TrignoImporter(BaseImporter):
     """Importer for Delsys Trigno EMG system data."""
 
-    def _analyze_csv_structure(self, csv_path: str) -> tuple[list[str], int, str]:
+    def _analyze_csv_structure(self, csv_path: str) -> tuple[list[str], int, str | None]:
         """
         Analyze the CSV file structure to identify metadata and data sections.
 


### PR DESCRIPTION
## Summary
First pass toward #43 (drive ty to zero, then make it blocking). Fixes the **genuine** type bugs ty flagged — the ones that indicate real annotation errors, not ty's conservative `Optional`-access narrowing. **Zero behaviour change** (annotations + one `int()` cast); full suite 342 passed.

- Honest Optional params: `fft_noise_range: tuple = None` / `svd_rank: int = None` → `... | None = None` across `analyze_signal*`, `EMG.to_edf`, `EDFExporter.export`.
- `EMG.set_metadata`/`get_metadata` use `typing.Any`, not the builtin `any`, as the annotation (was an invalid-type-form).
- `EMG.to_edf` actually returns a dict (verification report) → `-> dict | None`; `EDFExporter.export` returns the written path → `-> str` (was `-> None`).
- `_analyze_csv_structure` can return `header_line=None` → `tuple[list[str], int, str | None]`.
- `find_elbow_point` returns a Python `int` (was `np.intp`).
- New `ImporterName` Literal alias: `_infer_importer` returns it (fixes the str-vs-Literal assignment in `from_file`) and it de-duplicates the importer literal list.

## Scope note (#43 stays open)
ty went **151 → 137**. The remaining are (a) conservative `Optional`-access in the `xdf` importer (dynamic pyxdf `dict|str|int|float` unions) and (b) `signals`/`events` Optional-access in tests. Driving those to zero and **making ty blocking** is a larger, delicate refactor best done as a focused follow-up; ty remains non-blocking (step-level `continue-on-error`) until it is truly zero. This PR is the safe, high-value subset.