### PR TITLE
Add Parquet + Arrow exporters/importers (round-trip)

### DIFF
--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -24,7 +24,9 @@ else:
     logging.basicConfig(level=logging.CRITICAL)  # Effectively turns off most logging
 
 # Supported importer names (extension-inferred or passed explicitly to from_file).
-ImporterName = Literal["trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision"]
+ImporterName = Literal[
+    "trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision", "tabular"
+]
 
 
 class Recording:
@@ -113,6 +115,8 @@ class Recording:
             return "meg"
         elif extension in {".vhdr"}:
             return "brainvision"
+        elif extension in {".parquet", ".feather", ".arrow"}:
+            return "tabular"
         else:
             raise ValueError(f"Unsupported file extension: {extension}")
 
@@ -140,6 +144,7 @@ class Recording:
                 - 'xdf': XDF format (multi-stream Lab Streaming Layer files)
                 - 'meg': MEG via MNE (.fif and CTF .ds; requires the 'meg' extra)
                 - 'brainvision': BrainVision .vhdr via MNE (requires the 'meg' extra)
+                - 'tabular': biosigIO Parquet/Arrow/Feather (requires the 'arrow' extra)
                 If None, the importer will be inferred from the file extension.
                 Automatic import is supported for CSV/TXT files.
             force_csv: If True and importer is 'csv', forces using the generic CSV
@@ -170,6 +175,7 @@ class Recording:
             "xdf": "XDFImporter",  # XDF multi-stream format
             "meg": "MEGImporter",  # MEG via MNE (.fif, CTF .ds)
             "brainvision": "BrainVisionImporter",  # BrainVision via MNE (.vhdr)
+            "tabular": "TabularImporter",  # biosigIO Parquet / Arrow / Feather
         }
 
         if importer not in importers:
@@ -184,7 +190,8 @@ class Recording:
                 "- wfdb: Waveform Database\n"
                 "- xdf: XDF multi-stream format\n"
                 "- meg: MEG via MNE (.fif, CTF .ds)\n"
-                "- brainvision: BrainVision via MNE (.vhdr)"
+                "- brainvision: BrainVision via MNE (.vhdr)\n"
+                "- tabular: biosigIO Parquet/Arrow/Feather (.parquet, .feather, .arrow)"
             )
 
         # If using CSV importer and force_csv is set, pass it as force_generic
@@ -627,6 +634,40 @@ class Recording:
                 }
 
         return verification_report_dict
+
+    def to_parquet(self, filepath: str) -> str:
+        """Export to a self-describing biosigIO Parquet file.
+
+        Signals are stored as a columnar table (channels = columns, time index
+        preserved); channels/events/metadata travel in the file's schema metadata,
+        so ``Recording.from_file`` round-trips it losslessly. Great for analytics
+        (DuckDB/Polars/pandas/Spark). Requires the ``arrow`` extra (pyarrow).
+
+        Args:
+            filepath: Output ``.parquet`` path.
+
+        Returns:
+            str: The written file path.
+        """
+        from ..exporters.tabular import TabularExporter
+
+        return TabularExporter.to_parquet(self, filepath)
+
+    def to_arrow(self, filepath: str) -> str:
+        """Export to a biosigIO Arrow/Feather file (fast zero-copy IPC).
+
+        Same self-describing schema as :meth:`to_parquet`; round-trips via
+        ``Recording.from_file``. Requires the ``arrow`` extra (pyarrow).
+
+        Args:
+            filepath: Output ``.feather`` / ``.arrow`` path.
+
+        Returns:
+            str: The written file path.
+        """
+        from ..exporters.tabular import TabularExporter
+
+        return TabularExporter.to_arrow(self, filepath)
 
     def set_metadata(self, key: str, value: Any) -> None:
         """

--- a/emgio/exporters/tabular.py
+++ b/emgio/exporters/tabular.py
@@ -8,7 +8,7 @@ optional dependency (the ``arrow`` extra), imported lazily.
 """
 
 from ..core.emg import Recording
-from ..tabular_schema import recording_to_table, require_pyarrow
+from ..tabular_schema import recording_to_table
 
 
 class TabularExporter:
@@ -16,16 +16,18 @@ class TabularExporter:
 
     @staticmethod
     def to_parquet(rec: Recording, filepath: str) -> str:
-        require_pyarrow()
+        # recording_to_table calls require_pyarrow() (clear install hint) before
+        # we import the pyarrow.parquet submodule.
+        table = recording_to_table(rec)
         import pyarrow.parquet as pq
 
-        pq.write_table(recording_to_table(rec), filepath)
+        pq.write_table(table, filepath)
         return filepath
 
     @staticmethod
     def to_arrow(rec: Recording, filepath: str) -> str:
-        require_pyarrow()
+        table = recording_to_table(rec)
         import pyarrow.feather as feather
 
-        feather.write_feather(recording_to_table(rec), filepath)
+        feather.write_feather(table, filepath)
         return filepath

--- a/emgio/exporters/tabular.py
+++ b/emgio/exporters/tabular.py
@@ -1,0 +1,31 @@
+"""Parquet and Arrow/Feather exporters (biosigIO tabular schema).
+
+Thin wrappers over :mod:`emgio.tabular_schema`: a Recording becomes one columnar
+table (channels = columns, time index preserved) with a self-describing
+``biosigio`` metadata blob, written as Parquet (analytics) or Arrow/Feather
+(fast IPC). Both round-trip losslessly via ``Recording.from_file``. pyarrow is an
+optional dependency (the ``arrow`` extra), imported lazily.
+"""
+
+from ..core.emg import Recording
+from ..tabular_schema import recording_to_table, require_pyarrow
+
+
+class TabularExporter:
+    """Exporter for the columnar biosigIO formats (Parquet, Arrow/Feather)."""
+
+    @staticmethod
+    def to_parquet(rec: Recording, filepath: str) -> str:
+        require_pyarrow()
+        import pyarrow.parquet as pq
+
+        pq.write_table(recording_to_table(rec), filepath)
+        return filepath
+
+    @staticmethod
+    def to_arrow(rec: Recording, filepath: str) -> str:
+        require_pyarrow()
+        import pyarrow.feather as feather
+
+        feather.write_feather(recording_to_table(rec), filepath)
+        return filepath

--- a/emgio/importers/tabular.py
+++ b/emgio/importers/tabular.py
@@ -1,0 +1,34 @@
+"""Importer for the columnar biosigIO formats (Parquet, Arrow/Feather).
+
+Reads a biosigIO tabular file (written by :class:`TabularExporter`) back into a
+:class:`~emgio.core.emg.Recording`, reconstructing signals (with their time
+index), per-channel metadata, events, and recording metadata from the
+self-describing ``biosigio`` schema blob. pyarrow is an optional dependency
+(the ``arrow`` extra), imported lazily.
+"""
+
+import os
+
+from ..core.emg import Recording
+from ..tabular_schema import require_pyarrow, table_to_recording
+from .base import BaseImporter
+
+
+class TabularImporter(BaseImporter):
+    """Importer for .parquet and .feather/.arrow biosigIO files."""
+
+    def load(self, filepath: str) -> Recording:
+        require_pyarrow()
+        ext = os.path.splitext(filepath)[1].lower()
+        try:
+            if ext == ".parquet":
+                import pyarrow.parquet as pq
+
+                table = pq.read_table(filepath)
+            else:  # .feather / .arrow
+                import pyarrow.feather as feather
+
+                table = feather.read_table(filepath)
+        except Exception as e:
+            raise ValueError(f"Error reading tabular file {filepath}: {e}") from e
+        return table_to_recording(table)

--- a/emgio/tabular_schema.py
+++ b/emgio/tabular_schema.py
@@ -1,0 +1,107 @@
+"""Canonical biosigIO tabular serialization schema (Parquet / Arrow / Feather).
+
+A :class:`~emgio.core.emg.Recording` is stored as a single columnar table whose
+columns are the channel signals (the time index is preserved). All non-signal
+state -- recording metadata, per-channel info, and events -- is serialized as one
+JSON blob under the ``biosigio`` schema-metadata key, so the file is fully
+self-describing and round-trips losslessly. The same schema backs both the
+exporter and the importer (and is intended to back the future Zarr path), so it
+lives here once rather than being duplicated.
+
+pyarrow is an optional dependency (``arrow`` extra), imported lazily.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+    from .core.emg import Recording
+
+# Schema-metadata key + format tag/version, so a reader can recognize and
+# version-check a biosigIO tabular file.
+METADATA_KEY = b"biosigio"
+FORMAT = "biosigio-tabular"
+VERSION = 1
+
+
+def require_pyarrow():
+    """Import pyarrow lazily, raising a clear install hint when it is absent."""
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "Parquet/Arrow serialization requires pyarrow, an optional dependency. "
+            "Install it with: uv sync --extra arrow  (or, for an existing install, "
+            "uv pip install 'emgio[arrow]')."
+        ) from e
+    import pyarrow
+
+    return pyarrow
+
+
+def _json_default(obj: Any):
+    """Make numpy scalars/arrays JSON-serializable; fall back to str."""
+    if isinstance(obj, np.generic):
+        return obj.item()
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    return str(obj)
+
+
+def recording_to_table(rec: Recording) -> pa.Table:
+    """Build a pyarrow Table from a Recording (signals + biosigio metadata blob)."""
+    pa = require_pyarrow()
+    if rec.signals is None:
+        raise ValueError("No signals to serialize")
+
+    table = pa.Table.from_pandas(rec.signals, preserve_index=True)
+    events = (
+        rec.events.to_dict("records") if rec.events is not None and not rec.events.empty else []
+    )
+    blob = json.dumps(
+        {
+            "format": FORMAT,
+            "version": VERSION,
+            "metadata": dict(rec.metadata),
+            "channels": {name: dict(info) for name, info in rec.channels.items()},
+            "events": events,
+        },
+        default=_json_default,
+    ).encode("utf-8")
+    existing = table.schema.metadata or {}
+    return table.replace_schema_metadata({**existing, METADATA_KEY: blob})
+
+
+def table_to_recording(table: pa.Table) -> Recording:
+    """Reconstruct a Recording from a biosigIO tabular Table."""
+    from .core.emg import Recording
+
+    blob = (table.schema.metadata or {}).get(METADATA_KEY)
+    if blob is None:
+        raise ValueError(
+            "Not a biosigIO tabular file: missing the 'biosigio' schema metadata. "
+            "Only files written by emgio's Parquet/Arrow exporter can be imported."
+        )
+    meta = json.loads(blob)
+    if meta.get("format") != FORMAT:
+        raise ValueError(f"Unexpected tabular format tag: {meta.get('format')!r}")
+
+    rec = Recording()
+    rec.signals = table.to_pandas()  # restores the preserved (time) index
+    rec.metadata = meta.get("metadata", {})
+    rec.channels = meta.get("channels", {})
+
+    event_rows = meta.get("events", [])
+    if event_rows:
+        events = pd.DataFrame(event_rows, columns=["onset", "duration", "description"])
+        events["onset"] = events["onset"].astype("float64")
+        events["duration"] = events["duration"].astype("float64")
+        rec.events = events
+    return rec

--- a/emgio/tabular_schema.py
+++ b/emgio/tabular_schema.py
@@ -13,6 +13,7 @@ pyarrow is an optional dependency (``arrow`` extra), imported lazily.
 
 from __future__ import annotations
 
+import datetime
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -46,13 +47,43 @@ def require_pyarrow():
     return pyarrow
 
 
+# Marks a JSON object that encodes a non-JSON-native value (e.g. a datetime) so
+# it can be reconstructed to its original type on read, instead of silently
+# degrading to a string.
+_TYPE_KEY = "__biosigio_type__"
+
+
 def _json_default(obj: Any):
-    """Make numpy scalars/arrays JSON-serializable; fall back to str."""
+    """Encode non-JSON-native values losslessly; RAISE rather than silently coerce.
+
+    datetimes/dates become a typed envelope (reconstructed by ``_json_object_hook``)
+    and numpy scalars/arrays become their Python equivalents. Anything else raises
+    a TypeError so unexpected metadata is surfaced, never silently str()-ified
+    (metadata loss is data loss).
+    """
+    if isinstance(obj, datetime.datetime):
+        return {_TYPE_KEY: "datetime", "value": obj.isoformat()}
+    if isinstance(obj, datetime.date):
+        return {_TYPE_KEY: "date", "value": obj.isoformat()}
     if isinstance(obj, np.generic):
         return obj.item()
     if isinstance(obj, np.ndarray):
         return obj.tolist()
-    return str(obj)
+    raise TypeError(
+        f"Object of type {type(obj).__name__!r} in recording metadata is not JSON-"
+        "serializable and cannot be stored in the biosigIO tabular schema; convert "
+        "it to a primitive (or datetime) before exporting."
+    )
+
+
+def _json_object_hook(d: dict) -> Any:
+    """Reconstruct typed envelopes written by :func:`_json_default`."""
+    kind = d.get(_TYPE_KEY)
+    if kind == "datetime":
+        return datetime.datetime.fromisoformat(d["value"])
+    if kind == "date":
+        return datetime.date.fromisoformat(d["value"])
+    return d
 
 
 def recording_to_table(rec: Recording) -> pa.Table:
@@ -89,9 +120,14 @@ def table_to_recording(table: pa.Table) -> Recording:
             "Not a biosigIO tabular file: missing the 'biosigio' schema metadata. "
             "Only files written by emgio's Parquet/Arrow exporter can be imported."
         )
-    meta = json.loads(blob)
+    meta = json.loads(blob, object_hook=_json_object_hook)
     if meta.get("format") != FORMAT:
         raise ValueError(f"Unexpected tabular format tag: {meta.get('format')!r}")
+    if meta.get("version") != VERSION:
+        raise ValueError(
+            f"Unsupported biosigIO tabular schema version {meta.get('version')!r} "
+            f"(this build reads version {VERSION})."
+        )
 
     rec = Recording()
     rec.signals = table.to_pandas()  # restores the preserved (time) index

--- a/emgio/tests/test_tabular.py
+++ b/emgio/tests/test_tabular.py
@@ -1,0 +1,70 @@
+"""Parquet / Arrow round-trip tests for the biosigIO tabular schema.
+
+Columnar storage is lossless (no quantization like EDF), so the round-trip must
+be bit-exact on signals and fully preserve the time index, per-channel metadata,
+and events via the self-describing ``biosigio`` schema blob. NO MOCKS: real
+fixture, real pyarrow files. Skips if the optional ``arrow`` extra is absent.
+"""
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from emgio import Recording
+
+pytest.importorskip("pyarrow", reason="tabular serialization requires the optional 'arrow' extra")
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EMG_EDF = _REPO / "examples/bids/emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
+
+requires_emg = pytest.mark.skipif(not EMG_EDF.exists(), reason="EMG fixture missing")
+
+
+@requires_emg
+@pytest.mark.parametrize("ext,method", [("parquet", "to_parquet"), ("feather", "to_arrow")])
+def test_tabular_roundtrip_is_lossless(tmp_path, ext, method):
+    rec = Recording.from_file(str(EMG_EDF))
+    rec.add_event(onset=0.5, duration=0.1, description="m1")
+    rec.add_event(onset=1.0, duration=0.0, description="m2")
+
+    out = tmp_path / f"r.{ext}"
+    assert getattr(rec, method)(str(out)) == str(out)
+    rt = Recording.from_file(str(out))
+
+    # Signals are bit-exact (columnar storage is lossless), with the time index.
+    assert np.array_equal(rec.signals.to_numpy(), rt.signals.to_numpy())
+    assert np.allclose(rec.signals.index.to_numpy(), rt.signals.index.to_numpy())
+    assert list(rt.signals.columns) == list(rec.signals.columns)
+
+    # Per-channel metadata preserved.
+    for ch in rec.channels:
+        for key in ("channel_type", "modality", "physical_dimension", "sample_frequency"):
+            assert rt.channels[ch][key] == rec.channels[ch][key]
+
+    # Events preserved (sorted, with values).
+    assert list(rt.events["description"]) == ["m1", "m2"]
+    assert np.allclose(rt.events["onset"].to_numpy(), [0.5, 1.0])
+    assert rt.events["onset"].dtype == np.float64
+
+
+@requires_emg
+def test_tabular_explicit_importer_and_no_modality_creep(tmp_path):
+    rec = Recording.from_file(str(EMG_EDF))
+    out = tmp_path / "r.parquet"
+    rec.to_parquet(str(out))
+    rt = Recording.from_file(str(out), importer="tabular")
+    assert len(rt.channels) == len(rec.channels)
+    # The reconstructed object is a Recording with the same channel set.
+    assert isinstance(rt, Recording)
+    assert set(rt.channels) == set(rec.channels)
+
+
+def test_plain_parquet_is_rejected(tmp_path):
+    """A non-biosigIO parquet (no schema blob) must be rejected with a clear error."""
+    import pandas as pd
+
+    path = tmp_path / "plain.parquet"
+    pd.DataFrame({"a": [1.0, 2.0, 3.0]}).to_parquet(path)
+    with pytest.raises(ValueError, match="biosigIO tabular"):
+        Recording.from_file(str(path))

--- a/emgio/tests/test_tabular.py
+++ b/emgio/tests/test_tabular.py
@@ -47,6 +47,13 @@ def test_tabular_roundtrip_is_lossless(tmp_path, ext, method):
     assert np.allclose(rt.events["onset"].to_numpy(), [0.5, 1.0])
     assert rt.events["onset"].dtype == np.float64
 
+    # Recording metadata preserved with TYPES intact (e.g. startdate stays a
+    # datetime, not silently coerced to a string).
+    for key, value in rec.metadata.items():
+        assert key in rt.metadata, f"metadata key {key!r} dropped"
+        assert type(rt.metadata[key]) is type(value), f"metadata[{key!r}] type changed"
+        assert rt.metadata[key] == value, f"metadata[{key!r}] value changed"
+
 
 @requires_emg
 def test_tabular_explicit_importer_and_no_modality_creep(tmp_path):
@@ -58,6 +65,27 @@ def test_tabular_explicit_importer_and_no_modality_creep(tmp_path):
     # The reconstructed object is a Recording with the same channel set.
     assert isinstance(rt, Recording)
     assert set(rt.channels) == set(rec.channels)
+
+
+def test_tabular_roundtrip_with_no_events(tmp_path):
+    """A recording with no events round-trips to an empty (typed) events frame."""
+    rec = Recording()
+    rec.add_channel("C1", np.sin(np.arange(500) / 10.0), 100, "uV", "EEG")
+    out = tmp_path / "noevents.parquet"
+    rec.to_parquet(str(out))
+    rt = Recording.from_file(str(out))
+    assert rt.events.empty
+    assert list(rt.events.columns) == ["onset", "duration", "description"]
+    assert np.array_equal(rec.signals.to_numpy(), rt.signals.to_numpy())
+
+
+def test_non_serializable_metadata_raises(tmp_path):
+    """Unexpected non-primitive metadata must raise, not be silently str()-ified."""
+    rec = Recording()
+    rec.add_channel("C1", np.zeros(10), 100, "uV", "EEG")
+    rec.set_metadata("weird", object())  # not JSON/datetime/numpy serializable
+    with pytest.raises(TypeError, match="not JSON-"):
+        rec.to_parquet(str(tmp_path / "x.parquet"))
 
 
 def test_plain_parquet_is_rejected(tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,12 +61,18 @@ biosigio = "emgio.cli:main"
 meg = [
     "mne>=1.6",
 ]
+# Parquet + Arrow/Feather serialization (analytics, fast IPC). Install with
+# `uv sync --extra arrow`. Zarr will get its own extra in a later phase.
+arrow = [
+    "pyarrow>=14",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.14",
     "ty",
     "mne>=1.6",
+    "pyarrow>=14",
 ]
 docs = [
     "mkdocs>=1.6.0",
@@ -77,7 +83,7 @@ docs = [
     "mike>=2.1.0",
 ]
 all = [
-    "emgio[dev,docs,meg]",
+    "emgio[dev,docs,meg,arrow]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
v1 analytics serialization: a `Recording` can now export to **Parquet** (analytics) and **Arrow/Feather** (fast IPC), with **round-trip importers** and a shared **canonical schema** — exactly the principles agreed (round-trip + one schema, reusable for Zarr next).

- `emgio/tabular_schema.py` — the canonical schema: signals as one columnar table (channels = columns, **time index preserved**); recording metadata + per-channel info + events serialized as a single self-describing `biosigio` JSON blob in the file's schema metadata. Backs both the exporter and importer (and the future Zarr path) so it lives in one place.
- `Recording.to_parquet(path)` / `Recording.to_arrow(path)` (via `TabularExporter`).
- `TabularImporter` reads `.parquet` / `.feather` / `.arrow`; registered in `_infer_importer` + the `from_file` map (`importer="tabular"`). Non-biosigIO files are rejected with a clear error.
- pyarrow is an optional `arrow` extra (lazy import + install hint; also in `dev` so CI exercises it).

## Verification (real data, NO MOCKS)
Round-trip on the real EMG fixture, both formats: **signals bit-exact** (columnar storage is lossless, unlike EDF quantization), **time index preserved**, per-channel type/modality/unit/sample_frequency preserved, events preserved (sorted, float64). Full suite **349 passed**; `ty` (blocking gate) **zero**; ruff clean.

Next in this phase (separate PRs): **Zarr** (parallel/cloud + multi-rate), reusing this schema. Filed #74 (pre-existing pytest `testpaths` config drift surfaced while checking warnings).