### PR TITLE
Neo-backed importer for proprietary ephys formats

### DIFF
--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -25,7 +25,7 @@ else:
 
 # Supported importer names (extension-inferred or passed explicitly to from_file).
 ImporterName = Literal[
-    "trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision", "tabular"
+    "trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision", "tabular", "neo"
 ]
 
 
@@ -117,6 +117,23 @@ class Recording:
             return "brainvision"
         elif extension in {".parquet", ".feather", ".arrow"}:
             return "tabular"
+        elif extension in {
+            ".rhd",
+            ".rhs",
+            ".ns1",
+            ".ns2",
+            ".ns3",
+            ".ns4",
+            ".ns5",
+            ".ns6",
+            ".smr",
+            ".smrx",
+            ".plx",
+            ".pl2",
+            ".trc",
+            ".ncs",
+        }:
+            return "neo"
         else:
             raise ValueError(f"Unsupported file extension: {extension}")
 
@@ -145,6 +162,9 @@ class Recording:
                 - 'meg': MEG via MNE (.fif and CTF .ds; requires the 'meg' extra)
                 - 'brainvision': BrainVision .vhdr via MNE (requires the 'meg' extra)
                 - 'tabular': biosigIO Parquet/Arrow/Feather (requires the 'arrow' extra)
+                - 'neo': proprietary electrophysiology formats via python-neo
+                  (Intan, Blackrock, Spike2, Plexon, Micromed, Neuralynx, ...;
+                  requires the 'neo' extra)
                 If None, the importer will be inferred from the file extension.
                 Automatic import is supported for CSV/TXT files.
             force_csv: If True and importer is 'csv', forces using the generic CSV
@@ -176,6 +196,7 @@ class Recording:
             "meg": "MEGImporter",  # MEG via MNE (.fif, CTF .ds)
             "brainvision": "BrainVisionImporter",  # BrainVision via MNE (.vhdr)
             "tabular": "TabularImporter",  # biosigIO Parquet / Arrow / Feather
+            "neo": "NeoImporter",  # proprietary ephys via python-neo
         }
 
         if importer not in importers:
@@ -191,7 +212,9 @@ class Recording:
                 "- xdf: XDF multi-stream format\n"
                 "- meg: MEG via MNE (.fif, CTF .ds)\n"
                 "- brainvision: BrainVision via MNE (.vhdr)\n"
-                "- tabular: biosigIO Parquet/Arrow/Feather (.parquet, .feather, .arrow)"
+                "- tabular: biosigIO Parquet/Arrow/Feather (.parquet, .feather, .arrow)\n"
+                "- neo: proprietary electrophysiology formats via python-neo "
+                "(Intan, Blackrock, Spike2, Plexon, Micromed, Neuralynx, ...)"
             )
 
         # If using CSV importer and force_csv is set, pass it as force_generic

--- a/emgio/importers/neo.py
+++ b/emgio/importers/neo.py
@@ -52,6 +52,20 @@ def _physical_dimension(signal) -> str:
     return dim if dim and dim != "dimensionless" else "n/a"
 
 
+def _unique_label(name: str, used: set[str]) -> str:
+    """Return ``name``, or the first free ``name_<n>``, so merged streams stay distinct.
+
+    Counter-based so it always terminates, even when several disambiguated names
+    already collide (e.g. ``used = {"ch", "ch_0", "ch_0_0"}``).
+    """
+    if name not in used:
+        return name
+    i = 0
+    while f"{name}_{i}" in used:
+        i += 1
+    return f"{name}_{i}"
+
+
 def _channel_names(signal, stream_index: int, n_channels: int) -> list[str]:
     """Channel names from neo array annotations, falling back to generated names.
 
@@ -128,11 +142,7 @@ class NeoImporter(BaseImporter):
                 dimension = _physical_dimension(sig)
                 names = _channel_names(sig, idx, data.shape[1])
                 for col, name in enumerate(names):
-                    label = name
-                    while label in used:  # disambiguate collisions across merged streams
-                        label = f"{name}_{idx}"
-                        if label in used:
-                            label = f"{name}_{idx}_{col}"
+                    label = _unique_label(name, used)  # keep merged streams distinct
                     used.add(label)
                     emg.add_channel(
                         label=label,
@@ -145,12 +155,15 @@ class NeoImporter(BaseImporter):
             emg.signals = emg.signals.copy()  # de-fragment after many inserts (#66)
 
         # Align events to the imported signal's time origin (neo times are in the
-        # recording's absolute time base, which may not start at zero).
+        # recording's absolute time base, which may not start at zero). The 0-based
+        # signal grid discards the absolute origin, so keep it in metadata for
+        # downstream (e.g. BIDS) temporal alignment.
         t0 = float(selected[0].t_start.rescale("s").magnitude)
         self._add_events(emg, seg, t0)
 
         emg.set_metadata("source_file", filepath)
         emg.set_metadata("neo_io", type(reader).__name__)
+        emg.set_metadata("t_start_s", t0)
         emg.set_metadata("number_of_signals", len(emg.channels))
         return emg
 
@@ -183,6 +196,11 @@ class NeoImporter(BaseImporter):
                 raise ValueError(
                     f"No stream named {stream!r}; available streams: {describe(analogsignals)}"
                 )
+            if len(matches) > 1:
+                raise ValueError(
+                    f"Stream name {stream!r} is ambiguous ({len(matches)} streams share it); "
+                    f"select by integer index instead. Streams: {describe(analogsignals)}"
+                )
             return matches
 
         if len(analogsignals) == 1:
@@ -200,6 +218,15 @@ class NeoImporter(BaseImporter):
             raise ValueError(
                 f"{filepath} has same-rate streams of differing lengths that cannot share "
                 f"one time grid; pass stream= to choose one. Streams: {describe(analogsignals)}"
+            )
+        # Same rate and length but a different t_start would place samples at the
+        # wrong relative time on the shared 0-based grid -- refuse to merge silently.
+        t_starts = {round(float(s.t_start.rescale("s").magnitude), 9) for s in analogsignals}
+        if len(t_starts) > 1:
+            raise ValueError(
+                f"{filepath} has same-rate streams with differing t_start values that cannot "
+                f"share one time grid; pass stream= to choose one. Streams: "
+                f"{describe(analogsignals)}"
             )
         return list(analogsignals)
 

--- a/emgio/importers/neo.py
+++ b/emgio/importers/neo.py
@@ -1,0 +1,225 @@
+"""python-neo-backed importer for proprietary electrophysiology acquisition formats.
+
+Reads continuous recordings from the many acquisition systems covered by
+python-neo's unified reader layer (Intan .rhd/.rhs, Blackrock .ns1-.ns6,
+Spike2/CED .smr/.smrx, Plexon .plx/.pl2, Micromed .trc, Neuralynx .ncs, ...)
+into a :class:`~emgio.core.emg.Recording`.
+
+neo models a recording as Block -> Segment -> AnalogSignal, where each
+AnalogSignal is one *signal stream*: a group of channels that share a sampling
+rate (e.g. an Intan amplifier bank at 30 kHz versus an auxiliary ADC). emgio's
+single time grid holds one rate, so streams that share a rate are merged into
+one Recording, while streams at different rates require an explicit ``stream``
+selector. A multi-rate file is never silently collapsed to a single rate.
+
+neo carries signal values, physical units, sampling rates, channel names, and
+events, but not BIDS channel *types* (a .rhd file does not distinguish SEEG from
+EEG). Channels therefore default to type ``OTHER``; pass ``channel_type=`` to
+label an entire recording, or rely on a sibling BIDS ``_channels.tsv`` (applied
+by :meth:`Recording.from_file`) for per-channel types.
+
+neo is an optional, heavy dependency, imported lazily via :func:`require_neo`.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from ..core.emg import Recording
+from .base import BaseImporter
+
+
+def require_neo():
+    """Import python-neo lazily, raising a clear install hint when it is absent."""
+    try:
+        import neo  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "Neo-backed import of proprietary electrophysiology formats requires "
+            "python-neo, an optional dependency. Install it with: "
+            "uv sync --extra neo  (or, for an existing install, "
+            "uv pip install 'emgio[neo]')."
+        ) from e
+    import neo
+
+    return neo
+
+
+def _physical_dimension(signal) -> str:
+    """Map a neo AnalogSignal's units to an EDF-style physical-dimension string."""
+    dim = str(signal.units.dimensionality)
+    return dim if dim and dim != "dimensionless" else "n/a"
+
+
+def _channel_names(signal, stream_index: int, n_channels: int) -> list[str]:
+    """Channel names from neo array annotations, falling back to generated names.
+
+    Some neo readers (and round-trips through formats that drop array
+    annotations) leave ``channel_names`` empty or mismatched; in that case names
+    are generated from the stream name so every channel is still labelled.
+    """
+    names = signal.array_annotations.get("channel_names")
+    if names is not None and len(names) == n_channels:
+        return [str(n) for n in names]
+    base = signal.name or f"stream{stream_index}"
+    return [f"{base}_{i}" for i in range(n_channels)]
+
+
+class NeoImporter(BaseImporter):
+    """Importer for proprietary electrophysiology formats via python-neo."""
+
+    def load(
+        self,
+        filepath: str,
+        *,
+        stream: int | str | None = None,
+        segment: int = 0,
+        channel_type: str = "OTHER",
+    ) -> Recording:
+        """Load a neo-readable recording into a :class:`Recording`.
+
+        Args:
+            filepath: Path to the acquisition file (or directory, for folder-based
+                formats such as Open Ephys / CTF).
+            stream: Which signal stream (neo AnalogSignal) to import, by integer
+                index or by stream name. Required only when the file holds streams
+                at more than one sampling rate; otherwise all same-rate streams are
+                merged onto one time grid.
+            segment: Segment (trial) index for multi-segment recordings (default 0).
+            channel_type: BIDS channel type applied to every imported channel.
+                neo does not carry channel types, so this defaults to ``OTHER``;
+                set it (e.g. ``"SEEG"``, ``"EEG"``, ``"EMG"``) to label the whole
+                recording, or supply a sibling ``_channels.tsv``.
+        """
+        neo = require_neo()
+        try:
+            reader = neo.io.get_io(filepath)
+            block = reader.read_block(lazy=False)
+        except Exception as e:
+            raise ValueError(f"Error reading neo file {filepath}: {e}") from e
+
+        segments = block.segments
+        if not segments:
+            raise ValueError(f"No segments found in {filepath}")
+        if not 0 <= segment < len(segments):
+            raise ValueError(
+                f"segment {segment} out of range: {filepath} has {len(segments)} segment(s)"
+            )
+        if len(segments) > 1:
+            warnings.warn(
+                f"{filepath} has {len(segments)} segments; importing segment {segment}. "
+                "Pass segment= to choose another.",
+                stacklevel=2,
+            )
+        seg = segments[segment]
+
+        selected = self._select_streams(seg.analogsignals, stream, filepath)
+
+        emg = Recording()
+        used: set[str] = set()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
+            for idx, sig in enumerate(selected):
+                data = np.asarray(sig.magnitude)
+                if data.ndim == 1:
+                    data = data[:, np.newaxis]
+                fs = float(sig.sampling_rate.rescale("Hz").magnitude)
+                dimension = _physical_dimension(sig)
+                names = _channel_names(sig, idx, data.shape[1])
+                for col, name in enumerate(names):
+                    label = name
+                    while label in used:  # disambiguate collisions across merged streams
+                        label = f"{name}_{idx}"
+                        if label in used:
+                            label = f"{name}_{idx}_{col}"
+                    used.add(label)
+                    emg.add_channel(
+                        label=label,
+                        data=data[:, col],
+                        sample_frequency=fs,
+                        physical_dimension=dimension,
+                        channel_type=channel_type,
+                    )
+        if emg.signals is not None:
+            emg.signals = emg.signals.copy()  # de-fragment after many inserts (#66)
+
+        # Align events to the imported signal's time origin (neo times are in the
+        # recording's absolute time base, which may not start at zero).
+        t0 = float(selected[0].t_start.rescale("s").magnitude)
+        self._add_events(emg, seg, t0)
+
+        emg.set_metadata("source_file", filepath)
+        emg.set_metadata("neo_io", type(reader).__name__)
+        emg.set_metadata("number_of_signals", len(emg.channels))
+        return emg
+
+    @staticmethod
+    def _select_streams(analogsignals, stream, filepath):
+        """Resolve which AnalogSignal stream(s) to import (see class docstring)."""
+        if not analogsignals:
+            raise ValueError(
+                f"No continuous analog signals found in {filepath}; events/spikes-only "
+                "recordings are not supported by the neo importer."
+            )
+
+        def describe(signals):
+            return "; ".join(
+                f"[{i}] name={s.name!r} rate={float(s.sampling_rate.rescale('Hz').magnitude)}Hz "
+                f"channels={s.shape[1] if s.ndim > 1 else 1}"
+                for i, s in enumerate(signals)
+            )
+
+        if stream is not None:
+            if isinstance(stream, int):
+                if not 0 <= stream < len(analogsignals):
+                    raise ValueError(
+                        f"stream index {stream} out of range; available streams: "
+                        f"{describe(analogsignals)}"
+                    )
+                return [analogsignals[stream]]
+            matches = [s for s in analogsignals if s.name == stream]
+            if not matches:
+                raise ValueError(
+                    f"No stream named {stream!r}; available streams: {describe(analogsignals)}"
+                )
+            return matches
+
+        if len(analogsignals) == 1:
+            return list(analogsignals)
+
+        rates = {float(s.sampling_rate.rescale("Hz").magnitude) for s in analogsignals}
+        if len(rates) > 1:
+            raise ValueError(
+                f"{filepath} has {len(analogsignals)} signal streams at different sampling "
+                f"rates; pass stream= (index or name) to choose one. Streams: "
+                f"{describe(analogsignals)}"
+            )
+        lengths = {s.shape[0] for s in analogsignals}
+        if len(lengths) > 1:
+            raise ValueError(
+                f"{filepath} has same-rate streams of differing lengths that cannot share "
+                f"one time grid; pass stream= to choose one. Streams: {describe(analogsignals)}"
+            )
+        return list(analogsignals)
+
+    @staticmethod
+    def _add_events(emg: Recording, seg, t0: float) -> None:
+        """Add neo Events (instantaneous) and Epochs (with duration) as emgio events."""
+
+        def labels_for(obj, times):
+            labels = [str(label) for label in np.asarray(obj.labels)]
+            if len(labels) != len(times):  # neo objects may carry no labels
+                base = obj.name or "event"
+                labels = [f"{base}_{i}" for i in range(len(times))]
+            return labels
+
+        for ev in seg.events:
+            times = np.asarray(ev.times.rescale("s").magnitude)
+            for onset, label in zip(times, labels_for(ev, times), strict=True):
+                emg.add_event(onset=float(onset) - t0, duration=0.0, description=label)
+        for ep in seg.epochs:
+            times = np.asarray(ep.times.rescale("s").magnitude)
+            durations = np.asarray(ep.durations.rescale("s").magnitude)
+            for onset, dur, label in zip(times, durations, labels_for(ep, times), strict=True):
+                emg.add_event(onset=float(onset) - t0, duration=float(dur), description=label)

--- a/emgio/tests/test_neo_importer.py
+++ b/emgio/tests/test_neo_importer.py
@@ -18,7 +18,7 @@ from emgio import Recording
 neo = pytest.importorskip("neo", reason="neo importer requires the optional 'neo' extra")
 import quantities as pq  # noqa: E402  (only importable once neo is present)
 
-from emgio.importers.neo import NeoImporter, _channel_names  # noqa: E402
+from emgio.importers.neo import NeoImporter, _channel_names, _unique_label  # noqa: E402
 
 
 def _write_block(path, streams, *, events=None, epochs=None):
@@ -55,6 +55,7 @@ def test_neo_roundtrip_single_stream(tmp_path):
 
     rec = NeoImporter().load(str(path))
 
+    assert rec.signals is not None
     assert len(rec.channels) == 3
     assert rec.signals.shape == (1000, 3)
     for ch in rec.channels:
@@ -62,6 +63,7 @@ def test_neo_roundtrip_single_stream(tmp_path):
         assert rec.channels[ch]["physical_dimension"] == "uV"
         assert rec.channels[ch]["channel_type"] == "OTHER"
     assert np.allclose(np.sort(rec.signals.to_numpy(), axis=0), np.sort(data, axis=0))
+    assert rec.metadata["t_start_s"] == 0.0
 
 
 def test_neo_from_file_routing(tmp_path):
@@ -92,9 +94,13 @@ def test_neo_infer_importer_extensions():
 # --- stream selection (real in-memory neo AnalogSignals, no mocks) ---
 
 
-def _sig(name, n_samples, n_channels, rate):
+def _sig(name, n_samples, n_channels, rate, t_start=0.0):
     return neo.AnalogSignal(
-        np.zeros((n_samples, n_channels)), units="uV", sampling_rate=rate * pq.Hz, name=name
+        np.zeros((n_samples, n_channels)),
+        units="uV",
+        sampling_rate=rate * pq.Hz,
+        t_start=t_start * pq.s,
+        name=name,
     )
 
 
@@ -120,15 +126,34 @@ def test_select_multirate_requires_selector():
         NeoImporter._select_streams(streams, "missing", "f")
 
 
+def test_select_ambiguous_stream_name_rejected():
+    streams = [_sig("amp", 100, 2, 30000.0), _sig("amp", 50, 1, 1000.0)]
+    with pytest.raises(ValueError, match="ambiguous"):
+        NeoImporter._select_streams(streams, "amp", "f")
+
+
 def test_select_same_rate_differing_lengths_rejected():
     streams = [_sig("a", 100, 2, 1000.0), _sig("b", 80, 2, 1000.0)]
     with pytest.raises(ValueError, match="differing lengths"):
         NeoImporter._select_streams(streams, None, "f")
 
 
+def test_select_same_rate_differing_t_start_rejected():
+    streams = [_sig("a", 100, 2, 1000.0, t_start=0.0), _sig("b", 100, 2, 1000.0, t_start=5.0)]
+    with pytest.raises(ValueError, match="differing t_start"):
+        NeoImporter._select_streams(streams, None, "f")
+
+
 def test_select_no_signals_rejected():
     with pytest.raises(ValueError, match="No continuous analog signals"):
         NeoImporter._select_streams([], None, "f")
+
+
+def test_unique_label_terminates_on_deep_collisions():
+    assert _unique_label("ch", set()) == "ch"
+    assert _unique_label("ch", {"ch"}) == "ch_0"
+    # The adversarial set that made the old two-step fallback spin forever.
+    assert _unique_label("ch", {"ch", "ch_0", "ch_0_0"}) == "ch_1"
 
 
 def test_channel_names_from_annotations_else_generated():

--- a/emgio/tests/test_neo_importer.py
+++ b/emgio/tests/test_neo_importer.py
@@ -1,0 +1,186 @@
+"""Tests for the python-neo-backed electrophysiology importer.
+
+NO MOCKS: signals flow through real neo objects and real files. The full load
+path is exercised against a real neo file (written with ``NeoMatlabIO``, which
+needs only scipy, so no proprietary binary fixture has to be vendored), and the
+stream-selection / event-alignment logic is exercised directly against real
+in-memory neo ``AnalogSignal``/``Segment`` objects. The proprietary readers
+themselves (Intan, Blackrock, ...) are neo's responsibility and are covered by
+neo's own test suite; here we verify the neo -> Recording mapping. Skips when
+the optional ``neo`` extra is absent.
+"""
+
+import numpy as np
+import pytest
+
+from emgio import Recording
+
+neo = pytest.importorskip("neo", reason="neo importer requires the optional 'neo' extra")
+import quantities as pq  # noqa: E402  (only importable once neo is present)
+
+from emgio.importers.neo import NeoImporter, _channel_names  # noqa: E402
+
+
+def _write_block(path, streams, *, events=None, epochs=None):
+    """Write a real neo Block (list of AnalogSignals + optional events) to a .mat.
+
+    ``streams`` is a list of (name, data 2-D array, rate_hz, units, t_start_s).
+    NeoMatlabIO round-trips through scipy, so the file is a genuine neo file.
+    """
+    seg = neo.Segment()
+    for name, data, rate, units, t_start in streams:
+        sig = neo.AnalogSignal(
+            data.astype("float64"),
+            units=units,
+            sampling_rate=rate * pq.Hz,
+            t_start=t_start * pq.s,
+            name=name,
+        )
+        seg.analogsignals.append(sig)
+    for ev in events or []:
+        seg.events.append(ev)
+    for ep in epochs or []:
+        seg.epochs.append(ep)
+    block = neo.Block()
+    block.segments.append(seg)
+    neo.io.NeoMatlabIO(filename=str(path)).write_block(block)
+    return path
+
+
+def test_neo_roundtrip_single_stream(tmp_path):
+    """A single-stream neo file imports with correct data, rate, and units."""
+    t = np.arange(1000)
+    data = np.column_stack([np.sin(t / 10.0), np.cos(t / 7.0), t / 100.0])
+    path = _write_block(tmp_path / "rec.mat", [("amp", data, 2000.0, "uV", 0.0)])
+
+    rec = NeoImporter().load(str(path))
+
+    assert len(rec.channels) == 3
+    assert rec.signals.shape == (1000, 3)
+    for ch in rec.channels:
+        assert rec.channels[ch]["sample_frequency"] == 2000.0
+        assert rec.channels[ch]["physical_dimension"] == "uV"
+        assert rec.channels[ch]["channel_type"] == "OTHER"
+    assert np.allclose(np.sort(rec.signals.to_numpy(), axis=0), np.sort(data, axis=0))
+
+
+def test_neo_from_file_routing(tmp_path):
+    """Recording.from_file dispatches to the neo importer when asked explicitly."""
+    data = np.random.randn(200, 2)
+    path = _write_block(tmp_path / "rec.mat", [("amp", data, 500.0, "V", 0.0)])
+    rec = Recording.from_file(str(path), importer="neo")
+    assert isinstance(rec, Recording)
+    assert len(rec.channels) == 2
+
+
+def test_neo_channel_type_labels_whole_recording(tmp_path):
+    """channel_type= labels every channel and infers the coarse modality."""
+    data = np.random.randn(300, 4)
+    path = _write_block(tmp_path / "rec.mat", [("amp", data, 1000.0, "uV", 0.0)])
+    rec = NeoImporter().load(str(path), channel_type="SEEG")
+    for ch in rec.channels:
+        assert rec.channels[ch]["channel_type"] == "SEEG"
+        assert rec.channels[ch]["modality"] == "IEEG"
+
+
+def test_neo_infer_importer_extensions():
+    """Proprietary ephys extensions route to the neo importer."""
+    for ext in (".rhd", ".rhs", ".ns5", ".smr", ".plx", ".trc", ".ncs"):
+        assert Recording._infer_importer(f"rec{ext}") == "neo"
+
+
+# --- stream selection (real in-memory neo AnalogSignals, no mocks) ---
+
+
+def _sig(name, n_samples, n_channels, rate):
+    return neo.AnalogSignal(
+        np.zeros((n_samples, n_channels)), units="uV", sampling_rate=rate * pq.Hz, name=name
+    )
+
+
+def test_select_single_and_same_rate_merge():
+    one = [_sig("a", 100, 3, 1000.0)]
+    assert NeoImporter._select_streams(one, None, "f") == one
+
+    same_rate = [_sig("a", 100, 3, 1000.0), _sig("b", 100, 2, 1000.0)]
+    assert NeoImporter._select_streams(same_rate, None, "f") == same_rate  # merged
+
+
+def test_select_multirate_requires_selector():
+    streams = [_sig("amp", 100, 3, 30000.0), _sig("lfp", 50, 2, 1000.0)]
+    with pytest.raises(ValueError, match="different sampling rates"):
+        NeoImporter._select_streams(streams, None, "f")
+
+    assert NeoImporter._select_streams(streams, 1, "f") == [streams[1]]  # by index
+    assert NeoImporter._select_streams(streams, "lfp", "f") == [streams[1]]  # by name
+
+    with pytest.raises(ValueError, match="out of range"):
+        NeoImporter._select_streams(streams, 5, "f")
+    with pytest.raises(ValueError, match="No stream named"):
+        NeoImporter._select_streams(streams, "missing", "f")
+
+
+def test_select_same_rate_differing_lengths_rejected():
+    streams = [_sig("a", 100, 2, 1000.0), _sig("b", 80, 2, 1000.0)]
+    with pytest.raises(ValueError, match="differing lengths"):
+        NeoImporter._select_streams(streams, None, "f")
+
+
+def test_select_no_signals_rejected():
+    with pytest.raises(ValueError, match="No continuous analog signals"):
+        NeoImporter._select_streams([], None, "f")
+
+
+def test_channel_names_from_annotations_else_generated():
+    sig = _sig("amp", 10, 3, 1000.0)
+    sig.array_annotate(channel_names=np.array(["L1", "L2", "L3"]))
+    assert _channel_names(sig, 0, 3) == ["L1", "L2", "L3"]
+
+    bare = _sig("amp", 10, 2, 1000.0)  # no channel_names annotation
+    assert _channel_names(bare, 0, 2) == ["amp_0", "amp_1"]
+
+
+def test_merged_stream_channel_names_are_unique(tmp_path):
+    """Two same-rate streams with colliding generated names stay distinct."""
+    a = np.random.randn(50, 1)
+    b = np.random.randn(50, 1)
+    # Both streams unnamed -> generated names would collide on stream0/stream1.
+    path = _write_block(
+        tmp_path / "rec.mat", [("dup", a, 1000.0, "uV", 0.0), ("dup", b, 1000.0, "uV", 0.0)]
+    )
+    rec = NeoImporter().load(str(path))
+    assert len(rec.channels) == 2
+    assert len(set(rec.channels)) == 2  # no duplicate labels
+
+
+# --- event / epoch alignment (real in-memory neo Segment, no mocks) ---
+
+
+def test_events_and_epochs_aligned_to_stream_origin():
+    """neo Events/Epochs become emgio events, shifted by the stream's t_start."""
+    seg = neo.Segment()
+    seg.events.append(
+        neo.Event(times=np.array([3.0, 3.7]) * pq.s, labels=np.array(["stim", "resp"]))
+    )
+    seg.epochs.append(
+        neo.Epoch(
+            times=np.array([3.2]) * pq.s,
+            durations=np.array([0.4]) * pq.s,
+            labels=np.array(["burst"]),
+        )
+    )
+    rec = Recording()
+    NeoImporter._add_events(rec, seg, t0=2.5)
+
+    events = rec.events.sort_values("onset").reset_index(drop=True)
+    assert list(events["description"]) == ["stim", "burst", "resp"]
+    assert np.allclose(events["onset"].to_numpy(), [0.5, 0.7, 1.2])
+    assert np.allclose(events["duration"].to_numpy(), [0.0, 0.4, 0.0])
+
+
+def test_events_without_labels_get_generated_descriptions():
+    seg = neo.Segment()
+    seg.events.append(neo.Event(times=np.array([1.0, 2.0]) * pq.s, name="trig"))
+    rec = Recording()
+    NeoImporter._add_events(rec, seg, t0=0.0)
+    assert list(rec.events["description"]) == ["trig_0", "trig_1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ meg = [
 arrow = [
     "pyarrow>=14",
 ]
+# Proprietary electrophysiology acquisition formats (Intan, Blackrock, Spike2,
+# Plexon, Micromed, Neuralynx, ...) via python-neo. Install with
+# `uv sync --extra neo`.
+neo = [
+    "neo>=0.13",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
@@ -73,6 +79,7 @@ dev = [
     "ty",
     "mne>=1.6",
     "pyarrow>=14",
+    "neo>=0.13",
 ]
 docs = [
     "mkdocs>=1.6.0",
@@ -83,7 +90,7 @@ docs = [
     "mike>=2.1.0",
 ]
 all = [
-    "emgio[dev,docs,meg,arrow]",
+    "emgio[dev,docs,meg,arrow,neo]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
Adds a python-neo-backed importer (`NeoImporter`) so emgio can read proprietary electrophysiology acquisition formats (Intan `.rhd/.rhs`, Blackrock `.ns1`-`.ns6`, Spike2/CED `.smr/.smrx`, Plexon `.plx/.pl2`, Micromed `.trc`, Neuralynx `.ncs`, ...) into a `Recording`. Part of the biosigIO epic (#44), Direction B. Closes #76.

## Design
- `emgio/importers/neo.py` over `neo.io.get_io` + `read_block`. neo is an optional, heavy dependency, imported lazily via `require_neo()` (clear install hint), behind a new `neo` extra (added to `dev` so CI/`ty` resolve it).
- neo models a recording as Block -> Segment -> AnalogSignal, where each AnalogSignal is one *signal stream* (channels sharing a rate). emgio's single time grid holds one rate, so:
  - same-rate streams merge onto one grid (unique labels guaranteed),
  - multi-rate files require an explicit `stream=` selector (index or name) and are never silently collapsed,
  - same-rate streams of differing lengths are rejected (cannot share a grid).
- neo carries values, units, rates, channel names, and events, but not BIDS channel *types*; channels default to `OTHER`, overridable via `channel_type=` (labels the whole recording) or a sibling `_channels.tsv` (applied by `from_file`).
- Events: neo `Event` (instantaneous) + `Epoch` (with duration) -> emgio events, aligned to the stream's `t_start`.
- Registered in `_infer_importer`, the `from_file` map, and the `ImporterName` literal.

## Testing (NO MOCKS)
`emgio/tests/test_neo_importer.py`: the full load path runs against a real neo file written with `NeoMatlabIO` (scipy-only, so no proprietary binary fixture is vendored); stream-selection and event/epoch-alignment logic run against real in-memory neo `AnalogSignal`/`Segment` objects. The proprietary readers themselves are neo's responsibility (covered by neo's own suite).

- 363 passed, 4 skipped (full suite)
- `ty check emgio` clean (blocking gate)
- ruff check + format clean

## Notes
- Standalone events-only files (e.g. Blackrock `.nev` with no continuous data) raise a clear error rather than importing empty; paired `.ns*`+`.nev` works because neo reads the sibling `.nev` events when loading the `.ns*`.