### PR TITLE
Zarr serving-format exporter + reader (PRD M1/M2)

### DIFF
--- a/.context/prototypes/biosignal_zarr_PRD.md
+++ b/.context/prototypes/biosignal_zarr_PRD.md
@@ -1,0 +1,220 @@
+# Biosignal Zarr Serving Format
+
+**PRD and engineering specification**
+
+| | |
+|---|---|
+| Status | Draft for engineering review |
+| Owner | Yahya Shirazi |
+| Applies to | `biosigio` (formerly `emgio`), NEMAR serving layer |
+| Reference code | `zarr_exporter.py` (target path `biosigio/exporters/zarr.py`) |
+
+---
+
+## 1. Summary
+
+We need one derived data format that serves three jobs from a single conversion: fast viewing on edge devices, inference at the edge and in batch, and training-time streaming. Today `biosigio` exports only EDF and EDF+ (events as annotations), and NEMAR holds BIDS data on object storage. EDF is an archival container, not a serving format, so neither viewing nor ML streams from it well.
+
+The decision is to add a **sharded Zarr v3 exporter with a min/max view pyramid**. The BIDS dataset stays the source of truth. The Zarr store is a derived serving copy that all three consumers read directly from object storage, with no decode backend required for reads.
+
+This document records the decisions, the on-disk contract, the signal-processing rules, the serving model, and the work plan.
+
+---
+
+## 2. Goals and non-goals
+
+**Goals**
+
+- One conversion and one store per recording. No separate viewing and training pipelines.
+- Interactive viewing of arbitrarily long recordings on thin clients, with bounded bytes per view.
+- Inference-ready signal at a sensible per-modality rate, readable in the browser and in Python.
+- Training-time throughput comparable to a sharded sequential format.
+- Reproducible downsampling, with provenance in metadata.
+
+**Non-goals**
+
+- Replacing BIDS or EDF. BIDS remains the archival source of truth and the citable artifact.
+- Replacing XDF or LSL. Those stay the acquisition and live-stream layer. This format is downstream of acquisition.
+- A general analysis API. The store is a typed array contract that clients read directly.
+
+---
+
+## 3. Why Zarr, and why not the alternatives
+
+We evaluated the formats already in or adjacent to the field.
+
+| Format | Role it solves well | Why not the single serving store |
+|---|---|---|
+| EDF, EDF+ | Archival interchange, current biosigio output | Record-interleaved, no index, no multi-resolution, not browser-native |
+| XDF | LSL acquisition and live multi-stream recording | Append-only, no index, in-memory load, no browser reader. NEMAR data is not even in XDF |
+| WebDataset | Training throughput (sequential shards) | No random access, no pyramids, cannot serve interactive viewing |
+| Parquet, Arrow | Events, annotations, channel and dataset metadata | Wrong shape for dense multichannel signal and view pyramids |
+| **Zarr v3 (sharded)** | **Chosen** | Chunked random access plus shard-level sequential reads, multi-resolution, cloud-native, browser readers exist |
+
+The deciding feature is **Zarr v3 sharding**. A shard is one object holding many chunks plus an index. Training reads a whole shard sequentially in one request and gets many windows. Viewing and inference range-read a single chunk inside that shard. The same bytes serve both the random and the sequential access patterns, which is what lets one store cover all three jobs.
+
+Parquet and Arrow still have a role around the signal: events and metadata. We keep those lightweight and do not force them into the array store.
+
+---
+
+## 4. Store contract
+
+One Zarr v3 group per recording. The reader and writer both honor this layout.
+
+```
+/                              root group
+  attrs: biosigio_version, format="biosigio-zarr", format_version,
+         source_format, modality_rates, dtype, view_downsample,
+         anti_alias_filter, channel_groups, recording_metadata, created_utc
+
+  <modality>_<rate>hz/         one group per (modality, native rate)
+    attrs: modality, rate, original_rate, n_channels, n_samples, channels[]
+    0                          (n_ch, n_time) base signal, sharded
+      attrs: level=0, rate, downsample_factor=1, kind="signal",
+             usable_for_inference=true, scale[], offset[],
+             physical_formula="physical = digital * scale + offset"
+    view/                      min/max render pyramid (not sharded)
+      1, 2, ...                (2, n_ch, n_time_L), axis0 = [min, max]
+        attrs: level, downsample_factor, rate_effective,
+               kind="minmax_envelope", usable_for_inference=false
+
+  events/
+    onset (f64), duration (f64), code (i32)
+    attrs: label_map {code: description}, n_events
+```
+
+Per-channel metadata (in each group's `channels` attribute):
+
+`label, channel_type, modality, unit, prefilter, original_rate, target_rate, anti_aliased, usable_for_inference, scale, offset, row_index`
+
+Key contract points:
+
+- **`level 0` is the inference signal.** Anti-aliased, resampled to the canonical rate, one sample per time step. Inference and training read this.
+- **`view/*` are render envelopes.** Min/max per downsample bin, two values per bin, nonlinear. They are flagged `usable_for_inference=false`. Clients must not train or infer on them.
+- **`physical = digital * scale + offset`**, per channel, when `dtype="int16"`. For `float32` the scale is 1 and offset is 0.
+- **Events** are stored as onset, duration, and an integer code per event, with a portable code to label map. This stays compact when there are many events with few unique labels.
+
+---
+
+## 5. Signal-processing requirements
+
+These are correctness rules, not preferences.
+
+**Per-modality canonical rate.** `target = min(native, cap)`, never upsample.
+
+| Modality | Default cap (Hz) | Rationale |
+|---|---|---|
+| EEG | 250 | Scalp content sits below ~100 Hz; 250 keeps a clean passband to ~100 Hz |
+| MEG | 250 | Same default as EEG. See open decision in section 8 |
+| iEEG (SEEG, ECoG, DBS) | 1000 | Ripples and high-gamma live at 80 to 250 Hz and above |
+| EMG | 1000 | Surface and HD-EMG carry content to several hundred Hz |
+| Other (BEH, MISC) | native | No cap; kept as recorded |
+
+The cap table is a single configurable parameter, not hard-coded behavior.
+
+**Anti-aliasing.** Downsampling `level 0` uses polyphase resampling (`scipy.signal.resample_poly`). Decimating without a low-pass would fold line-noise harmonics and muscle into band. This is the analysis data, so it must be spectrally clean.
+
+**View pyramid uses min/max, not anti-aliased decimation.** Envelopes preserve visible transients so spikes do not vanish when zoomed out. This is why view levels are not inference-usable. The two downsampling philosophies coexist on purpose: anti-aliased for `level 0`, min/max for `view/*`.
+
+**Discrete channels.** Trigger and clock types (`TRIG`, `SYSCLOCK`, `CTRL`) are resampled by nearest sample, with no anti-alias filter, so step edges survive. They are flagged `usable_for_inference=false`.
+
+**Heterogeneous channels.** BIDS allows mixed channel types and, less often, mixed native rates within a modality. Channels are grouped by `(modality, native rate)` so every array stays length-consistent. The common single-rate recording yields one group per modality. A genuinely mixed-rate source yields one group per rate, which is faithful rather than silently resampled together.
+
+---
+
+## 6. Serving and deployment
+
+**Reads need no backend.** A Zarr v3 store is objects plus JSON. A browser reader (zarrita) streams it directly from object storage over HTTPS with ranged GETs. This is a direct payoff of choosing Zarr: the viewing path has no decode service.
+
+**CORS is the one hard requirement.** The bucket must allow browser GET, HEAD, and Range, and expose ETag and Content-Length.
+
+**CDN is recommended for the public production viewer**, for reasons specific to this workload:
+
+1. Many small requests. A viewport pulls several chunk objects. A CDN serves from an edge POP with HTTP/2 or HTTP/3 multiplexing, so many chunk fetches share one connection.
+2. Hot, shared coarse levels. Overview pyramid levels and `zarr.json` are tiny and identical across users, so they cache at the edge with a near-total hit rate.
+3. Cost. Browser viewing generates many small GETs. A CDN collapses request count and origin egress, the dominant cost for a public archive. Cloudflare R2 plus its CDN, whose model has no egress fees, is worth evaluating against S3 plus CloudFront.
+
+**The viewer code is identical with or without a CDN**, since zarrita reads object URLs. Ship on S3 plus CORS, then front it with a CDN by changing the base URL. The store is also already CDN-friendly: view levels are not sharded, so the hot viewing path is plain one-object-per-chunk GETs with no shard-index double-fetch. Sharding stays on the cold throughput path (`level 0` and training).
+
+**Caching.** The store is write-once per dataset version. Set immutable, long max-age headers on chunks and version the store prefix with a build hash or dataset version, so invalidation is never needed. Keep `zarr.json` on a shorter TTL or version it too.
+
+**Restricted data.** Public datasets get a public-read bucket behind the CDN. Access-controlled datasets cannot be public, so use signed cookies at the edge over a whole dataset prefix, rather than per-object signed URLs.
+
+---
+
+## 7. Reader contract
+
+**Viewer.** Read root and group attrs. For each group, pick the level whose `rate_effective` puts about one sample per screen pixel, fetch the chunks covering the viewport, and render the min/max band using per-channel `scale` and `offset`. At maximum zoom read `level 0` directly. Group display by modality. Overlay events from the `events` group.
+
+**Inference.** Read `level 0` of the relevant group, apply scale and offset, window. Never read `view/*`. For a lower analysis rate (for example 100 or 128 Hz models), derive it on read from `level 0` with an anti-aliased resample rather than persisting a third tier, unless that rate becomes a high-volume edge path.
+
+**Training.** Iterate shards of `level 0` sequentially, one object per shard, many windows per object. Shuffle at shard level plus a within-shard buffer. Use tensorstore for async, concurrent reads into the training loop.
+
+---
+
+## 8. Open decisions and risks
+
+| Item | Decision needed | Default for now |
+|---|---|---|
+| MEG rate | MEG at 250 Hz drops high-gamma. Raise the cap or set per-dataset | 250 Hz, flagged |
+| int16 vs float32 | int16 halves bytes with small quantization loss; float32 is lossless | int16, float32 available per call |
+| Low-rate inference tier | Persist a 100 or 128 Hz tier, or derive on read | Derive on read |
+| Window and chunk coupling | Base chunk size sets the random-access grain | Small base chunk, compose larger windows |
+| Conversion scale | Compute and storage budget for converting the NEMAR archive | Batch job, per-dataset, idempotent |
+| Event table size | Code plus map is fine for typical sizes; very large tables need review | Code plus map |
+
+---
+
+## 9. Work plan
+
+| Milestone | Deliverable | Status |
+|---|---|---|
+| M0 | Zarr writer (`zarr_exporter.py`), synthetic roundtrip verified | Done |
+| M1 | `Recording.to_zarr` wiring, plus unit and roundtrip tests in repo style | Done (`emgio/exporters/zarr.py`, `test_zarr.py`) |
+| M2 | `from_zarr` reader for verification and braindecode and training integration | Done (`emgio/importers/zarr.py`, `importer="zarr"` + `.zarr` autodetect) |
+| M3 | Batch conversion over NEMAR BIDS: per-dataset, idempotent, versioned output prefix, manifest, all four modalities | |
+| M4 | Web viewer: zarrita plus WebGL, pyramid level selection, events overlay | |
+| M5 | Serving infra: bucket layout, CORS, CDN, cache headers, auth for restricted data | |
+| M6 | Optional derive-on-read low-rate inference tier | |
+
+Cross-cutting: validation that reconstructed `level 0` matches the source within tolerance, and CI.
+
+The reference writer already implements per-modality resampling, anti-aliased `level 0`, the min/max pyramid, int16 scaling, heterogeneous-channel grouping, discrete-channel handling, events, and provenance attrs. Wiring it into the core mirrors the existing `to_edf` entry point:
+
+```python
+def to_zarr(self, filepath: str, **kwargs) -> str:
+    """Export to a sharded Zarr store with a min/max view pyramid."""
+    from ..exporters.zarr import ZarrExporter
+    if self.signals is None:
+        raise ValueError("No signals loaded")
+    return ZarrExporter.export(self, filepath, **kwargs)
+```
+
+---
+
+## 10. Acceptance criteria
+
+- One conversion produces viewing, inference, and training capability from a single store. No second pipeline exists.
+- An hour-long recording opens at overview zoom within an interactive budget and a bounded transfer, independent of recording length.
+- `level 0` reconstruction matches the anti-aliased source within tolerance (int16 quantization step or better).
+- Shard streaming throughput is comparable to a WebDataset baseline on the same data.
+- Metadata flags prevent training or inference on view envelopes.
+- The viewer reads the store directly from object storage with no decode backend.
+
+---
+
+## Appendix A. Default parameters
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `modality_rates` | EEG 250, MEG 250, iEEG 1000, EMG 1000 | Per-modality canonical rate cap |
+| `dtype` | `int16` | Storage type; `float32` for lossless |
+| `view_downsample` | 4 | Time decimation factor between pyramid levels |
+| `min_view_samples` | 512 | Stop building pyramid levels at this length |
+| `chunk_seconds` | 4 | Random-access grain |
+| `shard_seconds` | 300 | Sequential-read grain, rounded to whole chunks |
+| `compressor_level` | 5 | zstd level (Blosc codec) |
+
+## Appendix B. Bucket CORS, minimum
+
+Allow `GET` and `HEAD`, allow the `Range` request header, and expose `ETag`, `Content-Length`, and `Content-Range`. Set immutable, long max-age cache headers on chunk objects and version the store prefix so invalidation is never required.

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -25,7 +25,18 @@ else:
 
 # Supported importer names (extension-inferred or passed explicitly to from_file).
 ImporterName = Literal[
-    "trigno", "otb", "eeglab", "edf", "csv", "wfdb", "xdf", "meg", "brainvision", "tabular", "neo"
+    "trigno",
+    "otb",
+    "eeglab",
+    "edf",
+    "csv",
+    "wfdb",
+    "xdf",
+    "meg",
+    "brainvision",
+    "tabular",
+    "neo",
+    "zarr",
 ]
 
 
@@ -134,6 +145,8 @@ class Recording:
             ".ncs",
         }:
             return "neo"
+        elif extension == ".zarr":
+            return "zarr"
         else:
             raise ValueError(f"Unsupported file extension: {extension}")
 
@@ -165,6 +178,7 @@ class Recording:
                 - 'neo': proprietary electrophysiology formats via python-neo
                   (Intan, Blackrock, Spike2, Plexon, Micromed, Neuralynx, ...;
                   requires the 'neo' extra)
+                - 'zarr': biosigIO Zarr serving store (requires the 'zarr' extra)
                 If None, the importer will be inferred from the file extension.
                 Automatic import is supported for CSV/TXT files.
             force_csv: If True and importer is 'csv', forces using the generic CSV
@@ -197,6 +211,7 @@ class Recording:
             "brainvision": "BrainVisionImporter",  # BrainVision via MNE (.vhdr)
             "tabular": "TabularImporter",  # biosigIO Parquet / Arrow / Feather
             "neo": "NeoImporter",  # proprietary ephys via python-neo
+            "zarr": "ZarrImporter",  # biosigIO Zarr serving store
         }
 
         if importer not in importers:
@@ -214,7 +229,8 @@ class Recording:
                 "- brainvision: BrainVision via MNE (.vhdr)\n"
                 "- tabular: biosigIO Parquet/Arrow/Feather (.parquet, .feather, .arrow)\n"
                 "- neo: proprietary electrophysiology formats via python-neo "
-                "(Intan, Blackrock, Spike2, Plexon, Micromed, Neuralynx, ...)"
+                "(Intan, Blackrock, Spike2, Plexon, Micromed, Neuralynx, ...)\n"
+                "- zarr: biosigIO Zarr serving store (.zarr)"
             )
 
         # If using CSV importer and force_csv is set, pass it as force_generic
@@ -691,6 +707,30 @@ class Recording:
         from ..exporters.tabular import TabularExporter
 
         return TabularExporter.to_arrow(self, filepath)
+
+    def to_zarr(self, filepath: str, **kwargs) -> str:
+        """Export to a sharded Zarr v3 serving store with a min/max view pyramid.
+
+        Writes one cloud-native store that serves viewing, inference, and training
+        from a single conversion: ``level 0`` of each ``(modality, rate)`` group is
+        the anti-aliased, per-modality-resampled inference signal, with a min/max
+        render pyramid above it (flagged not-for-inference). A derived serving copy,
+        not the archival source (BIDS/EDF stay authoritative). Requires the ``zarr``
+        extra (zarr v3). See :class:`~emgio.exporters.zarr.ZarrExporter` for the
+        tuning knobs (``modality_rates``, ``dtype``, chunk/shard sizing, ...).
+
+        Args:
+            filepath: Output store path (``.zarr`` appended if missing).
+            **kwargs: Forwarded to :meth:`ZarrExporter.export`.
+
+        Returns:
+            str: The written store path.
+        """
+        from ..exporters.zarr import ZarrExporter
+
+        if self.signals is None:
+            raise ValueError("No signals loaded")
+        return ZarrExporter.export(self, filepath, **kwargs)
 
     def set_metadata(self, key: str, value: Any) -> None:
         """

--- a/emgio/exporters/zarr.py
+++ b/emgio/exporters/zarr.py
@@ -123,6 +123,9 @@ def _quantize_int16(block: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
     """Map a (n_ch, n_time) float block to int16 with per-channel scale/offset.
 
     ``physical = digital * scale + offset``. A constant channel gets scale=1.
+    Non-finite samples (NaN/inf) cannot be represented in int16 and would
+    silently decode to a midrange value, so they are rejected here rather than
+    corrupted -- use ``dtype="float32"`` (which preserves NaN) to keep them.
     """
     n_ch = block.shape[0]
     scale = np.ones(n_ch, dtype=np.float64)
@@ -131,10 +134,16 @@ def _quantize_int16(block: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
     digital_span = _INT16_MAX - _INT16_MIN
     for i in range(n_ch):
         row = block[i]
-        pmin = float(np.nanmin(row)) if row.size else 0.0
-        pmax = float(np.nanmax(row)) if row.size else 0.0
-        if not np.isfinite(pmin) or not np.isfinite(pmax) or pmax == pmin:
-            offset[i] = pmin if np.isfinite(pmin) else 0.0
+        if row.size and not np.all(np.isfinite(row)):
+            raise ValueError(
+                f"Channel index {i} has non-finite (NaN/inf) samples, which int16 storage "
+                "cannot represent without silently corrupting them. Use dtype='float32' "
+                "(preserves NaN) or mask/interpolate the samples before exporting."
+            )
+        pmin = float(np.min(row)) if row.size else 0.0
+        pmax = float(np.max(row)) if row.size else 0.0
+        if pmax == pmin:  # constant (or empty) channel: store the constant in offset
+            offset[i] = pmin
             out[i] = 0
             continue
         s = (pmax - pmin) / digital_span
@@ -269,7 +278,9 @@ class ZarrExporter:
                         "modality": modality,
                         "unit": info.get("physical_dimension", "n/a"),
                         "prefilter": info.get("prefilter", "n/a"),
-                        "original_rate": float(native_rate),
+                        # The true per-channel rate, not the rounded group key, so a
+                        # non-integer acquisition rate is not lost (metadata loss is data loss).
+                        "original_rate": float(info["sample_frequency"]),
                         "target_rate": float(target_rate),
                         "anti_aliased": bool((not discrete) and target_rate < native_rate),
                         "usable_for_inference": (not discrete),
@@ -292,7 +303,14 @@ class ZarrExporter:
             gname = f"{modality.lower()}_{int(round(target_rate))}hz"
             # Disambiguate the rare collision of two native rates -> same target.
             if gname in written_groups:
-                gname = f"{gname}_from{int(native_rate)}"
+                candidate = f"{gname}_from{int(native_rate)}"
+                if candidate in written_groups:
+                    raise ValueError(
+                        f"Zarr group name collision: {candidate!r} is already used. Three or more "
+                        f"native rates in modality {modality!r} map to the same target rate; "
+                        "split the recording or widen the modality rate cap."
+                    )
+                gname = candidate
             written_groups.append(gname)
             grp = root.create_group(gname)
             grp.attrs.update(
@@ -323,7 +341,8 @@ class ZarrExporter:
                     "downsample_factor": 1,
                     "kind": "signal",
                     "anti_aliased": any(m["anti_aliased"] for m in chan_meta),
-                    "usable_for_inference": True,
+                    # A group of only discrete channels is not inference-usable.
+                    "usable_for_inference": any(m["usable_for_inference"] for m in chan_meta),
                     "scale": scale.tolist(),
                     "offset": offset.tolist(),
                     "physical_formula": "physical = digital * scale + offset",

--- a/emgio/exporters/zarr.py
+++ b/emgio/exporters/zarr.py
@@ -1,0 +1,402 @@
+"""Zarr exporter for biosignal recordings (biosigIO serving format).
+
+Writes a single, cloud-native store that serves three jobs from one conversion:
+fast edge viewing, edge/batch inference, and training-time streaming. The design
+follows a few correctness rules:
+
+- ``level 0`` of every channel group is the **canonical inference signal**,
+  anti-aliased and resampled to a per-modality rate (250 Hz for EEG/MEG, 1000 Hz
+  for iEEG/EMG by default), never upsampled.
+- A **min/max view pyramid** sits above level 0 (``<group>/view/<L>``). These
+  levels are nonlinear envelopes for rendering only and are flagged
+  ``usable_for_inference=False`` so nobody trains on them by mistake.
+- Heterogeneous channels (mixed types/units, and the rarer mixed native rates
+  that BIDS allows within a modality) are grouped by ``(modality, native rate)``
+  so every array stays internally length-consistent. Trigger/clock channels are
+  resampled without anti-aliasing (nearest sample) to preserve step edges.
+- Signals are stored ``int16`` with a per-channel ``scale``/``offset`` by default
+  (half the bytes of float32; ML casts on read). Pass ``dtype="float32"`` for a
+  lossless store.
+
+The original full-rate recording is never the source of truth here; that stays in
+the BIDS archive. This store is a derived serving copy, and the downsampling
+parameters are recorded in attrs so it is reproducible. zarr is an optional
+dependency (the ``zarr`` extra), imported lazily.
+
+Layout (one root group per recording)::
+
+    /                         root attrs: provenance, modality_rates, metadata
+      <modality>_<rate>hz/    one group per (modality, native rate)
+        0                     (n_ch, n_time) base signal, anti-aliased, sharded
+        view/1, view/2, ...   (2, n_ch, n_time_L) min/max envelopes
+      events/                 onset, duration, code arrays + label_map attr
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from fractions import Fraction
+
+import numpy as np
+from scipy.signal import resample_poly
+
+from ..core.emg import Recording
+from ..tabular_schema import metadata_to_json
+from ..version import __version__ as _BIOSIGIO_VERSION
+
+# Format tag/version for the root attrs, so a reader can recognize and
+# version-check a biosigIO Zarr store.
+FORMAT = "biosigio-zarr"
+FORMAT_VERSION = 1
+
+# Per-modality canonical inference rate (Hz). target = min(native, cap); a
+# modality absent from this map keeps its native rate.
+DEFAULT_MODALITY_RATES: dict[str, int] = {
+    "EEG": 250,
+    "MEG": 250,
+    "IEEG": 1000,
+    "EMG": 1000,
+}
+
+# Channel types that are discrete/event-like rather than continuous signals. They
+# are resampled by nearest sample (no anti-alias low-pass) so step edges survive,
+# and they are never marked inference-usable.
+_DISCRETE_TYPES: frozenset[str] = frozenset({"TRIG", "SYSCLOCK", "CTRL"})
+
+_INT16_MIN, _INT16_MAX = -32768, 32767
+
+
+def require_zarr():
+    """Import zarr lazily, raising a clear install hint when it is absent."""
+    try:
+        import zarr  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "Zarr serving-format export/import requires zarr (v3), an optional "
+            "dependency. Install it with: uv sync --extra zarr  (or, for an existing "
+            "install, uv pip install 'emgio[zarr]')."
+        ) from e
+    import zarr
+
+    return zarr
+
+
+def _target_rate(native_rate: float, modality: str, modality_rates: dict[str, int]) -> float:
+    """Canonical rate for a channel: capped by modality, never upsampled."""
+    cap = modality_rates.get(modality.upper())
+    if cap is None:
+        return float(native_rate)
+    return float(min(native_rate, cap))
+
+
+def _resample_channel(
+    x: np.ndarray, native_rate: float, target_rate: float, *, discrete: bool
+) -> np.ndarray:
+    """Resample one channel to ``target_rate``.
+
+    Continuous channels use polyphase resampling (anti-aliased). Discrete channels
+    use nearest-sample selection so trigger edges are not smeared.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    if float(target_rate) == float(native_rate):
+        return x
+    n_out = int(round(len(x) * target_rate / native_rate))
+    if n_out <= 0:
+        return np.zeros(0, dtype=np.float64)
+    if discrete:
+        idx = np.minimum(
+            (np.arange(n_out) * native_rate / target_rate).round().astype(int), len(x) - 1
+        )
+        return x[idx]
+    frac = Fraction(int(round(target_rate)), int(round(native_rate)))
+    y = resample_poly(x, frac.numerator, frac.denominator)
+    # resample_poly length can be off by one versus the nominal target; trim or
+    # pad to the exact ratio length so a group's channels stay aligned.
+    if len(y) > n_out:
+        y = y[:n_out]
+    elif len(y) < n_out:
+        y = np.pad(y, (0, n_out - len(y)), mode="edge")
+    return y
+
+
+def _quantize_int16(block: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Map a (n_ch, n_time) float block to int16 with per-channel scale/offset.
+
+    ``physical = digital * scale + offset``. A constant channel gets scale=1.
+    """
+    n_ch = block.shape[0]
+    scale = np.ones(n_ch, dtype=np.float64)
+    offset = np.zeros(n_ch, dtype=np.float64)
+    out = np.zeros(block.shape, dtype=np.int16)
+    digital_span = _INT16_MAX - _INT16_MIN
+    for i in range(n_ch):
+        row = block[i]
+        pmin = float(np.nanmin(row)) if row.size else 0.0
+        pmax = float(np.nanmax(row)) if row.size else 0.0
+        if not np.isfinite(pmin) or not np.isfinite(pmax) or pmax == pmin:
+            offset[i] = pmin if np.isfinite(pmin) else 0.0
+            out[i] = 0
+            continue
+        s = (pmax - pmin) / digital_span
+        o = pmin - _INT16_MIN * s
+        scale[i] = s
+        offset[i] = o
+        digital = np.round((row - o) / s)
+        out[i] = np.clip(digital, _INT16_MIN, _INT16_MAX).astype(np.int16)
+    return out, scale, offset
+
+
+def _build_minmax_pyramid(
+    base: np.ndarray, factor: int, min_samples: int, max_levels: int
+) -> list[np.ndarray]:
+    """Return a list of (2, n_ch, n_time_L) min/max envelope levels.
+
+    Level L is built from level L-1 (min of mins, max of maxs), so the envelope is
+    exact at every zoom. Axis 0 is [min, max].
+    """
+    levels: list[np.ndarray] = []
+    cur_min = base
+    cur_max = base
+    n_ch = base.shape[0]
+    for _ in range(max_levels):
+        n_time = cur_min.shape[1]
+        if n_time <= min_samples:
+            break
+        n_out = n_time // factor
+        if n_out < 1:
+            break
+        trim = n_out * factor
+        lvl_min = cur_min[:, :trim].reshape(n_ch, n_out, factor).min(axis=2)
+        lvl_max = cur_max[:, :trim].reshape(n_ch, n_out, factor).max(axis=2)
+        levels.append(np.stack([lvl_min, lvl_max], axis=0))
+        cur_min, cur_max = lvl_min, lvl_max
+    return levels
+
+
+def _chunk_shard_time(
+    n_time: int, rate: float, chunk_seconds: float, shard_seconds: float
+) -> tuple[int, int]:
+    """Pick a time chunk and a shard that is a multiple of it."""
+    chunk_t = max(1, min(n_time, int(round(chunk_seconds * rate))))
+    k = max(1, int(round(shard_seconds / chunk_seconds)))
+    n_chunks = -(-n_time // chunk_t)  # ceil
+    shard_t = chunk_t * min(k, n_chunks)
+    return chunk_t, shard_t
+
+
+class ZarrExporter:
+    """Exporter to a sharded Zarr v3 store with a min/max view pyramid."""
+
+    @staticmethod
+    def export(
+        rec: Recording,
+        filepath: str,
+        *,
+        modality_rates: dict[str, int] | None = None,
+        dtype: str = "int16",
+        view_downsample: int = 4,
+        min_view_samples: int = 512,
+        max_view_levels: int = 12,
+        chunk_seconds: float = 4.0,
+        shard_seconds: float = 300.0,
+        compressor_level: int = 5,
+        events_df=None,
+    ) -> str:
+        """Write ``rec`` to a Zarr store at ``filepath``.
+
+        Args:
+            rec: Source recording.
+            filepath: Output store path (``.zarr`` appended if missing).
+            modality_rates: Per-modality canonical rate cap. Defaults to
+                :data:`DEFAULT_MODALITY_RATES`. MEG defaults to 250 Hz with EEG;
+                raise its cap if you need MEG high-gamma.
+            dtype: ``"int16"`` (default, scaled, half the bytes) or ``"float32"``
+                (lossless).
+            view_downsample: Time decimation factor between pyramid levels.
+            min_view_samples: Stop building levels at this length.
+            max_view_levels: Hard cap on pyramid depth.
+            chunk_seconds: Time span per chunk (random-access granularity).
+            shard_seconds: Time span per shard (sequential-read granularity for
+                training); rounded to a whole number of chunks.
+            compressor_level: zstd level for the Blosc codec.
+            events_df: Optional events table; falls back to ``rec.events``.
+
+        Returns:
+            The store path written.
+        """
+        zarr = require_zarr()
+        from zarr.codecs import BloscCodec
+
+        if rec.signals is None or len(rec.channels) == 0:
+            raise ValueError("No signals loaded")
+        if dtype not in ("int16", "float32"):
+            raise ValueError("dtype must be 'int16' or 'float32'")
+
+        rates = dict(DEFAULT_MODALITY_RATES if modality_rates is None else modality_rates)
+        if not filepath.endswith(".zarr"):
+            filepath = filepath + ".zarr"
+
+        store = zarr.storage.LocalStore(filepath)
+        root = zarr.create_group(store=store, overwrite=True)
+        compressors = [BloscCodec(cname="zstd", clevel=compressor_level)]
+
+        # Group channels by (modality, native rate) so each array is length-
+        # consistent. Preserve channel order within a group.
+        groups: dict[tuple[str, int], list[str]] = {}
+        for label in rec.signals.columns:
+            info = rec.channels[label]
+            key = (str(info.get("modality", "MISC")), int(round(info["sample_frequency"])))
+            groups.setdefault(key, []).append(label)
+
+        written_groups: list[str] = []
+        for (modality, native_rate), labels in groups.items():
+            target_rate = _target_rate(native_rate, modality, rates)
+
+            resampled = []
+            chan_meta = []
+            for label in labels:
+                info = rec.channels[label]
+                ctype = str(info.get("channel_type", "MISC")).upper()
+                discrete = ctype in _DISCRETE_TYPES
+                y = _resample_channel(
+                    rec.signals[label].values, native_rate, target_rate, discrete=discrete
+                )
+                resampled.append(y)
+                chan_meta.append(
+                    {
+                        "label": label,
+                        "channel_type": ctype,
+                        "modality": modality,
+                        "unit": info.get("physical_dimension", "n/a"),
+                        "prefilter": info.get("prefilter", "n/a"),
+                        "original_rate": float(native_rate),
+                        "target_rate": float(target_rate),
+                        "anti_aliased": bool((not discrete) and target_rate < native_rate),
+                        "usable_for_inference": (not discrete),
+                    }
+                )
+            block = np.vstack(resampled).astype(np.float64)
+            n_ch, n_time = block.shape
+
+            if dtype == "int16":
+                base, scale, offset = _quantize_int16(block)
+            else:
+                base = block.astype(np.float32)
+                scale = np.ones(n_ch)
+                offset = np.zeros(n_ch)
+            for i, m in enumerate(chan_meta):
+                m["scale"] = float(scale[i])
+                m["offset"] = float(offset[i])
+                m["row_index"] = i
+
+            gname = f"{modality.lower()}_{int(round(target_rate))}hz"
+            # Disambiguate the rare collision of two native rates -> same target.
+            if gname in written_groups:
+                gname = f"{gname}_from{int(native_rate)}"
+            written_groups.append(gname)
+            grp = root.create_group(gname)
+            grp.attrs.update(
+                {
+                    "modality": modality,
+                    "rate": float(target_rate),
+                    "original_rate": float(native_rate),
+                    "n_channels": int(n_ch),
+                    "n_samples": int(n_time),
+                    "channels": chan_meta,
+                }
+            )
+
+            chunk_t, shard_t = _chunk_shard_time(n_time, target_rate, chunk_seconds, shard_seconds)
+            a0 = grp.create_array(
+                "0",
+                shape=(n_ch, n_time),
+                chunks=(n_ch, chunk_t),
+                shards=(n_ch, shard_t),
+                dtype=base.dtype,
+                compressors=compressors,
+            )
+            a0[:] = base
+            a0.attrs.update(
+                {
+                    "level": 0,
+                    "rate": float(target_rate),
+                    "downsample_factor": 1,
+                    "kind": "signal",
+                    "anti_aliased": any(m["anti_aliased"] for m in chan_meta),
+                    "usable_for_inference": True,
+                    "scale": scale.tolist(),
+                    "offset": offset.tolist(),
+                    "physical_formula": "physical = digital * scale + offset",
+                }
+            )
+
+            # Min/max view pyramid (rendering only). Built in digital space so it
+            # shares the base scale/offset; never inference-usable.
+            view = grp.create_group("view")
+            pyramid = _build_minmax_pyramid(
+                base, view_downsample, min_view_samples, max_view_levels
+            )
+            for li, lvl in enumerate(pyramid, start=1):
+                eff_factor = view_downsample**li
+                ct = max(1, min(lvl.shape[2], int(round(chunk_seconds * target_rate / eff_factor))))
+                av = view.create_array(
+                    str(li),
+                    shape=lvl.shape,
+                    chunks=(2, n_ch, ct),
+                    dtype=lvl.dtype,
+                    compressors=compressors,
+                )
+                av[:] = lvl
+                av.attrs.update(
+                    {
+                        "level": li,
+                        "downsample_factor": eff_factor,
+                        "rate_effective": float(target_rate) / eff_factor,
+                        "kind": "minmax_envelope",
+                        "axis0": ["min", "max"],
+                        "usable_for_inference": False,
+                    }
+                )
+
+        # Events as onset/duration/code arrays plus a portable code->label map.
+        ev = rec.events if events_df is None else events_df
+        eg = root.create_group("events")
+        if ev is not None and len(ev) > 0:
+            onset = ev["onset"].to_numpy(dtype=np.float64)
+            duration = ev["duration"].to_numpy(dtype=np.float64)
+            descs = ev["description"].astype(str).to_numpy()
+            uniques = list(dict.fromkeys(descs.tolist()))
+            code_of = {d: i for i, d in enumerate(uniques)}
+            codes = np.array([code_of[d] for d in descs], dtype=np.int32)
+            for name, arr in (("onset", onset), ("duration", duration), ("code", codes)):
+                a = eg.create_array(name, shape=arr.shape, chunks=arr.shape, dtype=arr.dtype)
+                a[:] = arr
+            eg.attrs["label_map"] = {str(i): d for i, d in enumerate(uniques)}
+            eg.attrs["n_events"] = int(len(ev))
+        else:
+            eg.attrs["label_map"] = {}
+            eg.attrs["n_events"] = 0
+
+        root.attrs.update(
+            {
+                "biosigio_version": _BIOSIGIO_VERSION,
+                "format": FORMAT,
+                "format_version": FORMAT_VERSION,
+                "source_format": rec.metadata.get("source_format", "n/a"),
+                "modality_rates": rates,
+                "dtype": dtype,
+                "view_downsample": view_downsample,
+                "anti_alias_filter": "scipy.signal.resample_poly (polyphase FIR)",
+                "channel_groups": written_groups,
+                # Lossless JSON (datetimes/numpy survive), shared with the tabular
+                # schema, instead of a lossy str() dump.
+                "recording_metadata": metadata_to_json(rec.metadata),
+                "created_utc": _dt.datetime.now(_dt.UTC).isoformat(),
+                "note": (
+                    "Derived serving copy. level 0 of each group is the anti-aliased "
+                    "inference signal; view/* are min/max render envelopes (not for "
+                    "inference). BIDS source remains authoritative."
+                ),
+            }
+        )
+        return filepath

--- a/emgio/importers/zarr.py
+++ b/emgio/importers/zarr.py
@@ -1,0 +1,125 @@
+"""Importer for the biosigIO Zarr serving format (verification / training reads).
+
+Reconstructs a :class:`~emgio.core.emg.Recording` from a biosigIO Zarr store
+written by :class:`~emgio.exporters.zarr.ZarrExporter`: it reads ``level 0`` of a
+channel group, applies the per-channel ``physical = digital * scale + offset``
+dequantization, and restores channel metadata, events, and recording metadata.
+
+This is the *serving copy*, so reconstruction is at the store's canonical
+(possibly downsampled) ``level 0`` rate, not the original full-rate signal -- the
+BIDS archive remains the source of truth. The view pyramid (``view/*``) is never
+read here; it is render-only.
+
+A store can hold several ``(modality, rate)`` groups at different rates, which
+cannot share emgio's single time grid; the importer reconstructs one group at a
+time (auto when there is only one) and requires an explicit ``group=`` selector
+otherwise, mirroring the neo importer's per-stream selection. zarr is an optional
+dependency (the ``zarr`` extra), imported lazily.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from ..core.emg import Recording
+from ..exporters.zarr import FORMAT, require_zarr
+from ..tabular_schema import metadata_from_json
+from .base import BaseImporter
+
+
+class ZarrImporter(BaseImporter):
+    """Importer for biosigIO Zarr stores (``.zarr``)."""
+
+    def load(self, filepath: str, *, group: str | None = None) -> Recording:
+        """Reconstruct a Recording from a biosigIO Zarr store.
+
+        Args:
+            filepath: Path to the ``.zarr`` store (a directory).
+            group: Which ``(modality, rate)`` group to reconstruct, by name (e.g.
+                ``"eeg_250hz"``). Required only when the store holds more than one
+                group; otherwise the single group is used.
+        """
+        zarr = require_zarr()
+        try:
+            root = zarr.open_group(store=zarr.storage.LocalStore(filepath), mode="r")
+        except Exception as e:
+            raise ValueError(f"Error reading Zarr store {filepath}: {e}") from e
+
+        root_attrs = dict(root.attrs)
+        if root_attrs.get("format") != FORMAT:
+            raise ValueError(
+                f"Not a biosigIO Zarr store: root 'format' is {root_attrs.get('format')!r}, "
+                f"expected {FORMAT!r}. Only stores written by emgio's Zarr exporter can be read."
+            )
+
+        signal_groups = [name for name in root.keys() if name != "events"]
+        selected = self._select_group(signal_groups, group, filepath)
+
+        rec = Recording()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
+            grp = root[selected]
+            arr = grp["0"]
+            a0_attrs = dict(arr.attrs)
+            digital = np.asarray(arr[:])  # (n_channels, n_time)
+            scale = np.asarray(a0_attrs["scale"], dtype=np.float64)
+            offset = np.asarray(a0_attrs["offset"], dtype=np.float64)
+            rate = float(dict(grp.attrs)["rate"])
+            for meta in dict(grp.attrs)["channels"]:
+                i = int(meta["row_index"])
+                physical = digital[i].astype(np.float64) * scale[i] + offset[i]
+                rec.add_channel(
+                    label=str(meta["label"]),
+                    data=physical,
+                    sample_frequency=rate,
+                    physical_dimension=str(meta.get("unit", "n/a")),
+                    channel_type=str(meta.get("channel_type", "OTHER")),
+                    modality=meta.get("modality"),
+                    prefilter=str(meta.get("prefilter", "n/a")),
+                )
+        if rec.signals is not None:
+            rec.signals = rec.signals.copy()  # de-fragment after many inserts (#66)
+
+        self._add_events(rec, root)
+
+        meta_blob = root_attrs.get("recording_metadata")
+        if isinstance(meta_blob, str):
+            rec.metadata = metadata_from_json(meta_blob)
+        rec.set_metadata("source_file", filepath)
+        return rec
+
+    @staticmethod
+    def _select_group(signal_groups, group, filepath):
+        """Pick which channel group to reconstruct (see class docstring)."""
+        if not signal_groups:
+            raise ValueError(f"No channel groups found in Zarr store {filepath}")
+        if group is not None:
+            if group not in signal_groups:
+                raise ValueError(
+                    f"No group named {group!r} in {filepath}; available groups: {signal_groups}"
+                )
+            return group
+        if len(signal_groups) > 1:
+            raise ValueError(
+                f"{filepath} has {len(signal_groups)} channel groups at different rates that "
+                f"cannot share one time grid; pass group= to choose one: {signal_groups}"
+            )
+        return signal_groups[0]
+
+    @staticmethod
+    def _add_events(rec: Recording, root) -> None:
+        """Reconstruct events from the store's events group (code -> label map)."""
+        if "events" not in root.keys():
+            return
+        eg = root["events"]
+        attrs = dict(eg.attrs)
+        if not attrs.get("n_events", 0):
+            return
+        onset = np.asarray(eg["onset"][:], dtype=np.float64)
+        duration = np.asarray(eg["duration"][:], dtype=np.float64)
+        codes = np.asarray(eg["code"][:])
+        label_map = attrs.get("label_map", {})
+        for o, d, c in zip(onset, duration, codes, strict=True):
+            description = label_map.get(str(int(c)), str(int(c)))
+            rec.add_event(onset=float(o), duration=float(d), description=description)

--- a/emgio/tabular_schema.py
+++ b/emgio/tabular_schema.py
@@ -86,6 +86,21 @@ def _json_object_hook(d: dict) -> Any:
     return d
 
 
+def metadata_to_json(metadata) -> str:
+    """Serialize recording metadata to a JSON string, lossless for datetimes/numpy.
+
+    Shared canonical encoding (also used by the Zarr store's root attrs) so every
+    biosigIO format records metadata the same way and round-trips types intact,
+    rather than silently ``str()``-ifying values (metadata loss is data loss).
+    """
+    return json.dumps(dict(metadata), default=_json_default)
+
+
+def metadata_from_json(blob: str) -> dict:
+    """Inverse of :func:`metadata_to_json` (reconstructs datetimes etc.)."""
+    return json.loads(blob, object_hook=_json_object_hook)
+
+
 def recording_to_table(rec: Recording) -> pa.Table:
     """Build a pyarrow Table from a Recording (signals + biosigio metadata blob)."""
     pa = require_pyarrow()

--- a/emgio/tests/test_zarr.py
+++ b/emgio/tests/test_zarr.py
@@ -17,7 +17,7 @@ from emgio import Recording
 
 zarr = pytest.importorskip("zarr", reason="Zarr serving format requires the optional 'zarr' extra")
 
-from emgio.exporters.zarr import _resample_channel  # noqa: E402
+from emgio.exporters.zarr import _DISCRETE_TYPES, _resample_channel  # noqa: E402
 
 _REPO = pathlib.Path(__file__).resolve().parents[2]
 EMG_EDF = _REPO / "examples/bids/emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
@@ -104,6 +104,31 @@ def test_zarr_discrete_channel_nearest_not_inference(tmp_path):
     assert chan["channel_type"] == "TRIG"
     assert chan["anti_aliased"] is False
     assert chan["usable_for_inference"] is False
+    # A group of only discrete channels must not be flagged inference-usable.
+    assert root[name]["0"].attrs["usable_for_inference"] is False
+
+
+def test_zarr_int16_rejects_non_finite(tmp_path):
+    """NaN/inf would silently decode to a midrange int16 value, so int16 export rejects it."""
+    data = np.sin(np.arange(1000) / 5.0)
+    data[100] = np.nan
+    rec = Recording()
+    rec.add_channel("C1", data, 250, "uV", "EEG")
+    with pytest.raises(ValueError, match="non-finite"):
+        rec.to_zarr(str(tmp_path / "r"))  # dtype="int16" default
+
+
+def test_zarr_float32_preserves_nan(tmp_path):
+    """float32 storage represents NaN, so the gap survives the round-trip."""
+    data = np.sin(np.arange(1000) / 5.0)
+    data[100:110] = np.nan
+    rec = Recording()
+    rec.add_channel("C1", data, 250, "uV", "EEG")
+
+    rt = Recording.from_file(rec.to_zarr(str(tmp_path / "r"), dtype="float32"))
+    got = rt.signals["C1"].to_numpy()
+    assert np.array_equal(np.isnan(got), np.isnan(data))
+    assert np.allclose(got[~np.isnan(got)], data[~np.isnan(data)])
 
 
 def test_zarr_events_roundtrip(tmp_path):
@@ -174,7 +199,10 @@ def test_zarr_real_emg_fixture_exports_and_reconstructs(tmp_path):
     label = list(rt.channels)[0]
     native = rec.channels[label]["sample_frequency"]
     target = rt.channels[label]["sample_frequency"]
-    expected = _resample_channel(rec.signals[label].to_numpy(), native, target, discrete=False)
+    ctype = str(rec.channels[label].get("channel_type", "")).upper()
+    expected = _resample_channel(
+        rec.signals[label].to_numpy(), native, target, discrete=ctype in _DISCRETE_TYPES
+    )
     got = rt.signals[label].to_numpy()
     n = min(len(expected), len(got))
     assert np.corrcoef(expected[:n], got[:n])[0, 1] > 0.99

--- a/emgio/tests/test_zarr.py
+++ b/emgio/tests/test_zarr.py
@@ -1,0 +1,180 @@
+"""Round-trip and contract tests for the biosigIO Zarr serving format.
+
+NO MOCKS: real synthetic signals (sines/ramps, the same pattern the tabular and
+neo tests use) give precise control to assert the per-modality rate caps,
+anti-aliasing, int16 quantization tolerance, the min/max view-pyramid flags, and
+event/metadata fidelity; one end-to-end test exports a real EMG EDF fixture.
+Skips when the optional ``zarr`` extra is absent.
+"""
+
+import datetime
+import pathlib
+
+import numpy as np
+import pytest
+
+from emgio import Recording
+
+zarr = pytest.importorskip("zarr", reason="Zarr serving format requires the optional 'zarr' extra")
+
+from emgio.exporters.zarr import _resample_channel  # noqa: E402
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EMG_EDF = _REPO / "examples/bids/emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
+
+
+def _open(path):
+    return zarr.open_group(store=zarr.storage.LocalStore(str(path)), mode="r")
+
+
+def test_zarr_float32_roundtrip_lossless(tmp_path):
+    """float32, no resample (rate == cap): signals reconstruct exactly."""
+    t = np.arange(2000)
+    rec = Recording()
+    rec.add_channel("C3", np.sin(t / 5.0).astype(np.float64), 250, "uV", "EEG")
+    rec.add_channel("C4", np.cos(t / 8.0).astype(np.float64), 250, "uV", "EEG")
+
+    out = rec.to_zarr(str(tmp_path / "r"), dtype="float32")
+    assert out.endswith(".zarr")
+    rt = Recording.from_file(out)
+
+    assert rt.signals is not None
+    assert list(rt.signals.columns) == ["C3", "C4"]
+    assert np.allclose(rt.signals.to_numpy(), rec.signals.to_numpy())
+    for ch in ("C3", "C4"):
+        assert rt.channels[ch]["sample_frequency"] == 250.0
+        assert rt.channels[ch]["physical_dimension"] == "uV"
+        assert rt.channels[ch]["modality"] == "EEG"
+
+
+def test_zarr_int16_within_quantization_step(tmp_path):
+    """int16 reconstruction stays within one quantization step of the source."""
+    t = np.arange(3000)
+    data = (np.sin(t / 4.0) * 100.0).astype(np.float64)
+    rec = Recording()
+    rec.add_channel("EMG1", data, 1000, "uV", "EMG")  # 1000 == EMG cap, no resample
+
+    rt = Recording.from_file(rec.to_zarr(str(tmp_path / "r")))
+    step = (data.max() - data.min()) / 65535.0
+    assert np.max(np.abs(rt.signals["EMG1"].to_numpy() - data)) <= step
+
+
+def test_zarr_modality_cap_resamples_and_flags_antialias(tmp_path):
+    """EEG above the 250 Hz cap is anti-alias downsampled; below it is untouched."""
+    t = np.arange(4000)
+    rec = Recording()
+    rec.add_channel("hi", np.sin(t / 6.0).astype(np.float64), 500, "uV", "EEG")  # -> 250
+    rec.add_channel("lo", np.sin(t / 6.0).astype(np.float64), 100, "uV", "EEG")  # stays 100
+
+    root = _open(rec.to_zarr(str(tmp_path / "r")))
+    names = [k for k in root.keys() if k != "events"]
+    assert set(names) == {"eeg_250hz", "eeg_100hz"}
+    assert root["eeg_250hz"].attrs["n_samples"] == 2000  # 4000 @ 500Hz -> 2000 @ 250Hz
+    assert root["eeg_250hz"]["0"].attrs["anti_aliased"] is True
+    assert root["eeg_100hz"].attrs["n_samples"] == 4000  # never upsampled, unchanged
+    assert root["eeg_100hz"]["0"].attrs["anti_aliased"] is False
+
+
+def test_zarr_view_pyramid_flagged_not_for_inference(tmp_path):
+    """A view pyramid is built and marked render-only; level 0 is inference-usable."""
+    rec = Recording()
+    rec.add_channel("C1", np.sin(np.arange(8000) / 3.0).astype(np.float64), 250, "uV", "EEG")
+
+    grp = _open(rec.to_zarr(str(tmp_path / "r")))["eeg_250hz"]
+    assert grp["0"].attrs["usable_for_inference"] is True
+    view = grp["view"]
+    levels = sorted(view.keys(), key=int)
+    assert levels, "expected at least one view pyramid level"
+    for lvl in levels:
+        a = view[lvl]
+        assert a.attrs["kind"] == "minmax_envelope"
+        assert a.attrs["usable_for_inference"] is False
+        assert a.shape[0] == 2  # [min, max]
+
+
+def test_zarr_discrete_channel_nearest_not_inference(tmp_path):
+    """A TRIG channel is nearest-resampled (no anti-alias) and not inference-usable."""
+    steps = np.repeat([0.0, 1.0, 0.0, 1.0], 1000)  # 4000 samples of square edges
+    rec = Recording()
+    rec.add_channel("trig", steps, 500, "n/a", "TRIG")  # EEG-less; modality MISC, 500->?
+
+    root = _open(rec.to_zarr(str(tmp_path / "r")))
+    name = next(k for k in root.keys() if k != "events")
+    chan = root[name].attrs["channels"][0]
+    assert chan["channel_type"] == "TRIG"
+    assert chan["anti_aliased"] is False
+    assert chan["usable_for_inference"] is False
+
+
+def test_zarr_events_roundtrip(tmp_path):
+    rec = Recording()
+    rec.add_channel("C1", np.sin(np.arange(1000) / 5.0).astype(np.float64), 250, "uV", "EEG")
+    rec.add_event(0.5, 0.1, "stim")
+    rec.add_event(1.0, 0.0, "resp")
+    rec.add_event(1.5, 0.2, "stim")  # repeated label exercises the code->label map
+
+    rt = Recording.from_file(rec.to_zarr(str(tmp_path / "r")))
+    events = rt.events.sort_values("onset").reset_index(drop=True)
+    assert list(events["description"]) == ["stim", "resp", "stim"]
+    assert np.allclose(events["onset"].to_numpy(), [0.5, 1.0, 1.5])
+    assert np.allclose(events["duration"].to_numpy(), [0.1, 0.0, 0.2])
+
+
+def test_zarr_metadata_types_preserved(tmp_path):
+    """Recording metadata round-trips with types intact (datetime stays datetime)."""
+    rec = Recording()
+    rec.add_channel("C1", np.zeros(500), 250, "uV", "EEG")
+    rec.set_metadata("startdate", datetime.datetime(2026, 5, 31, 12, 0, 0))
+    rec.set_metadata("subject", "sub-01")
+
+    rt = Recording.from_file(rec.to_zarr(str(tmp_path / "r")))
+    assert rt.metadata["startdate"] == datetime.datetime(2026, 5, 31, 12, 0, 0)
+    assert type(rt.metadata["startdate"]) is datetime.datetime
+    assert rt.metadata["subject"] == "sub-01"
+
+
+def test_zarr_multigroup_requires_group_selector(tmp_path):
+    """A multi-rate store cannot collapse to one grid; group= picks one."""
+    t = np.arange(2000)
+    rec = Recording()
+    rec.add_channel("E1", np.sin(t / 5.0).astype(np.float64), 250, "uV", "EEG")
+    rec.add_channel("M1", np.cos(t / 5.0).astype(np.float64), 1000, "uV", "EMG")
+
+    out = rec.to_zarr(str(tmp_path / "r"))
+    with pytest.raises(ValueError, match="group="):
+        Recording.from_file(out)
+    rt = Recording.from_file(out, importer="zarr", group="emg_1000hz")
+    assert list(rt.channels) == ["M1"]
+    assert rt.channels["M1"]["modality"] == "EMG"
+
+
+def test_zarr_infer_importer_and_no_signals():
+    assert Recording._infer_importer("store.zarr") == "zarr"
+    with pytest.raises(ValueError, match="No signals loaded"):
+        Recording().to_zarr("unused")
+
+
+@pytest.mark.skipif(not EMG_EDF.exists(), reason="EMG fixture missing")
+def test_zarr_real_emg_fixture_exports_and_reconstructs(tmp_path):
+    """End-to-end on a real EMG recording: export, then reconstruct one group.
+
+    Reconstruction is compared against the exporter's own anti-aliased resample of
+    the source (the serving copy is downsampled, not the full-rate original), so
+    fidelity is the int16 quantization tolerance, not the raw signal.
+    """
+    rec = Recording.from_file(str(EMG_EDF))
+    root = _open(rec.to_zarr(str(tmp_path / "emg")))
+    assert root.attrs["format"] == "biosigio-zarr"
+    groups = [k for k in root.keys() if k != "events"]
+    assert groups
+
+    # Reconstruct the first group and check a channel against the resampled source.
+    gname = groups[0]
+    rt = Recording.from_file(str(tmp_path / "emg.zarr"), importer="zarr", group=gname)
+    label = list(rt.channels)[0]
+    native = rec.channels[label]["sample_frequency"]
+    target = rt.channels[label]["sample_frequency"]
+    expected = _resample_channel(rec.signals[label].to_numpy(), native, target, discrete=False)
+    got = rt.signals[label].to_numpy()
+    n = min(len(expected), len(got))
+    assert np.corrcoef(expected[:n], got[:n])[0, 1] > 0.99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,11 @@ arrow = [
 neo = [
     "neo>=0.13",
 ]
+# Sharded Zarr v3 serving store (viewing + inference + training from one store).
+# Install with `uv sync --extra zarr`.
+zarr = [
+    "zarr>=3",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
@@ -80,6 +85,7 @@ dev = [
     "mne>=1.6",
     "pyarrow>=14",
     "neo>=0.13",
+    "zarr>=3",
 ]
 docs = [
     "mkdocs>=1.6.0",
@@ -90,7 +96,7 @@ docs = [
     "mike>=2.1.0",
 ]
 all = [
-    "emgio[dev,docs,meg,arrow,neo]",
+    "emgio[dev,docs,meg,arrow,neo,zarr]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
Implements the biosigIO **Zarr serving format** from the PRD (`.context/prototypes/biosignal_zarr_PRD.md`): one sharded Zarr v3 store per recording that serves viewing, inference, and training from a single conversion. Completes the serialization trio (Parquet/Arrow already shipped). Part of the biosigIO epic (#44). Closes #78.

Scope = the in-repo PRD deliverables **M1** (`to_zarr` wiring + tests) and **M2** (`from_zarr` reader). M0 (prototype writer) was done; it is now a reviewed/tested package module. M3-M6 (NEMAR batch conversion, web viewer, serving infra) are explicitly out of scope for the Python package.

## What landed
- **`emgio/exporters/zarr.py`** `ZarrExporter` + **`Recording.to_zarr()`**: `level 0` per `(modality, native rate)` group is the anti-aliased, per-modality-resampled inference signal (EEG/MEG 250 Hz, iEEG/EMG 1000 Hz caps; never upsample), sharded. A min/max `view/*` pyramid sits above it, flagged `usable_for_inference=false`. Discrete channels (`TRIG`/`SYSCLOCK`/`CTRL`) are nearest-resampled (no anti-alias) to keep edges. `int16` + per-channel `scale`/`offset` by default; `float32` lossless. Events as onset/duration/code + code->label map.
- **`emgio/importers/zarr.py`** `ZarrImporter` + **`from_file(importer="zarr")`** / `.zarr` autodetect: dequantizes `level 0` (`physical = digital*scale + offset`), restores channels/events/metadata. A multi-rate store can't share emgio's single time grid, so it reconstructs one group at a time (auto for a single group, explicit `group=` otherwise) -- mirroring the neo per-stream selector.
- **Lossless metadata:** two shared helpers in `tabular_schema` (`metadata_to_json`/`metadata_from_json`) so the Zarr root attrs record recording metadata with types intact (datetimes survive), instead of the prototype's `str(v)` dump (the exact issue the Parquet review caught).
- `zarr` optional extra (zarr v3) added to extras + `dev` + `all`. PRD recorded under `.context/prototypes/`.

## Testing (NO MOCKS)
`emgio/tests/test_zarr.py` (10 tests): float32 lossless round-trip; int16 within one quantization step; modality-cap resample + anti-alias flags; never-upsample; view-pyramid flags; discrete-channel handling; events round-trip; metadata type fidelity (datetime stays datetime); multi-group `group=` selector; `.zarr` autodetect + no-signals guard; one end-to-end export+reconstruct of the real EMG EDF fixture (Pearson r > 0.99 vs the resampled source).

- Full suite: 376 passed, 4 skipped
- `ty check emgio` clean (blocking gate); ruff check + format clean

## Notes
- The store is a **derived serving copy**; `from_zarr` reconstructs at the canonical (possibly downsampled) `level 0` rate, not the original full-rate signal. BIDS/EDF remain authoritative.