### PR TITLE
Rename core EMG class -> Recording (deprecated EMG alias)

### DIFF
--- a/emgio/__init__.py
+++ b/emgio/__init__.py
@@ -1,8 +1,19 @@
-"""EMGIO: A Python package for EMG data import/export and manipulation."""
+"""emgio (evolving into biosigIO): import/export biosignal recordings across formats.
 
-from .core.emg import EMG
+The core class is :class:`Recording` (modality-agnostic: EEG/EMG/iEEG/MEG/...).
+``EMG`` is a deprecated alias of ``Recording`` kept for backward compatibility.
+"""
+
+from .core.emg import EMG, Recording
 from .exporters.edf import EDFExporter
 from .importers.trigno import TrignoImporter
 from .version import __version__, __version_info__
 
-__all__ = ["EMG", "TrignoImporter", "EDFExporter", "__version__", "__version_info__"]
+__all__ = [
+    "Recording",
+    "EMG",
+    "TrignoImporter",
+    "EDFExporter",
+    "__version__",
+    "__version_info__",
+]

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -27,9 +27,13 @@ else:
 ImporterName = Literal["trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision"]
 
 
-class EMG:
+class Recording:
     """
-    Core EMG class for handling EMG data and metadata.
+    Core biosignal recording: signals + channels + events + metadata.
+
+    Modality-agnostic container for EEG / EMG / iEEG / MEG / stim / marker data
+    imported from any supported format. (``EMG`` is a deprecated alias of this
+    class kept for backward compatibility; prefer ``Recording``.)
 
     Attributes:
         signals (pd.DataFrame): Raw signal data with time as index.
@@ -40,7 +44,7 @@ class EMG:
     """
 
     def __init__(self):
-        """Initialize an empty EMG object."""
+        """Initialize an empty recording."""
         self.signals = None
         self.metadata = {}
         self.channels = {}
@@ -120,7 +124,7 @@ class EMG:
         force_csv: bool = False,
         bids_channels: str = "auto",
         **kwargs,
-    ) -> "EMG":
+    ) -> "Recording":
         """
         The method to create EMG object from file.
 
@@ -215,7 +219,7 @@ class EMG:
         inplace: bool = False,
         *,
         modality: str | None = None,
-    ) -> "EMG":
+    ) -> "Recording":
         """
         Select specific channels from the data and return a new EMG object.
 
@@ -281,7 +285,7 @@ class EMG:
                 raise ValueError(f"None of the selected channels are of modality: {modality}")
 
         # Create new EMG object
-        new_emg = EMG()
+        new_emg = Recording()
 
         # Copy selected signals and channels
         new_emg.signals = self.signals[channels].copy()
@@ -298,7 +302,7 @@ class EMG:
             self.metadata = new_emg.metadata
             return self
 
-    def resample(self, target_rate: float) -> "EMG":
+    def resample(self, target_rate: float) -> "Recording":
         """Return a NEW, anti-aliased down-sampled copy of this recording.
 
         Low-resolution demos need a smaller, lighter recording; this rebuilds the
@@ -367,7 +371,7 @@ class EMG:
                 "resample() only down-samples (low-res). Up-sampling is out of scope."
             )
 
-        new_emg = EMG()
+        new_emg = Recording()
         new_emg.channels = {ch: info.copy() for ch, info in self.channels.items()}
         new_emg.metadata = self.metadata.copy()
         # Onsets/durations are in SECONDS, so they remain valid after the grid
@@ -591,7 +595,7 @@ class EMG:
             logging.info(f"Verification requested. Reloading exported file: {filepath}")
             try:
                 # Reload the exported file
-                reloaded_emg = EMG.from_file(filepath, importer="edf")
+                reloaded_emg = Recording.from_file(filepath, importer="edf")
 
                 logging.info("Comparing original signals with reloaded signals...")
                 # Compare signals using the imported function
@@ -753,3 +757,9 @@ class EMG:
             self.events = pd.concat([self.events, new_event], ignore_index=True)
         # Sort events by onset time for consistency
         self.events = self.events.sort_values(by="onset").reset_index(drop=True)
+
+
+# Deprecated alias: the class was named ``EMG`` before it became modality-agnostic
+# (it now holds EEG/iEEG/MEG/EMG/...). Kept for backward compatibility; new code
+# should use ``Recording``. (Package rename emgio -> biosigio is tracked separately.)
+EMG = Recording

--- a/emgio/tests/test_recording_alias.py
+++ b/emgio/tests/test_recording_alias.py
@@ -1,0 +1,29 @@
+"""The core class is `Recording`; `EMG` is a deprecated backward-compat alias.
+
+When the package handled only EMG the class was named `EMG`; it is now a
+modality-agnostic biosignal recording (EEG/EMG/iEEG/MEG/...) named `Recording`,
+with `EMG` retained as an alias so existing code keeps working. NO MOCKS.
+"""
+
+import numpy as np
+
+from emgio import EMG, Recording
+
+
+def test_emg_is_alias_of_recording():
+    assert EMG is Recording
+
+
+def test_recording_is_the_canonical_class_name():
+    rec = Recording()
+    assert type(rec).__name__ == "Recording"
+
+
+def test_alias_works_for_construction_and_isinstance():
+    rec = Recording()
+    rec.add_channel("C", np.zeros(100), 100, "uV", "EMG")
+    via_alias = EMG()
+    via_alias.add_channel("C", np.zeros(100), 100, "uV", "EMG")
+    # Instances of one are instances of the other (same class).
+    assert isinstance(rec, EMG)
+    assert isinstance(via_alias, Recording)


### PR DESCRIPTION
## Summary
The core class holds EEG/EMG/iEEG/MEG/stim/markers — `EMG` was a misnomer. Rename it to **`Recording`** (modality-agnostic) and keep **`EMG = Recording`** as a deprecated backward-compat alias. `from emgio import Recording` is now the canonical entry point; `from emgio import EMG` still works.

Per the agreed plan: **class rename now, `emgio` → `biosigio` package rename later**.

## Scope (deliberately contained)
- `emgio/core/emg.py`: `class EMG:` → `class Recording:`, internal constructions/return hints updated, and `EMG = Recording` alias appended (doc-deprecated, no runtime warning to avoid breaking users abruptly).
- `emgio/__init__.py`: exports `Recording` (primary) + `EMG` (alias).
- Every other module and all tests keep importing `EMG` (the alias) **unchanged** — the alias is exactly what makes this low-risk.

Full internal migration (importers/exporters/docs/tests → `Recording`) and the package rename are tracked follow-ups.

## Verification
- `EMG is Recording` is `True`; alias works for construction and `isinstance` (new `test_recording_alias.py`).
- Full suite **345 passed, 4 skipped**; `ty` (now a blocking gate) reports **zero**; ruff clean.