### PR TITLE
Release 0.5.0: complete EMG -> Recording rename, deprecate EMG alias

### DIFF
--- a/.context/plan.md
+++ b/.context/plan.md
@@ -15,7 +15,7 @@
 - [x] Setup GitHub Actions CI/CD
 
 ### Phase 2: Core Features [COMPLETED]
-- [x] Implement EMG class with signal handling
+- [x] Implement Recording class with signal handling
 - [x] Add multi-format importers (EEGLAB, Trigno, OTB, EDF/BDF, WFDB, XDF, CSV)
 - [x] Create EDF/BDF exporter with auto format selection
 - [x] Implement metadata and channel management

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 ## Architecture Map
 ```
 emgio/
-├── core/          # EMG main class — central data handling
+├── core/          # Recording main class — central data handling
 ├── importers/     # Format-specific import logic (Trigno, EDF/BDF, WFDB, EEGLAB, OTB, CSV)
 ├── exporters/     # Format-specific export (EDF/BDF(+) with auto format selection)
 ├── analysis/      # Signal analysis routines
@@ -114,7 +114,7 @@ uv run mkdocs serve                                # Build docs
 - **Export:** EDF/BDF(+) with automatic format selection
 
 ### Key Classes
-- `EMG` (emgio/core) — main class for data handling
+- `Recording` (emgio/core) — main class for data handling
 - Importers (emgio/importers) — format-specific import logic
 - Exporters (emgio/exporters) — format-specific export logic
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ uv pip install .
 ### Basic Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load data with automatic format detection
-emg = EMG.from_file('data.csv')  # Format detected from file extension
+emg = Recording.from_file('data.csv')  # Format detected from file extension
 
 # Load data with explicit importer
-emg = EMG.from_file('data.csv', importer='trigno')
+emg = Recording.from_file('data.csv', importer='trigno')
 
 # Plot specific channels
 emg.plot_signals(['EMG1', 'EMG2'])
@@ -85,7 +85,7 @@ emg.to_edf('output.edf')
 
 ```python
 # Import a generic CSV file
-emg = EMG.from_file('data.csv', importer='csv',
+emg = Recording.from_file('data.csv', importer='csv',
                    sample_frequency=1000,  # Required if no time column
                    has_header=True,        # Whether file has header row
                    channel_names=['EMG_L', 'EMG_R', 'ACC_X'])

--- a/docs/api/analysis/verification.md
+++ b/docs/api/analysis/verification.md
@@ -12,7 +12,7 @@ The `verification` module provides functions for verifying signal integrity afte
 
 ## Key Functions Summary
 
-- `compare_signals()`: Compare signals between two EMG objects using normalized metrics.
+- `compare_signals()`: Compare signals between two Recording objects using normalized metrics.
 - `report_verification_results()`: Generate a detailed report based on verification results.
 
 ## Usage Examples
@@ -20,15 +20,15 @@ The `verification` module provides functions for verifying signal integrity afte
 ### Comparing Signals
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.analysis.verification import compare_signals, report_verification_results
 
 # Load original EMG data
-emg_original = EMG.from_file("data.csv", importer="trigno")
+emg_original = Recording.from_file("data.csv", importer="trigno")
 
 # Export to EDF and reload
 emg_original.to_edf("exported_data")
-emg_reloaded = EMG.from_file("exported_data.edf")
+emg_reloaded = Recording.from_file("exported_data.edf")
 
 # Compare signals
 results = compare_signals(emg_original, emg_reloaded)

--- a/docs/api/emg.md
+++ b/docs/api/emg.md
@@ -1,10 +1,10 @@
-# EMG Class API
+# Recording Class API
 
-The `EMG` class is the main class in EMGIO for working with EMG data. It encapsulates signals, channel information, and metadata, and provides methods for data manipulation and export.
+The `Recording` class is the main class in EMGIO for working with EMG data. It encapsulates signals, channel information, and metadata, and provides methods for data manipulation and export.
 
 ## Class Documentation
 
-::: emgio.core.emg.EMG
+::: emgio.core.emg.Recording
     handler: python
     options:
       show_root_heading: true
@@ -53,7 +53,7 @@ Details about the main attributes:
 ### Data Loading
 
 - `from_file()`: Load EMG data from a file (class method)
-- `from_dataframe()`: Create EMG object from a pandas DataFrame (class method)
+- `from_dataframe()`: Create Recording object from a pandas DataFrame (class method)
 
 ### Data Access
 
@@ -66,7 +66,7 @@ Details about the main attributes:
 
 ### Data Manipulation
 
-- `select_channels()`: Create a new EMG object with selected channels
+- `select_channels()`: Create a new Recording object with selected channels
 - `set_metadata()`: Set a single metadata field
 - `get_metadata()`: Get a single metadata field
 - `has_metadata()`: Check if a metadata field exists
@@ -84,23 +84,23 @@ Details about the main attributes:
 ### Loading Data
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load from file with automatic importer selection
-emg = EMG.from_file("data.otb+")
+emg = Recording.from_file("data.otb+")
 
 # Load with explicit importer
-emg = EMG.from_file("data.otb+", importer="otb")
+emg = Recording.from_file("data.otb+", importer="otb")
 
 # Load with explicit importer (.csv does not support automatic importer selection)
-emg = EMG.from_file("data.csv", importer='trigno')
+emg = Recording.from_file("data.csv", importer='trigno')
 ```
 
 ### Creating from DataFrame
 
 ```python
 import pandas as pd
-from emgio import EMG
+from emgio import Recording
 
 # Create a DataFrame with EMG data
 data = pd.DataFrame({
@@ -122,8 +122,8 @@ channels = {
     }
 }
 
-# Create EMG object
-emg = EMG.from_dataframe(data, channels=channels)
+# Create Recording object
+emg = Recording.from_dataframe(data, channels=channels)
 ```
 
 ### Selecting Channels
@@ -189,7 +189,7 @@ emg_original.to_edf('output', verify=True, verify_plot=True)
 
 # Manual verification (alternative approach)
 emg_original.to_edf('output')
-emg_reloaded = EMG.from_file('output.edf')
+emg_reloaded = Recording.from_file('output.edf')
 
 # Compare signals
 results = compare_signals(emg_original, emg_reloaded, tolerance=0.001)

--- a/docs/api/exporters/edf.md
+++ b/docs/api/exporters/edf.md
@@ -13,10 +13,10 @@ The EDF/BDF exporter module in EMGIO provides functionality to export EMG data t
 ## Usage Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load data
-emg = EMG.from_file('data.csv', importer='trigno')
+emg = Recording.from_file('data.csv', importer='trigno')
 
 # Export to EDF/BDF with automatic format selection
 emg.to_edf('output')  # Will generate output.edf or output.bdf

--- a/docs/api/importers/base.md
+++ b/docs/api/importers/base.md
@@ -93,15 +93,15 @@ The `load()` method must return a tuple of three elements:
 
 ## Registering a Custom Importer
 
-To make your custom importer available through `EMG.from_file()`, you need to register it:
+To make your custom importer available through `Recording.from_file()`, you need to register it:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from my_module import MyCustomImporter
 
 # Register the importer with a name
-EMG.register_importer('my_format', MyCustomImporter)
+Recording.register_importer('my_format', MyCustomImporter)
 
 # Now you can use it
-emg = EMG.from_file('data.custom', importer='my_format')
+emg = Recording.from_file('data.custom', importer='my_format')
 ``` 

--- a/docs/api/importers/csv.md
+++ b/docs/api/importers/csv.md
@@ -13,16 +13,16 @@ The `CSVImporter` class is responsible for importing EMG and other physiological
 ## Usage Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.importers.csv import CSVImporter
 
-# Method 1: Using EMG.from_file (recommended)
-emg = EMG.from_file('data.csv', importer='csv')
+# Method 1: Using Recording.from_file (recommended)
+emg = Recording.from_file('data.csv', importer='csv')
 
 # Method 2: Using the importer directly
 importer = CSVImporter('data.csv', has_header=True, delimiter=',')
 signals, channels, metadata = importer.load()
-emg = EMG(signals, channels, metadata)
+emg = Recording(signals, channels, metadata)
 ```
 
 ## Auto-Detection Features
@@ -78,14 +78,14 @@ The CSV importer uses pandas to:
 
 ```python
 # Load CSV with automatic format detection
-emg = EMG.from_file('data.csv', importer='csv')
+emg = Recording.from_file('data.csv', importer='csv')
 ```
 
 ### Headerless CSV with Custom Names
 
 ```python
 # Load headerless CSV with custom channel names
-emg = EMG.from_file('data.csv', importer='csv',
+emg = Recording.from_file('data.csv', importer='csv',
                    has_header=False,
                    sample_frequency=1000,  # Required since no time column
                    channel_names=['EMG_L', 'EMG_R', 'ACC_X'])
@@ -95,7 +95,7 @@ emg = EMG.from_file('data.csv', importer='csv',
 
 ```python
 # Specify channel types and physical dimensions
-emg = EMG.from_file('data.csv', importer='csv',
+emg = Recording.from_file('data.csv', importer='csv',
                    channel_types={
                        'EMG1': 'EMG',
                        'EMG2': 'EMG',

--- a/docs/api/importers/edf.md
+++ b/docs/api/importers/edf.md
@@ -13,16 +13,16 @@ The `EDFImporter` class is responsible for importing EMG and other physiological
 ## Usage Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.importers.edf import EDFImporter
 
-# Method 1: Using EMG.from_file (recommended)
-emg = EMG.from_file('data.edf', importer='edf')  # Works for both .edf and .bdf
+# Method 1: Using Recording.from_file (recommended)
+emg = Recording.from_file('data.edf', importer='edf')  # Works for both .edf and .bdf
 
 # Method 2: Using the importer directly
 importer = EDFImporter('data.edf')
 signals, channels, metadata = importer.load()
-emg = EMG(signals, channels, metadata)
+emg = Recording(signals, channels, metadata)
 ```
 
 ## File Format Support
@@ -90,7 +90,7 @@ EDF+ files can contain annotations that mark specific events or segments in the 
 
 ```python
 # Load EDF+ file with annotations
-emg = EMG.from_file('data.edf+', importer='edf')
+emg = Recording.from_file('data.edf+', importer='edf')
 
 # Access annotations
 annotations = emg.get_metadata('annotations')

--- a/docs/api/importers/eeglab.md
+++ b/docs/api/importers/eeglab.md
@@ -13,16 +13,16 @@ The `EEGLABImporter` class is responsible for importing EMG (and other biopotent
 ## Usage Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.importers.eeglab import EEGLABImporter
 
-# Method 1: Using EMG.from_file (recommended)
-emg = EMG.from_file('data.set', importer='eeglab')
+# Method 1: Using Recording.from_file (recommended)
+emg = Recording.from_file('data.set', importer='eeglab')
 
 # Method 2: Using the importer directly
 importer = EEGLABImporter('data.set')
 signals, channels, metadata = importer.load()
-emg = EMG(signals, channels, metadata)
+emg = Recording(signals, channels, metadata)
 ```
 
 ## File Format Support

--- a/docs/api/importers/otb.md
+++ b/docs/api/importers/otb.md
@@ -13,16 +13,16 @@ The `OTBImporter` class is responsible for importing EMG and other electrophysio
 ## Usage Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.importers.otb import OTBImporter
 
-# Method 1: Using EMG.from_file (recommended)
-emg = EMG.from_file('data.otb+', importer='otb')
+# Method 1: Using Recording.from_file (recommended)
+emg = Recording.from_file('data.otb+', importer='otb')
 
 # Method 2: Using the importer directly
 importer = OTBImporter('data.otb+')
 signals, channels, metadata = importer.load()
-emg = EMG(signals, channels, metadata)
+emg = Recording(signals, channels, metadata)
 ```
 
 ## File Format Support

--- a/docs/api/importers/trigno.md
+++ b/docs/api/importers/trigno.md
@@ -13,16 +13,16 @@ The `TrignoImporter` class is responsible for importing EMG data from Delsys Tri
 ## Usage Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.importers.trigno import TrignoImporter
 
-# Method 1: Using EMG.from_file (recommended)
-emg = EMG.from_file('data.csv', importer='trigno')
+# Method 1: Using Recording.from_file (recommended)
+emg = Recording.from_file('data.csv', importer='trigno')
 
 # Method 2: Using the importer directly
 importer = TrignoImporter('data.csv')
 signals, channels, metadata = importer.load()
-emg = EMG(signals, channels, metadata)
+emg = Recording(signals, channels, metadata)
 ```
 
 ## File Format Requirements

--- a/docs/api/importers/xdf.md
+++ b/docs/api/importers/xdf.md
@@ -15,11 +15,11 @@ The `XDFImporter` class handles importing data from XDF (Extensible Data Format)
 ### Basic Loading
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.importers.xdf import XDFImporter
 
-# Method 1: Using EMG.from_file (recommended)
-emg = EMG.from_file('recording.xdf')
+# Method 1: Using Recording.from_file (recommended)
+emg = Recording.from_file('recording.xdf')
 
 # Method 2: Using the importer directly
 importer = XDFImporter()
@@ -54,30 +54,30 @@ print(summary)
 
 ```python
 # Load only specific stream types
-emg = EMG.from_file('recording.xdf', stream_types=['EMG'])
+emg = Recording.from_file('recording.xdf', stream_types=['EMG'])
 
 # Load multiple types
-emg = EMG.from_file('recording.xdf', stream_types=['EMG', 'EEG'])
+emg = Recording.from_file('recording.xdf', stream_types=['EMG', 'EEG'])
 
 # Load by stream name
-emg = EMG.from_file('recording.xdf', stream_names=['MyEMGDevice'])
+emg = Recording.from_file('recording.xdf', stream_names=['MyEMGDevice'])
 
 # Load by stream ID
-emg = EMG.from_file('recording.xdf', stream_ids=[2])
+emg = Recording.from_file('recording.xdf', stream_ids=[2])
 ```
 
 ### Setting Default Channel Type
 
 ```python
 # For streams without explicit channel type metadata
-emg = EMG.from_file('recording.xdf', default_channel_type='EMG')
+emg = Recording.from_file('recording.xdf', default_channel_type='EMG')
 ```
 
 ### Preserving LSL Timestamps
 
 ```python
 # Include original LSL timestamps as additional channels
-emg = EMG.from_file('recording.xdf', include_timestamps=True)
+emg = Recording.from_file('recording.xdf', include_timestamps=True)
 
 # Each stream gets a "{stream_name}_LSL_timestamps" channel
 # Useful for synchronization with other LSL-recorded data
@@ -105,7 +105,7 @@ The XDF importer supports:
 
 ## Return Values
 
-The `load()` method returns an `EMG` object with:
+The `load()` method returns a `Recording` object with:
 
 ### Signals (pandas.DataFrame)
 - Time-indexed signal data

--- a/docs/api/visualization/static.md
+++ b/docs/api/visualization/static.md
@@ -1,6 +1,6 @@
 # Static Visualization API
 
-The `static` module in `emgio.visualization` provides functions for static plotting of EMG data. These functions are primarily used internally by the `EMG` class methods but can also be called directly for advanced customization.
+The `static` module in `emgio.visualization` provides functions for static plotting of EMG data. These functions are primarily used internally by the `Recording` class methods but can also be called directly for advanced customization.
 
 ## Module Documentation
 
@@ -17,16 +17,16 @@ The `static` module in `emgio.visualization` provides functions for static plott
 
 ## Direct Usage Examples
 
-While these functions are typically accessed through the `EMG` class methods, they can be called directly for advanced use cases:
+While these functions are typically accessed through the `Recording` class methods, they can be called directly for advanced use cases:
 
 ### Plotting Signals Directly
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.visualization.static import plot_signals
 
 # Load EMG data
-emg = EMG.from_file("data.csv", importer="trigno")
+emg = Recording.from_file("data.csv", importer="trigno")
 
 # Plot signals directly with custom parameters
 plot_signals(
@@ -45,12 +45,12 @@ plot_signals(
 ### Plotting Comparison Directly
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.visualization.static import plot_comparison
 
 # Load original and reloaded EMG data
-emg_original = EMG.from_file("original.csv", importer="trigno")
-emg_reloaded = EMG.from_file("reloaded.edf")
+emg_original = Recording.from_file("original.csv", importer="trigno")
+emg_reloaded = Recording.from_file("reloaded.edf")
 
 # Create channel mapping
 channel_map = {
@@ -84,4 +84,4 @@ The static plotting functions provide several parameters for customization:
 - **Grid lines**: Toggle grid visibility
 - **Titles**: Add custom titles to plots
 
-For most use cases, the corresponding methods on the `EMG` class (`plot_signals()` and `plot_comparison()`) are recommended as they provide simplified interfaces to these functions. 
+For most use cases, the corresponding methods on the `Recording` class (`plot_signals()` and `plot_comparison()`) are recommended as they provide simplified interfaces to these functions. 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,7 @@ emgio/
 ├── emgio/              # Main package directory
 │   ├── __init__.py     # Package initialization
 │   ├── core/           # Core functionality
-│   │   ├── emg.py      # Main EMG class
+│   │   ├── emg.py      # Main Recording class
 │   ├── importers/      # Data import modules
 │   │   ├── base.py     # Base importer class
 │   │   ├── trigno.py   # Trigno importer
@@ -66,7 +66,7 @@ Example test:
 
 ```python
 def test_channel_selection():
-    # Create a test EMG object
+    # Create a test Recording object
     ...
     
     # Run the function being tested

--- a/docs/examples/eeglab.md
+++ b/docs/examples/eeglab.md
@@ -6,12 +6,12 @@ This page provides examples for working with EEGLAB `.set` files using EMGIO.
 
 ```python
 import os
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 
 # Load data from an EEGLAB .set file
 data_path = 'path_to_your_eeglab_file.set'
-emg = EMG.from_file(data_path, importer='eeglab')
+emg = Recording.from_file(data_path, importer='eeglab')
 
 # Print metadata
 print("\nMetadata:")
@@ -52,12 +52,12 @@ if emg_channels:
 EEGLAB files often contain event markers. Here's how to access and work with them:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import numpy as np
 import matplotlib.pyplot as plt
 
 # Load EEGLAB data with events
-emg = EMG.from_file('data_with_events.set', importer='eeglab')
+emg = Recording.from_file('data_with_events.set', importer='eeglab')
 
 # Check if events exist in the metadata
 if 'event' in emg.metadata:
@@ -99,11 +99,11 @@ if 'event' in emg.metadata:
 EEGLAB can store continuous or epoched data. EMGIO can work with both:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 
 # Load epoched EEGLAB data
-emg = EMG.from_file('epoched_data.set', importer='eeglab')
+emg = Recording.from_file('epoched_data.set', importer='eeglab')
 
 # Check if data is epoched
 is_epoched = emg.get_metadata('trials', 1) > 1
@@ -163,10 +163,10 @@ if is_epoched:
 Converting EEGLAB data to EDF/BDF format:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load EEGLAB data
-emg = EMG.from_file('data.set', importer='eeglab')
+emg = Recording.from_file('data.set', importer='eeglab')
 
 # Export all channels to EDF/BDF
 output_path = 'eeglab_all_channels'

--- a/docs/examples/notebooks.md
+++ b/docs/examples/notebooks.md
@@ -35,12 +35,12 @@ When working with EMGIO in Jupyter notebooks, you can take advantage of these fe
 ### Interactive Plotting
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 %matplotlib inline  # For displaying plots in the notebook
 
 # Load EMG data
-emg = EMG.from_file('data.csv', importer='trigno')
+emg = Recording.from_file('data.csv', importer='trigno')
 
 # Plot signals with customized appearance
 emg.plot_signals(
@@ -58,7 +58,7 @@ Jupyter notebooks are excellent for interactively exploring your EMG data:
 
 ```python
 # Load data
-emg = EMG.from_file('data.otb+', importer='otb')
+emg = Recording.from_file('data.otb+', importer='otb')
 
 # Display channel information
 channel_types = emg.get_channel_types()
@@ -84,7 +84,7 @@ import ipywidgets as widgets
 from IPython.display import display
 
 # Load data
-emg = EMG.from_file('data.set', importer='eeglab')
+emg = Recording.from_file('data.set', importer='eeglab')
 
 # Get all channels
 all_channels = list(emg.channels.keys())

--- a/docs/examples/otb.md
+++ b/docs/examples/otb.md
@@ -6,11 +6,11 @@ This page provides examples for working with OTB+ files from OT Bioelettronica d
 
 ```python
 import matplotlib.pyplot as plt
-from emgio import EMG
+from emgio import Recording
 
 # Load OTB data
 data_path = 'path_to_your_otb_file.otb+'
-emg = EMG.from_file(data_path, importer='otb')
+emg = Recording.from_file(data_path, importer='otb')
 
 # Print device information
 print("\nDevice Information:")
@@ -50,14 +50,14 @@ plt.show()
 OTB files often contain multiple channel types. Here's how to work specifically with EMG channels:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 import numpy as np
 
 # Load OTB data
-emg = EMG.from_file('otb_data.otb+', importer='otb')
+emg = Recording.from_file('otb_data.otb+', importer='otb')
 
-# Create a new EMG object with only EMG channels
+# Create a new Recording object with only EMG channels
 emg_channels = emg.get_channels_by_type('EMG')
 
 if emg_channels:
@@ -125,15 +125,15 @@ else:
 When working with multiple recordings from the same experiment:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 
 # Load two OTB files
 file1 = 'session1.otb+'
 file2 = 'session2.otb+'
 
-emg1 = EMG.from_file(file1, importer='otb')
-emg2 = EMG.from_file(file2, importer='otb')
+emg1 = Recording.from_file(file1, importer='otb')
+emg2 = Recording.from_file(file2, importer='otb')
 
 # Add metadata to distinguish them
 emg1.set_metadata('session', '1')
@@ -187,10 +187,10 @@ if emg_channels:
 Converting OTB data to EDF/BDF format:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load OTB data
-emg = EMG.from_file('data.otb+', importer='otb')
+emg = Recording.from_file('data.otb+', importer='otb')
 
 # Add metadata for export
 emg.set_metadata('subject', 'S001')

--- a/docs/examples/trigno.md
+++ b/docs/examples/trigno.md
@@ -6,12 +6,12 @@ This page demonstrates how to work with EMG data from the Delsys Trigno wireless
 
 ```python
 import os
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 
 # Load data from Trigno CSV file
 data_path = 'path_to_your_trigno_data.csv'
-emg = EMG.from_file(data_path, importer='trigno')
+emg = Recording.from_file(data_path, importer='trigno')
 
 # Print information about the loaded data
 print(f"Number of channels: {emg.get_n_channels()}")
@@ -87,8 +87,8 @@ If you have multiple recordings from the same experiment, you can load them sepa
 
 ```python
 # Load two recordings
-session1 = EMG.from_file('session1.csv', importer='trigno')
-session2 = EMG.from_file('session2.csv', importer='trigno')
+session1 = Recording.from_file('session1.csv', importer='trigno')
+session2 = Recording.from_file('session2.csv', importer='trigno')
 
 # Add metadata to distinguish them
 session1.set_metadata('session', '1')
@@ -121,13 +121,13 @@ Here's a complete workflow using Trigno data:
 
 ```python
 import os
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 import numpy as np
 
 # 1. Load the data
 data_path = 'trigno_recording.csv'
-emg = EMG.from_file(data_path, importer='trigno')
+emg = Recording.from_file(data_path, importer='trigno')
 
 # 2. Add metadata
 emg.set_metadata('subject', 'S001')

--- a/docs/examples/verification.md
+++ b/docs/examples/verification.md
@@ -5,21 +5,21 @@ This page demonstrates how to use EMGIO's verification capabilities to ensure si
 ## Basic Verification Workflow
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 from emgio.analysis.verification import compare_signals, report_verification_results
 
 # Load original data from a device-specific format
-emg_original = EMG.from_file('sample_data.csv', importer='trigno')
+emg_original = Recording.from_file('sample_data.csv', importer='trigno')
 # just keep the EMG channels
 emg_channels = [ch for ch, info in emg_original.channels.items() if info['channel_type'] == 'EMG']
-emg_original = emg_original.select_channels(emg_channels)  # Creates a new EMG object with only EMG channels
+emg_original = emg_original.select_channels(emg_channels)  # Creates a new Recording object with only EMG channels
 
 # Export to EDF (automatically selects EDF or BDF based on signal characteristics)
 emg_original.to_edf('exported_data')
 
 # Reload the exported data
-emg_reloaded = EMG.from_file('exported_data.edf')
+emg_reloaded = Recording.from_file('exported_data.edf')
 
 # Verify signals using the verification module
 results = compare_signals(emg_original, emg_reloaded, tolerance=0.01)
@@ -117,13 +117,13 @@ plt.show()
 ## Real-World Example: CSV to EDF Conversion
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 from emgio.analysis.verification import compare_signals, report_verification_results
 from emgio.visualization.static import plot_comparison
 
 # 1. Load original Trigno CSV data
-emg_trigno = EMG.from_file('trigno_data.csv', importer='trigno')
+emg_trigno = Recording.from_file('trigno_data.csv', importer='trigno')
 
 # 2. Export to EDF
 emg_trigno.to_edf('converted_data')
@@ -131,7 +131,7 @@ print(f"Data exported. Duration: {emg_trigno.get_duration():.2f}s, "
       f"Channels: {emg_trigno.get_n_channels()}")
 
 # 3. Reload from EDF
-emg_edf = EMG.from_file('converted_data.edf')
+emg_edf = Recording.from_file('converted_data.edf')
 print(f"Data reloaded. Duration: {emg_edf.get_duration():.2f}s, "
       f"Channels: {emg_edf.get_n_channels()}")
 

--- a/docs/examples/wfdb.md
+++ b/docs/examples/wfdb.md
@@ -12,9 +12,9 @@ The `WFDBImporter` automatically detects and loads annotations if the correspond
 
 ## Key Steps Explained
 
-1.  **Import `EMG`:** The core class is imported.
+1.  **Import `Recording`:** The core class is imported.
 2.  **Define Path:** The path to the WFDB header file (`.hea`) is specified.
-3.  **Load Data:** `EMG.from_file()` is called with the header file path. EMGIO infers the importer (`'wfdb'`) based on the `.hea` extension (this could also be explicitly set using `importer='wfdb'`). The importer reads the header, data, and automatically looks for `100.atr` to load annotations.
+3.  **Load Data:** `Recording.from_file()` is called with the header file path. EMGIO infers the importer (`'wfdb'`) based on the `.hea` extension (this could also be explicitly set using `importer='wfdb'`). The importer reads the header, data, and automatically looks for `100.atr` to load annotations.
 4.  **Access Metadata:** Basic metadata like `record_name` and `sampling_frequency` are accessed using `emg.get_metadata()`.
 5.  **Access Channels:** Information about the loaded channels (`MLII`, `V5`) is iterated through `emg.channels`.
 6.  **Access Annotations:** The script checks if the `emg.events` DataFrame is populated. If the `.atr` file was loaded successfully, it prints the first and last few annotations.

--- a/docs/examples/xdf.md
+++ b/docs/examples/xdf.md
@@ -53,10 +53,10 @@ if mocap:
 ## Loading All Numeric Data
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load all numeric streams (EEG, EMG, Mocap - excludes Markers)
-emg = EMG.from_file('examples/multi_stream_test.xdf')
+emg = Recording.from_file('examples/multi_stream_test.xdf')
 
 print(f"Total channels: {len(emg.channels)}")
 print(f"Channel names: {list(emg.channels.keys())}")
@@ -68,12 +68,12 @@ print(f"Channel names: {list(emg.channels.keys())}")
 
 ```python
 # Load only EMG data
-emg_data = EMG.from_file('examples/multi_stream_test.xdf', stream_types=['EMG'])
+emg_data = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EMG'])
 print(f"EMG channels: {list(emg_data.channels.keys())}")
 # Output: ['EMG_L', 'EMG_R']
 
 # Load EEG and EMG together
-combined = EMG.from_file('examples/multi_stream_test.xdf', stream_types=['EEG', 'EMG'])
+combined = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EEG', 'EMG'])
 print(f"Combined channels: {len(combined.channels)}")
 # Output: 10 (8 EEG + 2 EMG)
 ```
@@ -82,7 +82,7 @@ print(f"Combined channels: {len(combined.channels)}")
 
 ```python
 # Load specific streams by name
-emg_data = EMG.from_file('examples/multi_stream_test.xdf', stream_names=['TestEMG'])
+emg_data = Recording.from_file('examples/multi_stream_test.xdf', stream_names=['TestEMG'])
 ```
 
 ## Working with Multi-Rate Data
@@ -91,7 +91,7 @@ When loading streams with different sampling rates, they're resampled to a commo
 
 ```python
 # Load EEG (256 Hz) and EMG (2048 Hz)
-combined = EMG.from_file('examples/multi_stream_test.xdf', stream_types=['EEG', 'EMG'])
+combined = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EEG', 'EMG'])
 
 # Check the resulting sample rate (will be the highest: 2048 Hz)
 first_channel = list(combined.channels.keys())[0]
@@ -104,7 +104,7 @@ XDF files contain per-sample LSL timestamps. To preserve these for synchronizati
 
 ```python
 # Load with timestamp channels
-emg = EMG.from_file('examples/multi_stream_test.xdf',
+emg = Recording.from_file('examples/multi_stream_test.xdf',
                     stream_types=['EMG'],
                     include_timestamps=True)
 
@@ -124,7 +124,7 @@ After loading, export to EDF/BDF format:
 
 ```python
 # Load EMG streams with timestamps for synchronization
-emg = EMG.from_file('examples/multi_stream_test.xdf',
+emg = Recording.from_file('examples/multi_stream_test.xdf',
                     stream_types=['EMG'],
                     include_timestamps=True)
 
@@ -132,14 +132,14 @@ emg = EMG.from_file('examples/multi_stream_test.xdf',
 emg.to_edf('output_emg.edf')
 
 # Verify the export
-emg_reloaded = EMG.from_file('output_emg.edf')
+emg_reloaded = Recording.from_file('output_emg.edf')
 print(f"Exported channels: {list(emg_reloaded.channels.keys())}")
 ```
 
 ## Complete Workflow Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.importers.xdf import summarize_xdf
 
 # 1. Explore the file
@@ -151,7 +151,7 @@ emg_streams = summary.get_streams_by_type('EMG')
 print(f"Found {len(emg_streams)} EMG streams")
 
 # 3. Load selected data
-emg = EMG.from_file('recording.xdf', stream_types=['EMG'])
+emg = Recording.from_file('recording.xdf', stream_types=['EMG'])
 
 # 4. Check loaded data
 print(f"Channels: {list(emg.channels.keys())}")

--- a/docs/formats/csv.md
+++ b/docs/formats/csv.md
@@ -12,16 +12,16 @@ EMGIO provides a flexible CSV importer that can handle a wide variety of CSV-for
 ## Usage
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Basic usage (automatic format detection)
-emg = EMG.from_file('data.csv')
+emg = Recording.from_file('data.csv')
 
 # Force using the generic CSV importer even if specialized format is detected
-emg = EMG.from_file('data.csv', importer='csv', force_csv=True)
+emg = Recording.from_file('data.csv', importer='csv', force_csv=True)
 
 # Specify custom parameters
-emg = EMG.from_file('data.csv', importer='csv', 
+emg = Recording.from_file('data.csv', importer='csv', 
                    sample_frequency=1000,  # Required if no time column
                    has_header=True,        # Whether file has header row
                    delimiter=',',          # Column delimiter
@@ -57,7 +57,7 @@ The CSV importer accepts many customization parameters:
 # 0.001,0.2,0.3,0.4
 # ...
 
-emg = EMG.from_file('data.csv', importer='csv')
+emg = Recording.from_file('data.csv', importer='csv')
 ```
 
 ### Headerless CSV with Custom Names
@@ -68,7 +68,7 @@ emg = EMG.from_file('data.csv', importer='csv')
 # 0.2,0.3,0.4
 # ...
 
-emg = EMG.from_file('data.csv', importer='csv',
+emg = Recording.from_file('data.csv', importer='csv',
                     has_header=False,
                     sample_frequency=1000,  # Required since no time column
                     channel_names=['EMG_L', 'EMG_R', 'ACC_X'])
@@ -77,7 +77,7 @@ emg = EMG.from_file('data.csv', importer='csv',
 ### Setting Channel Types and Units
 
 ```python
-emg = EMG.from_file('data.csv', importer='csv',
+emg = Recording.from_file('data.csv', importer='csv',
                     channel_types={
                         'EMG1': 'EMG',
                         'EMG2': 'EMG',
@@ -94,12 +94,12 @@ emg = EMG.from_file('data.csv', importer='csv',
 
 ```python
 # Only load columns 0 and 2
-emg = EMG.from_file('data.csv', importer='csv',
+emg = Recording.from_file('data.csv', importer='csv',
                     columns=[0, 2],
                     sample_frequency=1000)
 
 # Only load columns named 'EMG1' and 'ACC1'
-emg = EMG.from_file('data.csv', importer='csv',
+emg = Recording.from_file('data.csv', importer='csv',
                     columns=['EMG1', 'ACC1'])
 ```
 

--- a/docs/formats/edf.md
+++ b/docs/formats/edf.md
@@ -67,10 +67,10 @@ The EDF exporter in EMGIO (`emgio.exporters.edf`) also uses `pyedflib` to:
 ## Code Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Import from EDF file
-emg = EMG.from_file('input.edf', importer='edf')
+emg = Recording.from_file('input.edf', importer='edf')
 
 # Print basic information
 print(f"Number of channels: {emg.get_n_channels()}")

--- a/docs/formats/eeglab.md
+++ b/docs/formats/eeglab.md
@@ -42,10 +42,10 @@ The EEGLAB importer in EMGIO (`emgio.importers.eeglab`) works by:
 ## Code Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load data from EEGLAB .set file
-emg = EMG.from_file('data.set', importer='eeglab')
+emg = Recording.from_file('data.set', importer='eeglab')
 
 # Print metadata
 print(f"Subject: {emg.get_metadata('subject')}")

--- a/docs/formats/otb.md
+++ b/docs/formats/otb.md
@@ -39,11 +39,11 @@ The OTB importer in EMGIO (`emgio.importers.otb`) works by:
 ## Code Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 import matplotlib.pyplot as plt
 
 # Load data from OTB file
-emg = EMG.from_file('data.otb+', importer='otb')
+emg = Recording.from_file('data.otb+', importer='otb')
 
 # Print device information
 print(f"Device: {emg.get_metadata('device')}")

--- a/docs/formats/trigno.md
+++ b/docs/formats/trigno.md
@@ -44,10 +44,10 @@ The Trigno importer in EMGIO (`emgio.importers.trigno`) processes these files by
 ## Code Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load data from Trigno CSV file
-emg = EMG.from_file('data.csv', importer='trigno')
+emg = Recording.from_file('data.csv', importer='trigno')
 
 # Print identified channel types
 channel_types = emg.get_channel_types()

--- a/docs/formats/wfdb.md
+++ b/docs/formats/wfdb.md
@@ -12,16 +12,16 @@ Loading WFDB data typically involves three files sharing the same base name (e.g
 
 ## Loading Data
 
-To load a WFDB record, provide the path to the **header (`.hea`) file** or just the base record name (if the files are in the current directory or the path is configured) to `EMG.from_file`:
+To load a WFDB record, provide the path to the **header (`.hea`) file** or just the base record name (if the files are in the current directory or the path is configured) to `Recording.from_file`:
 
 ```python
-from emgio.core.emg import EMG
+from emgio.core.emg import Recording
 
 # Load using the header file path
-emg = EMG.from_file('path/to/your/record.hea')
+emg = Recording.from_file('path/to/your/record.hea')
 
 # Or load using just the base name (looks for files in the current directory)
-# emg = EMG.from_file('record')
+# emg = Recording.from_file('record')
 ```
 
 EMGIO uses the `wfdb` library (PyPI package `wfdb`) internally. It ships as a core dependency, so no separate installation is required.

--- a/docs/formats/xdf.md
+++ b/docs/formats/xdf.md
@@ -46,10 +46,10 @@ if stream:
 Load all numeric streams from an XDF file:
 
 ```python
-from emgio.core.emg import EMG
+from emgio.core.emg import Recording
 
 # Load all numeric streams (excludes marker/string streams)
-emg = EMG.from_file('recording.xdf')
+emg = Recording.from_file('recording.xdf')
 ```
 
 ### Selective Loading
@@ -58,16 +58,16 @@ XDF files often contain many streams. You can select specific streams:
 
 ```python
 # Load only EMG streams
-emg = EMG.from_file('recording.xdf', stream_types=['EMG'])
+emg = Recording.from_file('recording.xdf', stream_types=['EMG'])
 
 # Load specific stream types
-emg = EMG.from_file('recording.xdf', stream_types=['EMG', 'EXG'])
+emg = Recording.from_file('recording.xdf', stream_types=['EMG', 'EXG'])
 
 # Load by stream name
-emg = EMG.from_file('recording.xdf', stream_names=['MyEMGDevice'])
+emg = Recording.from_file('recording.xdf', stream_names=['MyEMGDevice'])
 
 # Load by stream ID
-emg = EMG.from_file('recording.xdf', stream_ids=[1, 3])
+emg = Recording.from_file('recording.xdf', stream_ids=[1, 3])
 ```
 
 ## Multi-Stream Handling
@@ -80,7 +80,7 @@ When loading multiple streams with different sampling rates, EMGIO:
 
 ```python
 # Load EEG and EMG together (different sample rates)
-emg = EMG.from_file('recording.xdf', stream_types=['EEG', 'EMG'])
+emg = Recording.from_file('recording.xdf', stream_types=['EEG', 'EMG'])
 
 # Channels will be named like: "StreamName_ChannelLabel"
 print(list(emg.channels.keys()))
@@ -113,7 +113,7 @@ The XDF importer attempts to infer channel types from:
 
 ```python
 # Set default channel type for streams without explicit type info
-emg = EMG.from_file('recording.xdf', default_channel_type='EMG')
+emg = Recording.from_file('recording.xdf', default_channel_type='EMG')
 ```
 
 ## Metadata
@@ -127,7 +127,7 @@ Loaded XDF files include metadata such as:
 - `stream_types`: Types of all streams
 
 ```python
-emg = EMG.from_file('recording.xdf')
+emg = Recording.from_file('recording.xdf')
 print(emg.get_metadata('stream_names'))
 print(emg.get_metadata('stream_types'))
 ```
@@ -140,7 +140,7 @@ To preserve the original LSL timestamps, use the `include_timestamps` option:
 
 ```python
 # Load with timestamp preservation
-emg = EMG.from_file('recording.xdf', include_timestamps=True)
+emg = Recording.from_file('recording.xdf', include_timestamps=True)
 
 # Each stream gets a timestamp channel named "{stream_name}_LSL_timestamps"
 print(list(emg.channels.keys()))

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,13 +52,13 @@ EMGIO simplifies this process by providing a standardized interface for loading,
 ## Quick Example
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Load data with automatic format detection, will issue an error to indicate use of the `trigno` importer
-emg = EMG.from_file('data.csv')  # Format detected from file extension
+emg = Recording.from_file('data.csv')  # Format detected from file extension
 
 # Load data with explicit importer
-emg = EMG.from_file('data.csv', importer='trigno')
+emg = Recording.from_file('data.csv', importer='trigno')
 
 # Plot specific channels
 emg.plot_signals(['EMG1', 'EMG2'])

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -4,25 +4,25 @@ EMGIO provides a unified interface for working with EMG data from various system
 
 ## Loading Data
 
-The main entry point for loading data is the `EMG.from_file()` method. This method automatically determines the correct importer based on the file extension, or you can specify the importer explicitly:
+The main entry point for loading data is the `Recording.from_file()` method. This method automatically determines the correct importer based on the file extension, or you can specify the importer explicitly:
 
 ```python
-from emgio import EMG
+from emgio import Recording
 
 # Automatic importer selection based on file extension
-emg = EMG.from_file('data.csv')  # Will use CSV importer for CSV files
-emg = EMG.from_file('data.edf')  # Will use EDF importer for EDF files
-emg = EMG.from_file('data.set')  # Will use EEGLAB importer for SET files
-emg = EMG.from_file('data.otb')  # Will use OTB importer for OTB files
-emg = EMG.from_file('data.hea')  # Will use WFDB importer for WFDB files
+emg = Recording.from_file('data.csv')  # Will use CSV importer for CSV files
+emg = Recording.from_file('data.edf')  # Will use EDF importer for EDF files
+emg = Recording.from_file('data.set')  # Will use EEGLAB importer for SET files
+emg = Recording.from_file('data.otb')  # Will use OTB importer for OTB files
+emg = Recording.from_file('data.hea')  # Will use WFDB importer for WFDB files
 
 # Explicit importer selection
-emg = EMG.from_file('data.csv', importer='trigno')
-emg = EMG.from_file('data.set', importer='eeglab')
-emg = EMG.from_file('data.otb+', importer='otb')
-emg = EMG.from_file('data.edf', importer='edf')
-emg = EMG.from_file('data.csv', importer='csv')  # Generic CSV importer
-emg = EMG.from_file('data.hea', importer='wfdb')  # WFDB importer
+emg = Recording.from_file('data.csv', importer='trigno')
+emg = Recording.from_file('data.set', importer='eeglab')
+emg = Recording.from_file('data.otb+', importer='otb')
+emg = Recording.from_file('data.edf', importer='edf')
+emg = Recording.from_file('data.csv', importer='csv')  # Generic CSV importer
+emg = Recording.from_file('data.hea', importer='wfdb')  # WFDB importer
 ```
 
 ### Automatic File Type Inference
@@ -45,7 +45,7 @@ For CSV files with specialized formats like Trigno, the generic CSV importer wil
 
 ```python
 # Force using the generic CSV importer even for specialized formats
-emg = EMG.from_file('trigno_data.csv', importer='csv', force_csv=True)
+emg = Recording.from_file('trigno_data.csv', importer='csv', force_csv=True)
 ```
 
 See the [Generic CSV Format](../formats/csv.md) documentation for more details on CSV import options.
@@ -107,7 +107,7 @@ import matplotlib.pyplot as plt
 
 # Export to EDF and reload
 emg_original.to_edf('output')
-emg_reloaded = EMG.from_file('output.edf')
+emg_reloaded = Recording.from_file('output.edf')
 
 # Compare signals
 results = compare_signals(emg_original, emg_reloaded)

--- a/docs/user-guide/channel-selection.md
+++ b/docs/user-guide/channel-selection.md
@@ -20,13 +20,13 @@ for ch_name, ch_info in emg.channels.items():
 
 ## Selecting Channels by Name
 
-You can create a new EMG object with only the channels you specify:
+You can create a new Recording object with only the channels you specify:
 
 ```python
 # Select specific channels by name
 subset_emg = emg.select_channels(['EMG1', 'EMG2', 'ACC1'])
 
-# The original EMG object remains unchanged
+# The original Recording object remains unchanged
 print(f"Original channels: {len(emg.channels)}")
 print(f"Selected channels: {len(subset_emg.channels)}")
 ```
@@ -66,7 +66,7 @@ subset_emg = emg.select_channels(selected_channels)
 
 ## Working with Selected Channels
 
-After selecting channels, you can work with the new EMG object just like the original:
+After selecting channels, you can work with the new Recording object just like the original:
 
 ```python
 # Plot the selected channels
@@ -87,7 +87,7 @@ emg_channels = emg.get_channels_by_type('EMG')
 # Filter to only include those from a specific muscle group
 bicep_channels = [ch for ch in emg_channels if 'Bicep' in ch]
 
-# Create a new EMG object with just these channels
+# Create a new Recording object with just these channels
 bicep_emg = emg.select_channels(bicep_channels)
 ```
 

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -2,7 +2,7 @@
 
 EMGIO provides comprehensive metadata management capabilities, allowing you to work with recording session information, subject details, and other contextual data. Proper metadata handling is particularly important when working with research data that needs to be shared or archived.
 
-The `EMG` object stores various pieces of metadata loaded from the source file or added manually.
+The `Recording` object stores various pieces of metadata loaded from the source file or added manually.
 
 ## Accessing Metadata
 
@@ -10,7 +10,7 @@ When you load data into EMGIO, any available metadata from the source file is au
 
 ```python
 # Load data
-emg = EMG.from_file('data.set', importer='eeglab')
+emg = Recording.from_file('data.set', importer='eeglab')
 
 # Access all metadata
 all_metadata = emg.metadata
@@ -162,9 +162,9 @@ EMG2    EMG     µV      2000                  ...
 ACC1    ACC     g       2000                  ...
 ```
 
-## Copying Metadata Between EMG Objects
+## Copying Metadata Between Recording Objects
 
-When working with multiple EMG objects, you can copy metadata between them:
+When working with multiple Recording objects, you can copy metadata between them:
 
 ```python
 # Create a subset with only EMG channels

--- a/docs/user-guide/verification.md
+++ b/docs/user-guide/verification.md
@@ -9,18 +9,18 @@ EMGIO provides tools to verify signal integrity when transferring data between f
 
 ## Verification Workflow
 
-The standard way to verify signal integrity involves comparing an original EMG object with one that has been exported and then reloaded. This is done using the `compare_signals` and `report_verification_results` functions from the `emgio.analysis.verification` module.
+The standard way to verify signal integrity involves comparing an original Recording object with one that has been exported and then reloaded. This is done using the `compare_signals` and `report_verification_results` functions from the `emgio.analysis.verification` module.
 
 ```python
-from emgio import EMG
+from emgio import Recording
 from emgio.analysis.verification import compare_signals, report_verification_results
 
 # Load original data
-emg_original = EMG.from_file('raw_data.csv', importer='trigno')
+emg_original = Recording.from_file('raw_data.csv', importer='trigno')
 
 # Export to EDF and reload
 emg_original.to_edf('exported_data')
-emg_reloaded = EMG.from_file('exported_data.edf')
+emg_reloaded = Recording.from_file('exported_data.edf')
 
 # Compare signals with detailed metrics
 results = compare_signals(emg_original, emg_reloaded, tolerance=0.01)

--- a/emgio/__init__.py
+++ b/emgio/__init__.py
@@ -1,19 +1,34 @@
 """emgio (evolving into biosigIO): import/export biosignal recordings across formats.
 
 The core class is :class:`Recording` (modality-agnostic: EEG/EMG/iEEG/MEG/...).
-``EMG`` is a deprecated alias of ``Recording`` kept for backward compatibility.
+``EMG`` is a deprecated alias of ``Recording`` that still works but emits a
+``DeprecationWarning``; it will be removed in biosigio 1.0.0.
 """
 
-from .core.emg import EMG, Recording
+from .core.emg import Recording
 from .exporters.edf import EDFExporter
 from .importers.trigno import TrignoImporter
 from .version import __version__, __version_info__
 
 __all__ = [
     "Recording",
-    "EMG",
     "TrignoImporter",
     "EDFExporter",
     "__version__",
     "__version_info__",
 ]
+
+
+def __getattr__(name: str):
+    """Resolve the deprecated ``EMG`` alias to ``Recording`` with a warning (PEP 562)."""
+    if name == "EMG":
+        import warnings
+
+        warnings.warn(
+            "emgio.EMG is a deprecated alias of emgio.Recording and will be removed "
+            "in biosigio 1.0.0; use emgio.Recording instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Recording
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/emgio/analysis/verification.py
+++ b/emgio/analysis/verification.py
@@ -9,23 +9,23 @@ import numpy as np
 
 # Use TYPE_CHECKING to avoid circular import at runtime
 if TYPE_CHECKING:
-    from ..core.emg import EMG
+    from ..core.emg import Recording
 
 
 def compare_signals(
-    emg_original: "EMG",
-    emg_reloaded: "EMG",
+    emg_original: "Recording",
+    emg_reloaded: "Recording",
     tolerance: float = 0.01,  # Default tolerance 1% for NRMSE and Max Norm Abs Diff
     channel_map: dict[str, str] | None = None,
 ) -> dict:
     """
-    Compare signals between two EMG objects using normalized metrics.
+    Compare signals between two Recording objects using normalized metrics.
     Returns a dictionary with comparison results per channel and a summary.
     Does NOT perform logging/printing.
 
     Args:
-        emg_original: The original EMG object before export.
-        emg_reloaded: The EMG object reloaded from the exported file.
+        emg_original: The original Recording object before export.
+        emg_reloaded: The Recording object reloaded from the exported file.
         tolerance: Relative tolerance for comparisons (default: 0.001 or 0.1%).
                    Used for NRMSE, Max Norm Abs Diff, and identity check.
         channel_map: Optional dictionary mapping original channel names (keys)
@@ -37,11 +37,11 @@ def compare_signals(
               Metrics include 'nrmse' (Normalized RMSE), 'max_norm_abs_diff'.
               Also includes 'channel_summary' with comparison mode and unmatched channels.
     """
-    # Removed local import: from emgio.core.emg import EMG
+    # Removed local import: from emgio.core.emg import Recording
 
     results = {}
     if emg_original.signals is None or emg_reloaded.signals is None:
-        raise ValueError("No signals loaded in one or both EMG objects to compare")
+        raise ValueError("No signals loaded in one or both Recording objects to compare")
     original_channels = set(emg_original.signals.columns)
     reloaded_channels = set(emg_reloaded.signals.columns)
 

--- a/emgio/bids.py
+++ b/emgio/bids.py
@@ -3,7 +3,7 @@
 When a data file follows the BIDS layout, the authoritative per-channel
 metadata lives in a sibling ``*_channels.tsv`` (the ``type`` and ``units``
 columns), not in the data file's own headers. These helpers locate that sidecar
-and apply it to an :class:`~emgio.core.emg.EMG` object so imported channels get
+and apply it to an :class:`~emgio.core.emg.Recording` object so imported channels get
 their real BIDS types (e.g. ``SEEG``) instead of header/label guesses.
 """
 
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 if TYPE_CHECKING:
-    from .core.emg import EMG
+    from .core.emg import Recording
 
 
 def _find_sidecar(data_filepath: str, kind: str) -> str | None:
@@ -58,7 +58,7 @@ def find_events_tsv(data_filepath: str) -> str | None:
     return _find_sidecar(data_filepath, "events")
 
 
-def apply_channels_tsv(emg: EMG, channels_tsv_path: str) -> int:
+def apply_channels_tsv(emg: Recording, channels_tsv_path: str) -> int:
     """Override per-channel ``type``/``units`` in ``emg`` from a ``_channels.tsv``.
 
     Rows are matched to channels by the ``name`` column; ``n/a`` and empty
@@ -66,7 +66,7 @@ def apply_channels_tsv(emg: EMG, channels_tsv_path: str) -> int:
     ``type`` is warned about and skipped rather than raising.
 
     Args:
-        emg: The EMG object to update in place.
+        emg: The Recording object to update in place.
         channels_tsv_path: Path to the BIDS ``_channels.tsv``.
 
     Returns:

--- a/emgio/cli.py
+++ b/emgio/cli.py
@@ -28,7 +28,7 @@ from collections.abc import Sequence
 from . import __version__
 from .analysis.verification import compare_signals
 from .bids import find_events_tsv
-from .core.emg import EMG
+from .core.emg import Recording
 from .core.modality import VALID_MODALITIES, infer_modality_from_channel_type
 
 logger = logging.getLogger("emgio.cli")
@@ -61,7 +61,7 @@ def _quiet_stdout():
         yield
 
 
-def _load_emg(path: str) -> EMG:
+def _load_emg(path: str) -> Recording:
     """Load a recording, mapping failures onto the exit-code contract."""
     if not os.path.exists(path):
         raise CliError(EXIT_INPUT, f"input not found: {path}")
@@ -69,7 +69,7 @@ def _load_emg(path: str) -> EMG:
         raise CliError(EXIT_INPUT, f"input is not a file: {path}")
     try:
         with _quiet_stdout():
-            return EMG.from_file(path)
+            return Recording.from_file(path)
     except ValueError as e:
         if "unsupported" in str(e).lower():
             raise CliError(EXIT_USAGE, str(e)) from e
@@ -84,11 +84,11 @@ def _is_unknown(info: dict) -> bool:
     return info.get("channel_type", "OTHER") in _UNKNOWN_CHANNEL_TYPES
 
 
-def _unknown_channels(emg: EMG) -> list[str]:
+def _unknown_channels(emg: Recording) -> list[str]:
     return [name for name, info in emg.channels.items() if _is_unknown(info)]
 
 
-def _apply_modality(emg: EMG, modality: str) -> None:
+def _apply_modality(emg: Recording, modality: str) -> None:
     """Fill the modality of UNKNOWN channels only; never override detected ones.
 
     Source-detected modalities win; omitting --modality (this is not called)
@@ -169,7 +169,7 @@ def cmd_convert(args: argparse.Namespace) -> int:
     if args.verify:
         try:
             with _quiet_stdout():
-                reloaded = EMG.from_file(written)
+                reloaded = Recording.from_file(written)
             results = compare_signals(emg, reloaded, tolerance=args.verify_tolerance)
         except Exception as e:
             raise CliError(EXIT_RUNTIME, f"verify reload failed: {e}") from e
@@ -277,7 +277,7 @@ def cmd_info(args: argparse.Namespace) -> int:
 def cmd_lowres(args: argparse.Namespace) -> int:
     """Down-sample a recording and export a lightweight low-res EDF/BDF.
 
-    Thin wrapper: the anti-aliased resampling lives in ``EMG.resample`` and the
+    Thin wrapper: the anti-aliased resampling lives in ``Recording.resample`` and the
     scaling/format bracketing in the EDF exporter. ``--bits 16`` -> EDF (16-bit),
     ``--bits 24`` -> BDF (24-bit). Default is "double low-res": 16-bit + 100 Hz.
     """
@@ -289,7 +289,7 @@ def cmd_lowres(args: argparse.Namespace) -> int:
     source_rate = max(rates) if rates else 0.0
 
     # Skip the resample step when the source is already at or below the target
-    # rate; up-sampling is out of scope (and EMG.resample would refuse it).
+    # rate; up-sampling is out of scope (and Recording.resample would refuse it).
     if source_rate <= args.rate:
         print(
             f"note: source rate {source_rate} Hz already <= target {args.rate} Hz; "

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -46,7 +46,8 @@ class Recording:
 
     Modality-agnostic container for EEG / EMG / iEEG / MEG / stim / marker data
     imported from any supported format. (``EMG`` is a deprecated alias of this
-    class kept for backward compatibility; prefer ``Recording``.)
+    class that still resolves to ``Recording`` but emits a ``DeprecationWarning``
+    and will be removed in biosigio 1.0.0; prefer ``Recording``.)
 
     Attributes:
         signals (pd.DataFrame): Raw signal data with time as index.
@@ -77,7 +78,7 @@ class Recording:
         plt_module=None,
     ):
         """
-        Plot EMG signals in a single plot with vertical offsets.
+        Plot signals in a single plot with vertical offsets.
 
         Args:
             channels: List of channels to plot. If None, plot all channels.
@@ -160,7 +161,7 @@ class Recording:
         **kwargs,
     ) -> "Recording":
         """
-        The method to create EMG object from file.
+        The method to create a Recording object from file.
 
         Args:
             filepath: Path to the input file
@@ -194,7 +195,7 @@ class Recording:
                 - stream_ids: List of stream IDs to import
 
         Returns:
-            EMG: New EMG object with loaded data
+            Recording: New Recording object with loaded data
         """
         if importer is None:
             importer = cls._infer_importer(filepath)
@@ -267,7 +268,7 @@ class Recording:
         modality: str | None = None,
     ) -> "Recording":
         """
-        Select specific channels from the data and return a new EMG object.
+        Select specific channels from the data and return a new Recording object.
 
         Args:
             channels: Channel name or list of channel names to select. If None and
@@ -277,7 +278,7 @@ class Recording:
                         channels of this type.
 
         Returns:
-            EMG: A new EMG object containing only the selected channels
+            Recording: A new Recording object containing only the selected channels
 
         Examples:
             # Select specific channels
@@ -330,7 +331,7 @@ class Recording:
             if not channels:
                 raise ValueError(f"None of the selected channels are of modality: {modality}")
 
-        # Create new EMG object
+        # Create new Recording object
         new_emg = Recording()
 
         # Copy selected signals and channels
@@ -358,7 +359,7 @@ class Recording:
         energy above the new Nyquist back into the band (aliasing); resample_poly
         removes that energy first, so no aliasing occurs.
 
-        Non-destructive: ``self`` is left untouched and a new EMG is returned,
+        Non-destructive: ``self`` is left untouched and a new Recording is returned,
         mirroring ``select_channels``'s copy semantics.
 
         Resampling factors come from the integer source/target rates:
@@ -374,7 +375,7 @@ class Recording:
                 detail and is out of scope for the low-res pipeline).
 
         Returns:
-            EMG: A new EMG with the resampled signals, each channel's
+            Recording: A new Recording with the resampled signals, each channel's
                 ``sample_frequency`` set to the achieved rate (source * up / down,
                 which equals ``target_rate`` for integer rates), and channel/recording
                 metadata and events preserved. Events are unchanged because their
@@ -530,7 +531,7 @@ class Recording:
         **kwargs,
     ) -> dict | None:
         """
-        Export EMG data to EDF/BDF format, optionally including events.
+        Export the recording to EDF/BDF format, optionally including events.
 
         Args:
             filepath: Path to save the EDF/BDF file
@@ -766,7 +767,7 @@ class Recording:
         prefilter: str = "n/a",
     ) -> None:
         """
-        Add a new channel to the EMG data.
+        Add a new channel to the recording.
 
         Args:
             label: Channel label or name (as per EDF specification)
@@ -842,7 +843,7 @@ class Recording:
 
     def add_event(self, onset: float, duration: float, description: str) -> None:
         """
-        Add an event/annotation to the EMG object.
+        Add an event/annotation to the recording.
 
         Args:
             onset: Event onset time in seconds.
@@ -863,7 +864,19 @@ class Recording:
         self.events = self.events.sort_values(by="onset").reset_index(drop=True)
 
 
-# Deprecated alias: the class was named ``EMG`` before it became modality-agnostic
-# (it now holds EEG/iEEG/MEG/EMG/...). Kept for backward compatibility; new code
-# should use ``Recording``. (Package rename emgio -> biosigio is tracked separately.)
-EMG = Recording
+# Deprecated alias. The class was named ``EMG`` before it became modality-agnostic
+# (it now holds EEG/iEEG/MEG/EMG/...). ``EMG`` still resolves to ``Recording`` via
+# this module ``__getattr__`` but emits a ``DeprecationWarning``; it will be removed
+# in biosigio 1.0.0. New code should use ``Recording``.
+def __getattr__(name: str):
+    if name == "EMG":
+        import warnings
+
+        warnings.warn(
+            "emgio.core.emg.EMG is a deprecated alias of Recording and will be "
+            "removed in biosigio 1.0.0; use Recording instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Recording
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/emgio/exporters/edf.py
+++ b/emgio/exporters/edf.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pyedflib
 
 from ..analysis.signal import analyze_signal, determine_format_suitability
-from ..core.emg import EMG
+from ..core.emg import Recording
 from ..core.modality import to_bids_channels_tsv_type
 
 # EDF and BDF share the same 256-byte-per-signal header layout: physical_min and
@@ -274,7 +274,7 @@ class EDFExporter:
 
     @staticmethod
     def export(
-        emg: EMG,
+        emg: Recording,
         filepath: str,
         precision_threshold: float = 0.01,
         method: str = "both",
@@ -293,7 +293,7 @@ class EDFExporter:
         Export EMG data to EDF/BDF format with optional BIDS-compliant channels.tsv file.
 
         Args:
-            emg: EMG object containing the data
+            emg: Recording object containing the data
             filepath: Path to save the EDF/BDF file
             precision_threshold: Maximum acceptable precision loss percentage (default: 0.01%)
             method: Method for signal analysis ('svd', 'fft', or 'both')
@@ -350,14 +350,14 @@ class EDFExporter:
             if not bypass_analysis:
                 print("\nUser specified BDF format (24-bit).")
             else:
-                # Log critical only if bypassing, already logged in EMG.to_edf
+                # Log critical only if bypassing, already logged in Recording.to_edf
                 pass  # logging.log(logging.CRITICAL, "Skipping analysis, using specified BDF format.")
         elif format.lower() == "edf":
             use_bdf = False
             if not bypass_analysis:
                 print("\nUser specified EDF format (16-bit).")
             else:
-                # Log critical only if bypassing, already logged in EMG.to_edf
+                # Log critical only if bypassing, already logged in Recording.to_edf
                 pass  # logging.log(logging.CRITICAL, "Skipping analysis, using specified EDF format.")
         elif format.lower() != "auto":
             warnings.warn(
@@ -423,7 +423,7 @@ class EDFExporter:
                     print(
                         "\nUsing EDF format (16-bit) based on signal analysis (precision within acceptable range)."
                     )
-        # else: # bypass_analysis is True - logging handled in EMG.to_edf
+        # else: # bypass_analysis is True - logging handled in Recording.to_edf
         #     pass # logging.log(logging.CRITICAL, "Signal analysis bypassed.")
 
         # Set file format and create writer

--- a/emgio/importers/_mne_common.py
+++ b/emgio/importers/_mne_common.py
@@ -2,7 +2,7 @@
 
 MNE is an optional, heavy dependency, so it is imported lazily via
 :func:`require_mne` (with a clear install hint) rather than at module import.
-Both importers turn an MNE ``Raw`` into an :class:`~emgio.core.emg.EMG` with the
+Both importers turn an MNE ``Raw`` into a :class:`~emgio.core.emg.Recording` with the
 same channel-type/unit mapping (:func:`raw_to_emg`); they differ only in how the
 ``Raw`` is read and how events are extracted.
 """
@@ -11,7 +11,7 @@ import warnings
 
 import pandas as pd
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 
 # MNE channel type (raw.get_channel_types()) -> emgio/BIDS channel type. Each MNE
 # type maps to its own emgio type so distinct sensor streams are preserved, not
@@ -57,8 +57,8 @@ def require_mne():
     return mne
 
 
-def raw_to_emg(raw) -> EMG:
-    """Build an EMG from an MNE ``Raw``: channels with mapped types and FIFF units.
+def raw_to_emg(raw) -> Recording:
+    """Build a Recording from an MNE ``Raw``: channels with mapped types and FIFF units.
 
     Does not read events (the two importers extract them differently) and does not
     set ``source_file`` (the caller has the path). High-channel-count recordings
@@ -66,7 +66,7 @@ def raw_to_emg(raw) -> EMG:
     expected pandas warning is suppressed and the frame de-fragmented once after
     (root-cause perf drift tracked in #66).
     """
-    emg = EMG()
+    emg = Recording()
     sfreq = float(raw.info["sfreq"])
     data = raw.get_data()  # (n_channels, n_samples) in SI units
     mne_types = raw.get_channel_types()

--- a/emgio/importers/base.py
+++ b/emgio/importers/base.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 
 
 class BaseImporter(ABC):
     """Base class for EMG data importers."""
 
     @abstractmethod
-    def load(self, filepath: str) -> EMG:
+    def load(self, filepath: str) -> Recording:
         """
         Load EMG data from file.
 
@@ -15,6 +15,6 @@ class BaseImporter(ABC):
             filepath: Path to the input file
 
         Returns:
-            EMG: EMG object containing the loaded data
+            Recording: Recording object containing the loaded data
         """
         pass

--- a/emgio/importers/brainvision.py
+++ b/emgio/importers/brainvision.py
@@ -4,12 +4,12 @@ Many OpenNeuro BIDS EEG/iEEG datasets ship the BrainVision triplet rather than
 EDF or EEGLAB .set. MNE reads it natively (only writing needs pybv), and is an
 optional dependency imported lazily with a clear install hint. Channel types and
 units come from the shared :mod:`_mne_common` mapping; ``.vmrk`` markers (which
-MNE exposes as annotations) are read into ``EMG.events``.
+MNE exposes as annotations) are read into ``Recording.events``.
 """
 
 import pandas as pd
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from ._mne_common import raw_to_emg, require_mne
 from .base import BaseImporter
 
@@ -36,7 +36,7 @@ class BrainVisionImporter(BaseImporter):
             evt["duration"] = evt["duration"].astype("float64")
         return evt
 
-    def load(self, filepath: str) -> EMG:
+    def load(self, filepath: str) -> Recording:
         """Load a BrainVision recording (pass the ``.vhdr`` header path).
 
         Args:
@@ -44,8 +44,8 @@ class BrainVisionImporter(BaseImporter):
                 ``.eeg`` siblings are resolved by MNE).
 
         Returns:
-            EMG: channels carry their type and physical unit; ``.vmrk`` markers
-            are read into ``EMG.events``.
+            Recording: channels carry their type and physical unit; ``.vmrk`` markers
+            are read into ``Recording.events``.
         """
         mne = require_mne()
         try:

--- a/emgio/importers/csv.py
+++ b/emgio/importers/csv.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from .base import BaseImporter
 
 
@@ -45,7 +45,7 @@ class CSVImporter(BaseImporter):
 
         return None
 
-    def load(self, filepath: str, force_generic: bool = False, **kwargs) -> EMG:
+    def load(self, filepath: str, force_generic: bool = False, **kwargs) -> Recording:
         """
         Load EMG data from a CSV file.
 
@@ -65,7 +65,7 @@ class CSVImporter(BaseImporter):
                 - metadata: Dict of additional metadata to include
 
         Returns:
-            EMG: EMG object containing the loaded data
+            Recording: Recording object containing the loaded data
 
         Raises:
             ValueError: If a specialized format is detected and force_generic is False
@@ -79,10 +79,10 @@ class CSVImporter(BaseImporter):
                     "trigno": (
                         "This file appears to be a Delsys Trigno CSV export. "
                         "For better metadata extraction and channel detection, use:\n\n"
-                        "emg = EMG.from_file(filepath, importer='trigno')\n\n"
+                        "recording = Recording.from_file(filepath, importer='trigno')\n\n"
                         "If you still want to use the generic CSV importer, set force_generic=True:\n"
                         "importer = CSVImporter()\n"
-                        "emg = importer.load(filepath, force_generic=True, **params)"
+                        "recording = importer.load(filepath, force_generic=True, **params)"
                     )
                     # Add more format-specific messages here as new importers are developed
                 }
@@ -203,8 +203,8 @@ class CSVImporter(BaseImporter):
                     "Please specify sample_frequency for proper time indexing."
                 )
 
-        # Create EMG object
-        emg = EMG()
+        # Create recording object
+        emg = Recording()
 
         # Add metadata
         emg.set_metadata("source_file", filepath)
@@ -245,7 +245,7 @@ class CSVImporter(BaseImporter):
                 # Default based on channel type
                 phys_dim = self._default_physical_dimension(ch_type)
 
-            # Add the channel to the EMG object
+            # Add the channel to the recording
             emg.add_channel(
                 label=column,
                 data=df[column].values,
@@ -424,12 +424,12 @@ class CSVImporter(BaseImporter):
         dimensions = {"EMG": "µV", "ACC": "g", "GYRO": "deg/s", "TIME": "s", "OTHER": "a.u."}
         return dimensions.get(channel_type, "a.u.")
 
-    def _print_metadata_reminder(self, emg: EMG) -> None:
+    def _print_metadata_reminder(self, emg: Recording) -> None:
         """
         Print a reminder to add metadata if essential information is missing.
 
         Args:
-            emg: EMG object to check
+            emg: Recording object to check
         """
         essential_metadata = ["subject", "device", "recording_date"]
         missing = [meta for meta in essential_metadata if meta not in emg.metadata]

--- a/emgio/importers/edf.py
+++ b/emgio/importers/edf.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pyedflib
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from .base import BaseImporter
 
 
@@ -123,7 +123,7 @@ class EDFImporter(BaseImporter):
 
         Returns:
             pd.DataFrame: events with float64 ``onset``/``duration`` and string
-            ``description``, sorted by onset (matching :meth:`EMG.add_event`).
+            ``description``, sorted by onset (matching :meth:`Recording.add_event`).
         """
         onsets, durations, descriptions = edf_reader.readAnnotations()
         rows = []
@@ -144,7 +144,7 @@ class EDFImporter(BaseImporter):
             events["duration"] = events["duration"].astype("float64")
         return events
 
-    def load(self, filepath: str) -> EMG:
+    def load(self, filepath: str) -> Recording:
         """
         Load EMG data from EDF/EDF+/BDF file.
 
@@ -152,13 +152,13 @@ class EDFImporter(BaseImporter):
             filepath: Path to the EDF file
 
         Returns:
-            EMG: EMG object containing the loaded data
+            Recording: Recording object containing the loaded data
         """
         try:
             edf_reader = pyedflib.EdfReader(filepath)
 
-            # Create EMG object
-            emg = EMG()
+            # Create Recording object
+            emg = Recording()
 
             # Extract and store metadata
             metadata = self._extract_metadata(edf_reader)
@@ -180,7 +180,7 @@ class EDFImporter(BaseImporter):
                     signal_info["label"], signal_info["transducer"]
                 )
 
-                # Add channel to EMG object
+                # Add channel to Recording object
                 emg.add_channel(
                     label=signal_info["label"],
                     data=signal_data,

--- a/emgio/importers/eeglab.py
+++ b/emgio/importers/eeglab.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from scipy.io import loadmat
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from ..core.modality import infer_modality_from_channel_type
 from .base import BaseImporter
 
@@ -221,7 +221,7 @@ class EEGLABImporter(BaseImporter):
 
         return event_list
 
-    def load(self, filepath: str) -> EMG:
+    def load(self, filepath: str) -> Recording:
         """
         Load EMG data from EEGLAB .set file.
 
@@ -229,14 +229,14 @@ class EEGLABImporter(BaseImporter):
             filepath: Path to the EEGLAB .set file
 
         Returns:
-            EMG: EMG object containing the loaded data
+            Recording: Recording object containing the loaded data
         """
         try:
             # Load the .set file
             data = loadmat(filepath)
 
-            # Create EMG object
-            emg = EMG()
+            # Create Recording object
+            emg = Recording()
 
             # Extract and store metadata
             metadata = self._extract_metadata(data)
@@ -277,7 +277,7 @@ class EEGLABImporter(BaseImporter):
                 # Create DataFrame with time index
                 df = pd.DataFrame(index=time_index)
 
-                # Add channels to EMG object
+                # Add channels to Recording object
                 for i, channel_info in enumerate(channel_info_list):
                     if i < signal_data.shape[0]:  # Make sure we have data for this channel
                         # Get channel data

--- a/emgio/importers/meg.py
+++ b/emgio/importers/meg.py
@@ -5,7 +5,7 @@ clear install hint rather than at module import. MEG recordings mix several
 sensor types in one file (magnetometers, gradiometers, reference sensors)
 alongside stim/EEG/EOG/ECG channels; the shared :mod:`_mne_common` mapping keeps
 each type distinct (they are NOT collapsed into a single "MEG" type), and
-stim-channel triggers are read into ``EMG.events``.
+stim-channel triggers are read into ``Recording.events``.
 """
 
 import os
@@ -13,7 +13,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from ._mne_common import raw_to_emg, require_mne
 from .base import BaseImporter
 
@@ -47,15 +47,15 @@ class MEGImporter(BaseImporter):
             evt["duration"] = evt["duration"].astype("float64")
         return evt
 
-    def load(self, filepath: str) -> EMG:
-        """Load a MEG recording into an EMG object.
+    def load(self, filepath: str) -> Recording:
+        """Load a MEG recording into a Recording object.
 
         Args:
             filepath: Path to a ``.fif`` file or a CTF ``.ds`` directory.
 
         Returns:
-            EMG: channels carry their MEG/EEG/stim type and physical unit; stim
-            triggers are read into ``EMG.events``.
+            Recording: channels carry their MEG/EEG/stim type and physical unit; stim
+            triggers are read into ``Recording.events``.
         """
         mne = require_mne()
         try:

--- a/emgio/importers/otb.py
+++ b/emgio/importers/otb.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree as ET
 
 import numpy as np
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from .base import BaseImporter
 
 
@@ -238,7 +238,7 @@ class OTBImporter(BaseImporter):
 
         return scaled_data, sampling_freq
 
-    def load(self, filepath: str) -> EMG:
+    def load(self, filepath: str) -> Recording:
         """
         Load EMG data from OTB/OTB+ file.
 
@@ -246,10 +246,10 @@ class OTBImporter(BaseImporter):
             filepath: Path to the OTB/OTB+ file
 
         Returns:
-            EMG: EMG object containing the loaded data
+            Recording: Recording object containing the loaded data
         """
-        # Create EMG object
-        emg = EMG()
+        # Create Recording object
+        emg = Recording()
         temp_dir = None
 
         try:
@@ -278,7 +278,7 @@ class OTBImporter(BaseImporter):
                 os.path.join(temp_dir, sig_files[0]), metadata
             )
 
-            # Add channels to EMG object
+            # Add channels to Recording object
             for ch_name, ch_info in metadata["channels"].items():
                 ch_idx = int(ch_name[2:]) - 1  # Extract channel number from 'CHx'
                 emg.add_channel(

--- a/emgio/importers/trigno.py
+++ b/emgio/importers/trigno.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from .base import BaseImporter
 
 
@@ -70,7 +70,7 @@ class TrignoImporter(BaseImporter):
 
         return channel_info
 
-    def load(self, filepath: str) -> EMG:
+    def load(self, filepath: str) -> Recording:
         """
         Load EMG data from Trigno CSV file.
 
@@ -78,10 +78,10 @@ class TrignoImporter(BaseImporter):
             filepath: Path to the Trigno CSV file
 
         Returns:
-            EMG: EMG object containing the loaded data
+            Recording: Recording object containing the loaded data
         """
-        # Create EMG object
-        emg = EMG()
+        # Create Recording object
+        emg = Recording()
 
         # Analyze file structure
         metadata_lines, data_start, header_line = self._analyze_csv_structure(filepath)
@@ -102,7 +102,7 @@ class TrignoImporter(BaseImporter):
         time_col = df.columns[0]  # First column is time
         df.set_index(time_col, inplace=True)
 
-        # Add channels to EMG object
+        # Add channels to Recording object
         for label in channel_labels:
             if label in channel_info:
                 info = channel_info[label]

--- a/emgio/importers/wfdb.py
+++ b/emgio/importers/wfdb.py
@@ -2,7 +2,7 @@ import os
 
 import wfdb
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 
 # import numpy as np # Keep commented out until needed
 # from typing import List, Dict # Keep commented out until needed
@@ -12,7 +12,7 @@ from .base import BaseImporter
 class WFDBImporter(BaseImporter):
     """Importer for WFDB format files."""
 
-    def load(self, filepath: str) -> EMG:
+    def load(self, filepath: str) -> Recording:
         """
         Load EMG data and annotations from WFDB files.
 
@@ -23,7 +23,7 @@ class WFDBImporter(BaseImporter):
             filepath: Path to the WFDB header file (.hea) or just the record name.
 
         Returns:
-            EMG: EMG object containing the loaded data and annotations.
+            Recording: Recording object containing the loaded data and annotations.
         """
         record_name = os.path.splitext(filepath)[0]
 
@@ -45,8 +45,8 @@ class WFDBImporter(BaseImporter):
             # physical=True ensures data is in physical units
             record = wfdb.rdrecord(record_name=record_name, sampfrom=0, sampto=None, physical=True)
 
-            # Create EMG object
-            emg = EMG()
+            # Create Recording object
+            emg = Recording()
 
             # Store metadata from header
             emg.set_metadata("source_file", filepath)
@@ -102,7 +102,7 @@ class WFDBImporter(BaseImporter):
                     record_name=record_name, extension="atr", sampfrom=0, sampto=None
                 )
 
-                # Add annotations to the EMG object
+                # Add annotations to the Recording object
                 # Assuming emg object has an `add_event` or `add_annotation` method
                 # The structure (onset, duration, description) is common
                 if hasattr(emg, "add_event") and callable(emg.add_event):

--- a/emgio/importers/xdf.py
+++ b/emgio/importers/xdf.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from ..core.modality import infer_modality_from_channel_type, validate_channel_type
 from .base import BaseImporter
 
@@ -445,7 +445,7 @@ class XDFImporter(BaseImporter):
         include_timestamps: bool = False,
         reference_stream: str | None = None,
         max_memory_gb: float | None = None,
-    ) -> EMG:
+    ) -> Recording:
         """
         Load EMG data from an XDF file.
 
@@ -486,7 +486,7 @@ class XDFImporter(BaseImporter):
                           limit. Use summarize_xdf() to estimate memory needs.
 
         Returns:
-            EMG: EMG object containing the loaded data
+            Recording: Recording object containing the loaded data
 
         Raises:
             ValueError: If no matching streams found or file cannot be read
@@ -536,8 +536,8 @@ class XDFImporter(BaseImporter):
                     "No matching streams found. Use summarize_xdf() to explore the file."
                 )
 
-        # Create EMG object
-        emg = EMG()
+        # Create Recording object
+        emg = Recording()
 
         # Store metadata
         emg.set_metadata("source_file", filepath)
@@ -700,7 +700,7 @@ class XDFImporter(BaseImporter):
 
     def _load_streams(
         self,
-        emg: EMG,
+        emg: Recording,
         streams: list[dict],
         default_channel_type: str,
         include_timestamps: bool = False,
@@ -895,7 +895,7 @@ class XDFImporter(BaseImporter):
 
     def _load_synchronized_streams(
         self,
-        emg: EMG,
+        emg: Recording,
         streams: list[dict],
         default_channel_type: str,
         include_timestamps: bool = False,

--- a/emgio/tests/test_bids_channels_tsv.py
+++ b/emgio/tests/test_bids_channels_tsv.py
@@ -10,7 +10,7 @@ import pathlib
 
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 from emgio.bids import find_channels_tsv
 
 _REPO = pathlib.Path(__file__).resolve().parents[2]
@@ -22,14 +22,14 @@ IEEG = (
 
 @pytest.mark.skipif(not IEEG.exists(), reason="iEEG BIDS fixture missing")
 def test_channels_tsv_assigns_seeg_types():
-    emg = EMG.from_file(str(IEEG))
+    emg = Recording.from_file(str(IEEG))
     assert {info["channel_type"] for info in emg.channels.values()} == {"SEEG"}
     assert {info["modality"] for info in emg.channels.values()} == {"IEEG"}
 
 
 @pytest.mark.skipif(not IEEG.exists(), reason="iEEG BIDS fixture missing")
 def test_bids_channels_off_falls_back_to_header_inference():
-    emg = EMG.from_file(str(IEEG), bids_channels="off")
+    emg = Recording.from_file(str(IEEG), bids_channels="off")
     # Without the sidecar the EDF header cannot supply SEEG; assert the sidecar
     # was not consulted rather than pinning the exact inferred type.
     assert "SEEG" not in {info["channel_type"] for info in emg.channels.values()}

--- a/emgio/tests/test_brainvision_importer.py
+++ b/emgio/tests/test_brainvision_importer.py
@@ -11,7 +11,7 @@ import pathlib
 import numpy as np
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 
 pytest.importorskip("mne", reason="BrainVision import requires the optional 'meg' extra (mne)")
 
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.skipif(not VHDR.exists(), reason="BrainVision fixture m
 
 @pytest.fixture(scope="module")
 def bv_emg():
-    return EMG.from_file(str(VHDR))
+    return Recording.from_file(str(VHDR))
 
 
 def test_brainvision_channels_and_units(bv_emg):
@@ -62,7 +62,7 @@ def test_brainvision_roundtrip_through_edf(bv_emg, tmp_path):
     out = tmp_path / "bv.edf"
     bv_emg.to_edf(str(out), format="bdf", bypass_analysis=True)
     written = out if out.exists() else out.with_suffix(".bdf")
-    reloaded = EMG.from_file(str(written), bids_channels="off")
+    reloaded = Recording.from_file(str(written), bids_channels="off")
     assert len(reloaded.channels) == len(bv_emg.channels)
     for ch in bv_emg.signals.columns:
         original = bv_emg.signals[ch].values.astype(float)

--- a/emgio/tests/test_cli.py
+++ b/emgio/tests/test_cli.py
@@ -14,7 +14,7 @@ import subprocess
 import numpy as np
 import pytest
 
-from emgio import EMG, __version__
+from emgio import Recording, __version__
 from emgio.cli import (
     EXIT_INPUT,
     EXIT_OK,
@@ -127,7 +127,7 @@ def test_is_unknown_uses_channel_type_not_modality():
 
 def test_apply_modality_fills_only_unknown_channels():
     """--modality fills OTHER-typed channels but leaves detected ones untouched."""
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("X", np.zeros(100), 100, "uV", "OTHER")
     emg.add_channel("ECG1", np.zeros(100), 100, "uV", "ECG")
     _apply_modality(emg, "EEG")

--- a/emgio/tests/test_core.py
+++ b/emgio/tests/test_core.py
@@ -7,19 +7,19 @@ import pandas as pd
 import pyedflib
 import pytest
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 
 
 @pytest.fixture
 def empty_emg():
-    """Create an empty EMG object."""
-    return EMG()
+    """Create an empty Recording object."""
+    return Recording()
 
 
 @pytest.fixture
 def sample_emg():
-    """Create an EMG object with sample data."""
-    emg = EMG()
+    """Create a Recording object with sample data."""
+    emg = Recording()
 
     # Add sample channels
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
@@ -33,14 +33,14 @@ def sample_emg():
 
 
 def test_emg_initialization(empty_emg):
-    """Test EMG object initialization."""
+    """Test Recording object initialization."""
     assert empty_emg.signals is None
     assert empty_emg.metadata == {}
     assert empty_emg.channels == {}
 
 
 def test_add_channel(empty_emg):
-    """Test adding a channel to EMG object."""
+    """Test adding a channel to Recording object."""
     data = np.array([1, 2, 3, 4, 5])
     empty_emg.add_channel("EMG1", data, 1000, "mV", "EMG")
 
@@ -178,7 +178,7 @@ def mock_importers(monkeypatch):
 
     class MockTrignoImporter(MockBaseImporter):
         def _load(self, filepath, **kwargs):
-            emg = EMG()
+            emg = Recording()
             emg.add_channel("TEST", np.array([1, 2, 3]), 1000, "mV", channel_type="EMG")
             emg.set_metadata("device", "Delsys Trigno")
             emg.set_metadata("source_file", filepath)
@@ -186,7 +186,7 @@ def mock_importers(monkeypatch):
 
     class MockOTBImporter(MockBaseImporter):
         def _load(self, filepath, **kwargs):
-            emg = EMG()
+            emg = Recording()
             emg.add_channel("OTB", np.array([4, 5, 6]), 2000, "mV", channel_type="EMG")
             emg.set_metadata("device", "OT Bioelettronica")
             emg.set_metadata("source_file", filepath)
@@ -206,11 +206,11 @@ def mock_importers(monkeypatch):
                     raise ValueError(
                         "This file appears to be a Delsys Trigno CSV export. "
                         "For better metadata extraction and channel detection, use:\n\n"
-                        "emg = EMG.from_file(filepath, importer='trigno')\n\n"
+                        "recording = Recording.from_file(filepath, importer='trigno')\n\n"
                         "If you still want to use the generic CSV importer, set force_generic=True"
                     )
 
-            emg = EMG()
+            emg = Recording()
             emg.add_channel("CSV_CH1", np.array([7, 8, 9]), 1000, "mV", channel_type="EMG")
             emg.set_metadata("file_format", "CSV")
             emg.set_metadata("source_file", filepath)
@@ -252,43 +252,43 @@ def test_from_file(mock_importers, tmp_path):
     trigno_named_file.write_text("")
 
     # Test Trigno importer
-    emg_trigno = EMG.from_file(str(trigno_file), importer="trigno")
+    emg_trigno = Recording.from_file(str(trigno_file), importer="trigno")
     assert "TEST" in emg_trigno.signals.columns
     assert emg_trigno.channels["TEST"]["sample_frequency"] == 1000
 
     # Test OTB importer (including auto-detection)
     for importer in ["otb", None]:
-        emg_otb = EMG.from_file(str(otb_file), importer=importer)
+        emg_otb = Recording.from_file(str(otb_file), importer=importer)
         assert "OTB" in emg_otb.signals.columns
         assert emg_otb.channels["OTB"]["sample_frequency"] == 2000
 
     # Test CSV importer
-    emg_csv = EMG.from_file(str(csv_file), importer="csv")
+    emg_csv = Recording.from_file(str(csv_file), importer="csv")
     assert "CSV_CH1" in emg_csv.signals.columns
     assert emg_csv.get_metadata("file_format") == "CSV"
 
     # Test CSV importer with auto-detection for .txt files
-    emg_txt = EMG.from_file(str(csv_file), importer=None)
+    emg_txt = Recording.from_file(str(csv_file), importer=None)
     assert "CSV_CH1" in emg_txt.signals.columns
     assert emg_txt.get_metadata("file_format") == "CSV"
 
     # Test format detection and force_csv
     # First, test that format detection raises an error for trigno file
     with pytest.raises(ValueError, match="Delsys Trigno CSV export"):
-        EMG.from_file(str(trigno_named_file), importer="csv")
+        Recording.from_file(str(trigno_named_file), importer="csv")
 
     # Now test with force_csv=True to bypass detection
-    emg_forced = EMG.from_file(str(trigno_named_file), importer="csv", force_csv=True)
+    emg_forced = Recording.from_file(str(trigno_named_file), importer="csv", force_csv=True)
     assert "CSV_CH1" in emg_forced.signals.columns
 
     # Test passing parameters to CSV importer
     custom_kwargs = {"channel_types": {"CSV_CH1": "ACC"}}
-    emg_with_params = EMG.from_file(str(csv_file), importer="csv", **custom_kwargs)
+    emg_with_params = Recording.from_file(str(csv_file), importer="csv", **custom_kwargs)
     assert "CSV_CH1" in emg_with_params.signals.columns
 
     # Test invalid importer
     with pytest.raises(ValueError, match="Unsupported importer"):
-        EMG.from_file(str(trigno_file), importer="invalid")
+        Recording.from_file(str(trigno_file), importer="invalid")
 
 
 class MockPlt:
@@ -434,7 +434,7 @@ def test_plot_signals_time_range(sample_emg, mock_plt):
 
 
 def test_emg_add_event(empty_emg):
-    """Test adding events to the EMG object."""
+    """Test adding events to the Recording object."""
     assert empty_emg.events.empty
 
     # Add first event
@@ -490,7 +490,7 @@ def test_to_edf_writes_real_file_and_channels_tsv(sample_emg, tmp_path):
     written = out if out.exists() else out.with_suffix(".bdf")
     assert written.exists()
     assert written.with_name(written.stem + "_channels.tsv").exists()
-    reloaded = EMG.from_file(str(written), bids_channels="off")
+    reloaded = Recording.from_file(str(written), bids_channels="off")
     assert set(reloaded.signals.columns) == {"EMG1", "ACC1"}
 
 
@@ -523,7 +523,7 @@ def test_to_edf_bypass_analysis_defaulting(sample_emg, tmp_path, capsys):
 
 def test_to_edf_external_events_are_written_and_object_untouched(sample_emg, tmp_path):
     """The external events_df (not self.events) is what reaches the file, and the
-    EMG object's own events are left intact.
+    Recording object's own events are left intact.
 
     Forwarding is verified by reading the EDF+ annotations back with pyedflib
     directly (emgio's own annotation read-back is pending #47).
@@ -543,7 +543,7 @@ def test_to_edf_external_events_are_written_and_object_untouched(sample_emg, tmp
 
 
 def test_to_edf_empty_raises(empty_emg, tmp_path):
-    """Exporting an EMG object with no signals raises ValueError."""
+    """Exporting a Recording object with no signals raises ValueError."""
     with pytest.raises(ValueError):
         empty_emg.to_edf(str(tmp_path / "test.edf"))
 

--- a/emgio/tests/test_edf_roundtrip.py
+++ b/emgio/tests/test_edf_roundtrip.py
@@ -10,7 +10,7 @@ import os
 
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 
 EXAMPLE_DIR = "examples"
 OTB_FIXTURE = os.path.join(EXAMPLE_DIR, "one_sessantaquattro_truncated.otb+")
@@ -20,7 +20,7 @@ OTB_FIXTURE = os.path.join(EXAMPLE_DIR, "one_sessantaquattro_truncated.otb+")
 @pytest.mark.parametrize("fmt", ["edf", "bdf"])
 def test_export_preserves_full_recording_length(tmp_path, fmt):
     """A multi-second recording must round-trip without losing samples."""
-    emg = EMG.from_file(OTB_FIXTURE, importer="otb")
+    emg = Recording.from_file(OTB_FIXTURE, importer="otb")
     first = emg.signals.columns[0]
     n_in = len(emg.signals[first])
     samples_per_record = emg.channels[first]["sample_frequency"]
@@ -30,7 +30,7 @@ def test_export_preserves_full_recording_length(tmp_path, fmt):
     out = tmp_path / f"roundtrip.{fmt}"
     emg.to_edf(str(out), format=fmt, bypass_analysis=True)
 
-    reloaded = EMG.from_file(str(out))
+    reloaded = Recording.from_file(str(out))
     n_out = len(reloaded.signals[reloaded.signals.columns[0]])
     # The true invariant is "no truncation". EDF stores whole data records, so a
     # recording that is not an integer number of seconds is zero-padded by at most
@@ -46,7 +46,9 @@ def test_export_preserves_full_recording_length(tmp_path, fmt):
 )
 def test_export_rejects_mixed_sample_rates(tmp_path):
     """Mixed per-channel sample rates must fail loudly, not write a corrupt file."""
-    emg = EMG.from_file(os.path.join(EXAMPLE_DIR, "truncated_trigno_sample.csv"), importer="trigno")
+    emg = Recording.from_file(
+        os.path.join(EXAMPLE_DIR, "truncated_trigno_sample.csv"), importer="trigno"
+    )
     rates = {int(emg.channels[c]["sample_frequency"]) for c in emg.channels}
     assert len(rates) > 1, "fixture must have mixed rates to exercise the guard"
     with pytest.raises(ValueError, match="single sampling rate"):

--- a/emgio/tests/test_edf_scaling.py
+++ b/emgio/tests/test_edf_scaling.py
@@ -14,7 +14,7 @@ import numpy as np
 import pyedflib
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 from emgio.exporters.edf import (
     _PHYS_FIELD_CHARS,
     _determine_scaling_factors,
@@ -198,7 +198,7 @@ def _export_reload(emg, tmp_path, **kw):
     out = tmp_path / "case.edf"
     emg.to_edf(str(out), **kw)
     written = out if out.exists() else out.with_suffix(".bdf")
-    return EMG.from_file(str(written), bids_channels="off"), written
+    return Recording.from_file(str(written), bids_channels="off"), written
 
 
 @pytest.mark.parametrize(
@@ -207,7 +207,7 @@ def _export_reload(emg, tmp_path, **kw):
 )
 def test_export_never_clips_within_header_window(tmp_path, amp, off, fmt):
     """Every reloaded sample lies inside the stored physical window (no overflow)."""
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("S", _sine(amp=amp, off=off), 1000, "uV", "EMG")
     reloaded, written = _export_reload(emg, tmp_path, format=fmt, bypass_analysis=True)
     with pyedflib.EdfReader(str(written)) as r:
@@ -220,7 +220,7 @@ def test_export_never_clips_within_header_window(tmp_path, amp, off, fmt):
 
 @pytest.mark.parametrize("constant", [0.0, 1.0, -3.5])
 def test_export_constant_and_zero_channels(tmp_path, constant):
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("C", np.full(2000, constant), 1000, "uV", "EMG")
     reloaded, _ = _export_reload(emg, tmp_path, format="bdf", bypass_analysis=True)
     assert np.allclose(reloaded.signals["C"].values, constant, atol=1e-3)
@@ -235,7 +235,7 @@ def test_singularity_protection_recovers_bulk(tmp_path):
     range and the bulk loses resolution. Auto must do at least as well, and meet
     the >0.99 bar that clipping is meant to protect.
     """
-    emg = EMG.from_file(str(EMG_FIXTURE))
+    emg = Recording.from_file(str(EMG_FIXTURE))
     ch = list(emg.channels)[0]
     base = emg.signals[ch].values.astype(float).copy()
     spike_idx = len(base) // 2
@@ -278,7 +278,7 @@ def test_export_rejects_unrepresentable_magnitude(tmp_path, fmt):
     that re-creates the #61 corruption), so the exporter must reject it loudly
     before writing, for BOTH formats (the physical field is 8 chars in each).
     """
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("BIG", _sine(amp=2e7), 1000, "uV", "EMG")
     with pytest.raises(ValueError, match="cannot be stored in the EDF/BDF header"):
         emg.to_edf(str(tmp_path / "big.edf"), format=fmt, bypass_analysis=True, clip_outliers=False)
@@ -286,7 +286,7 @@ def test_export_rejects_unrepresentable_magnitude(tmp_path, fmt):
 
 def test_export_rejects_huge_positive_offset(tmp_path):
     """A large positive DC offset (~1.2e8) also overflows the 8-char field."""
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("OFF", _sine(amp=1000.0) + 1.2e8, 1000, "uV", "EMG")
     with pytest.raises(ValueError, match="cannot be stored"):
         emg.to_edf(

--- a/emgio/tests/test_eeglab_bids_fixture.py
+++ b/emgio/tests/test_eeglab_bids_fixture.py
@@ -13,7 +13,7 @@ import pathlib
 
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 
 # Anchor to the repo root (this file is at emgio/tests/) so the test does not
 # silently skip when pytest runs from a different working directory.
@@ -25,7 +25,7 @@ EEG_SET = (
 
 @pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
 def test_eeglab_bids_eeg_fixture_imports():
-    emg = EMG.from_file(str(EEG_SET), importer="eeglab")
+    emg = Recording.from_file(str(EEG_SET), importer="eeglab")
 
     # All 64 channels imported with their real 10-10 montage labels.
     assert len(emg.channels) == 64

--- a/emgio/tests/test_exporters.py
+++ b/emgio/tests/test_exporters.py
@@ -12,14 +12,14 @@ from ..analysis.signal import analyze_signal, determine_format_suitability, quan
 from ..analysis.signal import analyze_signal_fft as _analyze_signal_fft
 from ..analysis.signal import analyze_signal_svd as _analyze_signal_svd
 from ..analysis.signal import find_elbow_point as _find_elbow_point
-from ..core.emg import EMG
+from ..core.emg import Recording
 from ..exporters.edf import EDFExporter, _determine_scaling_factors
 
 
 @pytest.fixture
 def sample_emg():
-    """Create an EMG object with sample data."""
-    emg = EMG()
+    """Create a Recording object with sample data."""
+    emg = Recording()
 
     # Create sample data
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
@@ -274,8 +274,8 @@ def test_edf_export_no_channels_tsv(sample_emg):
 
 
 def test_edf_export_no_signals():
-    """Test error handling when exporting empty EMG object."""
-    empty_emg = EMG()
+    """Test error handling when exporting empty Recording object."""
+    empty_emg = Recording()
     with pytest.raises(ValueError):
         with tempfile.NamedTemporaryFile(suffix=".edf") as f:
             EDFExporter.export(empty_emg, f.name)
@@ -368,23 +368,23 @@ def test_signal_analysis():
 
 def test_format_selection():
     """Test format selection based on signal characteristics (format='auto')."""
-    EMG()
+    Recording()
     time = np.linspace(0, 1, 1000)
 
     # Test case 1: High quality signal with small amplitude (should still use BDF due to dynamic range)
     clean_signal = np.sin(2 * np.pi * 10 * time) * 1  # Clean 10 Hz sine with amplitude 1
-    emg_clean = EMG()
+    emg_clean = Recording()
     emg_clean.add_channel("Clean", clean_signal, 1000, "uV", "EMG")
 
     # Test case 2: Moderate dynamic range signal that will trigger EDF
     # Update test to reflect signals under ~80dB typically use EDF
     hdr_signal, actual_dr = generate_high_dynamic_range_signal(dynamic_range_db=85)
     print(f"HDR signal generated with {actual_dr:.1f} dB dynamic range")
-    emg_hdr = EMG()
+    emg_hdr = Recording()
     emg_hdr.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
 
     # Test case 3: Mixed signals (should result in BDF due to high DR clean signal)
-    emg_mixed = EMG()
+    emg_mixed = Recording()
     emg_mixed.add_channel("Clean", clean_signal, 1000, "uV", "EMG")
     emg_mixed.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
 
@@ -454,12 +454,12 @@ def test_format_reproducibility():
 
     # BDF test signal (large amplitude, requires BDF ideally)
     bdf_signal = np.sin(2 * np.pi * 10 * time) * 1e6
-    emg_bdf = EMG()
+    emg_bdf = Recording()
     emg_bdf.add_channel("LargeAmp", bdf_signal, 1000, "uV", "EMG")
 
     # EDF test signal (smaller amplitude, suitable for EDF)
     edf_signal = np.sin(2 * np.pi * 10 * time) * 1000
-    emg_edf = EMG()
+    emg_edf = Recording()
     emg_edf.add_channel("SmallAmp", edf_signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
@@ -502,7 +502,7 @@ def test_format_reproducibility():
 
 def test_bdf_format_selection():
     """Test automatic BDF format selection with scaling verification."""
-    emg = EMG()
+    emg = Recording()
     time = np.linspace(0, 1, 1000)
     # Create signal that should trigger BDF in 'auto' mode
     signal = np.sin(2 * np.pi * 10 * time) * 1e6  # Large amplitude
@@ -551,14 +551,14 @@ def test_bdf_format_selection():
 
 def test_user_format_selection():
     """Test explicit format selection by user (format='edf' or 'bdf')."""
-    # Create necessary EMG objects inside the test where needed
+    # Create necessary Recording objects inside the test where needed
     time = np.linspace(0, 1, 1000)
 
     # Signal that would normally trigger BDF (High Dynamic Range)
     hdr_signal, _ = generate_high_dynamic_range_signal(
         dynamic_range_db=85
     )  # Lower threshold for reliability
-    emg_hdr = EMG()
+    emg_hdr = Recording()
     emg_hdr.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
 
     # Signal that would normally trigger EDF (Lower Dynamic Range)
@@ -566,7 +566,7 @@ def test_user_format_selection():
     noisy_signal = np.sin(2 * np.pi * 10 * time) * 100
     noise = np.random.normal(0, 5.0, 1000)
     noisy_signal += noise
-    emg_lowdr = EMG()
+    emg_lowdr = Recording()
     emg_lowdr.add_channel("LowDR", noisy_signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
@@ -635,8 +635,8 @@ def test_user_format_selection():
 
 def test_high_dynamic_range():
     """Test export of signals with high dynamic range using auto format."""
-    # Create EMG object
-    emg = EMG()
+    # Create Recording object
+    emg = Recording()
 
     # Generate a high dynamic range signal (lowered threshold for test reliability)
     hdr_signal, actual_dr = generate_high_dynamic_range_signal(dynamic_range_db=85)

--- a/emgio/tests/test_importer_wfdb.py
+++ b/emgio/tests/test_importer_wfdb.py
@@ -5,7 +5,7 @@ import shutil
 import pandas as pd
 import pytest
 
-from emgio.core.emg import EMG
+from emgio.core.emg import Recording
 from emgio.importers.wfdb import WFDBImporter
 
 # Directory containing the test WFDB files (relative to project root)
@@ -62,7 +62,7 @@ def test_wfdb_load_basic(wfdb_importer, wfdb_data):
     """Test basic loading of a WFDB record (.hea file)."""
     emg = wfdb_importer.load(str(wfdb_data["hea"]))
 
-    assert isinstance(emg, EMG)
+    assert isinstance(emg, Recording)
     assert emg.signals is not None
     assert isinstance(emg.signals, pd.DataFrame)
     # Record 100 has 2 signals
@@ -144,6 +144,6 @@ def test_wfdb_importer_handles_record_name_input(wfdb_importer, wfdb_data):
     record_base_path = os.path.join(wfdb_data["dir"], WFDB_RECORD_NAME)
     emg = wfdb_importer.load(record_base_path)
 
-    assert isinstance(emg, EMG)
+    assert isinstance(emg, Recording)
     assert emg.get_metadata("record_name") == WFDB_RECORD_NAME
     assert not emg.events.empty  # Check annotations loaded correctly too

--- a/emgio/tests/test_importers.py
+++ b/emgio/tests/test_importers.py
@@ -213,7 +213,7 @@ def test_csv_format_detection(sample_trigno_csv):
     # Check if the error message contains the trigno suggestion
     error_msg = str(exc_info.value)
     assert "Delsys Trigno CSV export" in error_msg
-    assert "emg = EMG.from_file(filepath, importer='trigno')" in error_msg
+    assert "recording = Recording.from_file(filepath, importer='trigno')" in error_msg
     assert "force_generic=True" in error_msg
 
     # Test with force_generic=True

--- a/emgio/tests/test_lowres.py
+++ b/emgio/tests/test_lowres.py
@@ -1,6 +1,6 @@
 """Low-resolution export pipeline tests (biosigIO phase 2).
 
-Covers ``EMG.resample`` (anti-aliased polyphase down-sampling) and the CLI
+Covers ``Recording.resample`` (anti-aliased polyphase down-sampling) and the CLI
 ``lowres`` subcommand. The headline test is the anti-aliasing proof: a tone
 above the new Nyquist must be removed by the resampler's filter, NOT folded
 back into the band. NO MOCKS: real fixtures and a real synthetic-signal FFT.
@@ -12,7 +12,7 @@ from math import ceil, gcd
 import numpy as np
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 from emgio.cli import EXIT_OK, main
 
 _REPO = pathlib.Path(__file__).resolve().parents[2]
@@ -25,14 +25,14 @@ requires_emg = pytest.mark.skipif(not EMG_EDF.exists(), reason="EMG fixture miss
 _CONST_PTP = 1e-9  # below this peak-to-peak a channel has no defined correlation
 
 
-def _rates(emg: EMG) -> set:
+def _rates(emg: Recording) -> set:
     return {info["sample_frequency"] for info in emg.channels.values()}
 
 
 @requires_eeg
 def test_resample_eeg_250_to_100_structure():
     """250 -> 100 Hz: new rate on all channels, expected sample count, channels/events kept."""
-    emg = EMG.from_file(str(EEG), importer="eeglab")
+    emg = Recording.from_file(str(EEG), importer="eeglab")
     n_old = emg.signals.shape[0]
     n_channels = len(emg.channels)
     n_events = len(emg.events)
@@ -55,7 +55,7 @@ def test_resample_eeg_250_to_100_structure():
 @requires_eeg
 def test_resample_preserves_channel_and_recording_metadata():
     """Channel type/modality/units/prefilter and recording metadata survive."""
-    emg = EMG.from_file(str(EEG), importer="eeglab")
+    emg = Recording.from_file(str(EEG), importer="eeglab")
     emg.set_metadata("subject", "sub-01")
     rs = emg.resample(100)
 
@@ -80,7 +80,7 @@ def test_resample_anti_aliasing_removes_above_nyquist():
     t = np.arange(int(fs * 10)) / fs
     signal = np.sin(2 * np.pi * 5 * t) + np.sin(2 * np.pi * 80 * t)
 
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("S", signal, fs, "uV", "EEG")
     rs = emg.resample(100)
 
@@ -102,7 +102,7 @@ def test_resample_anti_aliasing_removes_above_nyquist():
 @requires_eeg
 def test_resample_roundtrip_through_edf():
     """resample(100) -> EDF export -> reload: 100 Hz, per-channel r > 0.99 on 10 s."""
-    emg = EMG.from_file(str(EEG), importer="eeglab")
+    emg = Recording.from_file(str(EEG), importer="eeglab")
     rs = emg.resample(100)
 
     import tempfile
@@ -110,7 +110,7 @@ def test_resample_roundtrip_through_edf():
     with tempfile.TemporaryDirectory() as d:
         out = pathlib.Path(d) / "lowres.edf"
         rs.to_edf(str(out), format="edf", bypass_analysis=True)
-        reloaded = EMG.from_file(str(out), bids_channels="off")
+        reloaded = Recording.from_file(str(out), bids_channels="off")
 
         assert _rates(reloaded) == {100}, "reloaded recording must be 100 Hz"
 
@@ -143,7 +143,7 @@ def test_cli_lowres_creates_100hz_16bit(tmp_path):
     assert main(["lowres", str(EEG), str(out), "--rate", "100"]) == EXIT_OK
     assert out.exists()
 
-    reloaded = EMG.from_file(str(out), bids_channels="off")
+    reloaded = Recording.from_file(str(out), bids_channels="off")
     assert _rates(reloaded) == {100}
 
     # 16-bit EDF brackets digital values to int16 (max 32767), confirming the
@@ -159,14 +159,14 @@ def test_cli_lowres_default_is_double_lowres(tmp_path):
     """No --rate/--bits flags => 100 Hz + 16-bit EDF (double low-res default)."""
     out = tmp_path / "d.edf"
     assert main(["lowres", str(EEG), str(out)]) == EXIT_OK
-    reloaded = EMG.from_file(str(out), bids_channels="off")
+    reloaded = Recording.from_file(str(out), bids_channels="off")
     assert _rates(reloaded) == {100}
 
 
 @requires_emg
 def test_cli_lowres_skips_when_already_low(tmp_path, capsys):
     """Source already <= target rate: export without resampling, with a stderr note."""
-    emg = EMG.from_file(str(EMG_EDF))
+    emg = Recording.from_file(str(EMG_EDF))
     source_rate = max(_rates(emg))
     target = source_rate + 100.0  # guarantee source <= target
 
@@ -175,14 +175,14 @@ def test_cli_lowres_skips_when_already_low(tmp_path, capsys):
     assert out.exists()
     assert "without resampling" in capsys.readouterr().err
 
-    reloaded = EMG.from_file(str(out), bids_channels="off")
+    reloaded = Recording.from_file(str(out), bids_channels="off")
     assert _rates(reloaded) == _rates(emg), "rate unchanged when no resampling occurred"
 
 
 @requires_eeg
 def test_resample_equal_rate_returns_unchanged_copy():
     """target == source: a copy with the same rate and sample count, but a new object."""
-    emg = EMG.from_file(str(EEG), importer="eeglab")
+    emg = Recording.from_file(str(EEG), importer="eeglab")
     rs = emg.resample(250)
     assert rs is not emg
     assert _rates(rs) == {250}
@@ -193,7 +193,7 @@ def test_resample_equal_rate_returns_unchanged_copy():
 @requires_eeg
 def test_resample_above_source_raises():
     """Up-sampling is refused (low-res only)."""
-    emg = EMG.from_file(str(EEG), importer="eeglab")
+    emg = Recording.from_file(str(EEG), importer="eeglab")
     with pytest.raises(ValueError, match="exceeds source rate"):
         emg.resample(500)
 
@@ -205,7 +205,7 @@ def test_resample_non_integer_target_stores_actual_rate():
     integer factors up=25/down=64 -> achieves exactly 100.0 Hz, which must be what
     is written to the channels (not the requested 100.4).
     """
-    emg = EMG()
+    emg = Recording()
     rng = np.random.default_rng(0)
     emg.add_channel("X", rng.standard_normal(2560), 256, "uV", "EEG")
     rs = emg.resample(100.4)
@@ -219,7 +219,7 @@ def test_resample_mixed_rate_raises():
     emgio stores one uniform-length grid, so the two channels share a length;
     only their declared sample_frequency differs, which the guard must reject.
     """
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("A", np.zeros(1000), 500.0, "uV", "EEG")
     emg.add_channel("B", np.zeros(1000), 250.0, "uV", "EEG")
     with pytest.raises(ValueError, match="single sampling rate"):
@@ -227,6 +227,6 @@ def test_resample_mixed_rate_raises():
 
 
 def test_resample_no_signals_raises():
-    """An empty EMG cannot be resampled."""
+    """An empty Recording cannot be resampled."""
     with pytest.raises(ValueError, match="No signals loaded"):
-        EMG().resample(100)
+        Recording().resample(100)

--- a/emgio/tests/test_meg_importer.py
+++ b/emgio/tests/test_meg_importer.py
@@ -14,7 +14,7 @@ from collections import Counter
 import numpy as np
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 
 pytest.importorskip("mne", reason="MEG import requires the optional 'meg' extra (mne)")
 
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.skipif(not MEG.exists(), reason="MEG fixture missing")
 
 @pytest.fixture(scope="module")
 def meg_emg():
-    return EMG.from_file(str(MEG))
+    return Recording.from_file(str(MEG))
 
 
 def test_meg_channel_types_preserved(meg_emg):
@@ -75,7 +75,7 @@ def test_meg_roundtrip_preserves_tesla_signals(meg_emg, tmp_path):
     out = tmp_path / "meg.edf"
     meg_emg.to_edf(str(out), format="bdf", bypass_analysis=True)
     written = out if out.exists() else out.with_suffix(".bdf")
-    reloaded = EMG.from_file(str(written), bids_channels="off")
+    reloaded = Recording.from_file(str(written), bids_channels="off")
     assert len(reloaded.channels) == len(meg_emg.channels)
 
     # Check a handful of magnetometer channels on a 10 s window.

--- a/emgio/tests/test_modality_integration.py
+++ b/emgio/tests/test_modality_integration.py
@@ -10,7 +10,7 @@ import pathlib
 import numpy as np
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 from emgio.core.modality import VALID_CHANNEL_TYPES
 from emgio.importers.csv import CSVImporter
 
@@ -20,13 +20,13 @@ XDF_FILE = _REPO / "examples/multi_stream_test.xdf"
 
 
 def test_add_channel_requires_channel_type():
-    emg = EMG()
+    emg = Recording()
     with pytest.raises(TypeError):
         emg.add_channel("C", np.zeros(10), 100, "uV")  # channel_type omitted
 
 
 def test_add_channel_validates_and_infers_modality():
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("E1", np.zeros(10), 100, "uV", "eeg")  # case-insensitive
     assert emg.channels["E1"]["channel_type"] == "EEG"
     assert emg.channels["E1"]["modality"] == "EEG"
@@ -39,7 +39,7 @@ def test_add_channel_validates_and_infers_modality():
 
 
 def test_set_channel_and_modality_selectors():
-    emg = EMG()
+    emg = Recording()
     emg.add_channel("a", np.zeros(10), 100, "uV", "EEG")
     emg.add_channel("b", np.zeros(10), 100, "mV", "EMG")
 
@@ -60,7 +60,7 @@ def test_csv_time_column_is_not_an_invalid_type():
 
 @pytest.mark.skipif(not XDF_FILE.exists(), reason="XDF fixture missing")
 def test_xdf_channels_carry_valid_type_and_modality():
-    emg = EMG.from_file(str(XDF_FILE))
+    emg = Recording.from_file(str(XDF_FILE))
     assert len(emg.channels) > 0
     for info in emg.channels.values():
         # No raw/unvalidated LSL type strings leak through, and every channel
@@ -71,7 +71,7 @@ def test_xdf_channels_carry_valid_type_and_modality():
 
 @pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
 def test_real_eeg_does_not_creep_to_emg():
-    emg = EMG.from_file(str(EEG_SET), importer="eeglab")
+    emg = Recording.from_file(str(EEG_SET), importer="eeglab")
     types = {info["channel_type"] for info in emg.channels.values()}
     # The headline bug: EEG data must not be silently relabelled EMG.
     assert "EMG" not in types

--- a/emgio/tests/test_recording_alias.py
+++ b/emgio/tests/test_recording_alias.py
@@ -1,17 +1,38 @@
 """The core class is `Recording`; `EMG` is a deprecated backward-compat alias.
 
 When the package handled only EMG the class was named `EMG`; it is now a
-modality-agnostic biosignal recording (EEG/EMG/iEEG/MEG/...) named `Recording`,
-with `EMG` retained as an alias so existing code keeps working. NO MOCKS.
+modality-agnostic biosignal recording (EEG/EMG/iEEG/MEG/...) named `Recording`.
+`EMG` still resolves to `Recording` but now emits a ``DeprecationWarning`` and
+will be removed in biosigio 1.0.0. NO MOCKS.
 """
 
+import warnings
+
 import numpy as np
+import pytest
 
-from emgio import EMG, Recording
+import emgio
+from emgio import Recording
 
 
-def test_emg_is_alias_of_recording():
+def test_emg_alias_resolves_to_recording_with_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="EMG.*deprecated"):
+        cls = emgio.EMG
+    assert cls is Recording
+
+
+def test_emg_from_core_module_also_warns():
+    with pytest.warns(DeprecationWarning, match="EMG.*deprecated"):
+        from emgio.core.emg import EMG
     assert EMG is Recording
+
+
+def test_emg_alias_is_still_constructible():
+    with pytest.warns(DeprecationWarning):
+        cls = emgio.EMG
+    rec = cls()
+    rec.add_channel("C", np.zeros(100), 100, "uV", "EMG")
+    assert isinstance(rec, Recording)
 
 
 def test_recording_is_the_canonical_class_name():
@@ -19,11 +40,12 @@ def test_recording_is_the_canonical_class_name():
     assert type(rec).__name__ == "Recording"
 
 
-def test_alias_works_for_construction_and_isinstance():
-    rec = Recording()
-    rec.add_channel("C", np.zeros(100), 100, "uV", "EMG")
-    via_alias = EMG()
-    via_alias.add_channel("C", np.zeros(100), 100, "uV", "EMG")
-    # Instances of one are instances of the other (same class).
-    assert isinstance(rec, EMG)
-    assert isinstance(via_alias, Recording)
+def test_recording_access_emits_no_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert emgio.Recording is Recording
+
+
+def test_unknown_attribute_still_raises_attributeerror():
+    with pytest.raises(AttributeError):
+        _ = emgio.DoesNotExist

--- a/emgio/tests/test_roundtrip.py
+++ b/emgio/tests/test_roundtrip.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 
-from emgio import EMG
+from emgio import Recording
 
 # Round-trips are expensive; compute each fixture's once and share it across the
 # structural and value-integrity tests.
@@ -88,13 +88,13 @@ MIXED_RATE_CASES = [
 def _roundtrip(case):
     """Import -> export (auto) -> reimport once per fixture (cached)."""
     if case.name not in _RT_CACHE:
-        emg = EMG.from_file(str(case.path), importer=case.importer)
+        emg = Recording.from_file(str(case.path), importer=case.importer)
         out = os.path.join(_RT_DIR, f"{case.name}.edf")
         # format="auto" exercises the real EDF/BDF selection (and ignores
         # bypass_analysis by design), which is what a round-trip harness wants.
         emg.to_edf(out, format="auto")
         written = out if os.path.exists(out) else os.path.splitext(out)[0] + ".bdf"
-        _RT_CACHE[case.name] = (emg, EMG.from_file(written))
+        _RT_CACHE[case.name] = (emg, Recording.from_file(written))
     return _RT_CACHE[case.name]
 
 
@@ -162,7 +162,7 @@ def test_roundtrip_preserves_signal_values(case):
 def test_mixed_rate_export_raises(case, tmp_path):
     if not case.path.exists():
         pytest.skip(f"fixture missing: {case.path}")
-    emg = EMG.from_file(str(case.path), importer=case.importer)
+    emg = Recording.from_file(str(case.path), importer=case.importer)
     rates = {int(c["sample_frequency"]) for c in emg.channels.values()}
     if len(rates) <= 1:
         pytest.skip(f"{case.name}: fixture is single-rate, guard not exercised")
@@ -176,7 +176,7 @@ def test_meg_fif_imports_via_mne():
     if not meg.exists():
         pytest.skip("MEG fixture missing")
     pytest.importorskip("mne", reason="MEG import requires the optional 'meg' extra (mne)")
-    emg = EMG.from_file(str(meg))
+    emg = Recording.from_file(str(meg))
     assert len(emg.channels) > 0
     # No modality creep: a MEG file must not invent EMG channels.
     assert not [c for c, i in emg.channels.items() if i["channel_type"] == "EMG"]
@@ -192,13 +192,13 @@ def test_event_roundtrip_through_edf(tmp_path):
     fixture = BIDS / "emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
     if not fixture.exists():
         pytest.skip("EMG fixture missing")
-    emg = EMG.from_file(str(fixture))
+    emg = Recording.from_file(str(fixture))
     emg.add_event(onset=0.5, duration=0.0, description="m1")
     emg.add_event(onset=1.0, duration=0.2, description="m2")
     out = tmp_path / "ev.edf"
     emg.to_edf(str(out), format="edf", bypass_analysis=True)
 
-    reloaded = EMG.from_file(str(out), bids_channels="off")
+    reloaded = Recording.from_file(str(out), bids_channels="off")
     assert len(reloaded.events) == 2
     assert list(reloaded.events["description"]) == ["m1", "m2"]
     assert np.allclose(reloaded.events["onset"].to_numpy(), [0.5, 1.0], atol=1e-3)

--- a/emgio/tests/test_verification.py
+++ b/emgio/tests/test_verification.py
@@ -4,14 +4,14 @@ import numpy as np
 import pytest
 
 from ..analysis.verification import compare_signals, report_verification_results
-from ..core.emg import EMG
+from ..core.emg import Recording
 
 
 @pytest.fixture
 def sample_emg_pair():
-    """Create a pair of EMG objects with identical data for testing."""
-    emg_original = EMG()
-    emg_reloaded = EMG()
+    """Create a pair of Recording objects with identical data for testing."""
+    emg_original = Recording()
+    emg_reloaded = Recording()
 
     # Add identical channels
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
@@ -29,9 +29,9 @@ def sample_emg_pair():
 
 @pytest.fixture
 def sample_emg_pair_different():
-    """Create a pair of EMG objects with slightly different data."""
-    emg_original = EMG()
-    emg_reloaded = EMG()
+    """Create a pair of Recording objects with slightly different data."""
+    emg_original = Recording()
+    emg_reloaded = Recording()
 
     # Add slightly different channels
     time = np.linspace(0, 1, 1000)
@@ -53,9 +53,9 @@ def sample_emg_pair_different():
 
 @pytest.fixture
 def sample_emg_pair_renamed():
-    """Create a pair of EMG objects with same data but different channel names."""
-    emg_original = EMG()
-    emg_reloaded = EMG()
+    """Create a pair of Recording objects with same data but different channel names."""
+    emg_original = Recording()
+    emg_reloaded = Recording()
 
     # Add channels with different names but identical data
     time = np.linspace(0, 1, 1000)
@@ -73,9 +73,9 @@ def sample_emg_pair_renamed():
 
 @pytest.fixture
 def sample_emg_pair_different_lengths():
-    """Create a pair of EMG objects with different signal lengths."""
-    emg_original = EMG()
-    emg_reloaded = EMG()
+    """Create a pair of Recording objects with different signal lengths."""
+    emg_original = Recording()
+    emg_reloaded = Recording()
 
     # Add channels with different lengths
     time1 = np.linspace(0, 1, 1000)
@@ -163,8 +163,8 @@ def test_compare_signals_different_lengths(sample_emg_pair_different_lengths):
 
 def test_compare_signals_empty_intersection():
     """Test compare_signals with no common channels."""
-    emg1 = EMG()
-    emg2 = EMG()
+    emg1 = Recording()
+    emg2 = Recording()
 
     # Add completely different channels
     time = np.linspace(0, 1, 1000)
@@ -184,8 +184,8 @@ def test_compare_signals_empty_intersection():
 
 def test_compare_signals_invalid_channel_map():
     """Test compare_signals with invalid channel map."""
-    emg1 = EMG()
-    emg2 = EMG()
+    emg1 = Recording()
+    emg2 = Recording()
 
     time = np.linspace(0, 1, 1000)
     signal = np.sin(2 * np.pi * 10 * time)
@@ -202,8 +202,8 @@ def test_compare_signals_invalid_channel_map():
 
 def test_compare_signals_with_constant_signal():
     """Test compare_signals with constant signals (zero range)."""
-    emg1 = EMG()
-    emg2 = EMG()
+    emg1 = Recording()
+    emg2 = Recording()
 
     # Add constant signals to both
     const_signal = np.ones(1000)

--- a/emgio/tests/test_visualization.py
+++ b/emgio/tests/test_visualization.py
@@ -3,14 +3,14 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from emgio.core.emg import EMG
+from emgio.core.emg import Recording
 from emgio.visualization.static import plot_comparison, plot_signals
 
 
 @pytest.fixture
 def sample_emg():
-    """Create a sample EMG object for visualization testing."""
-    emg = EMG()
+    """Create a sample Recording object for visualization testing."""
+    emg = Recording()
 
     # Create sample data
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
@@ -28,9 +28,9 @@ def sample_emg():
 
 @pytest.fixture
 def emg_pair():
-    """Create a pair of EMG objects for comparison testing."""
-    emg_original = EMG()
-    emg_reloaded = EMG()
+    """Create a pair of Recording objects for comparison testing."""
+    emg_original = Recording()
+    emg_reloaded = Recording()
 
     # Create sample data
     time = np.linspace(0, 1, 1000)
@@ -138,8 +138,8 @@ def test_plot_signals_errors(sample_emg):
     with pytest.raises(ValueError):
         plot_signals(sample_emg, channels=["NonExistentChannel"])
 
-    # Test with empty EMG object
-    empty_emg = EMG()
+    # Test with empty Recording object
+    empty_emg = Recording()
     with pytest.raises(ValueError):
         plot_signals(empty_emg)
 
@@ -214,8 +214,8 @@ def test_plot_comparison_with_channel_map(emg_pair):
     """Test plot_comparison with channel mapping."""
     emg_original, emg_reloaded = emg_pair
 
-    # Create a reloaded EMG with different channel names
-    emg_renamed = EMG()
+    # Create a reloaded Recording with different channel names
+    emg_renamed = Recording()
     time = np.linspace(0, 1, 1000)
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
@@ -235,9 +235,9 @@ def test_plot_comparison_with_channel_map(emg_pair):
 
 def test_plot_comparison_no_common_channels():
     """Test plot_comparison with no common channels."""
-    # Create two EMG objects with completely different channels
-    emg1 = EMG()
-    emg2 = EMG()
+    # Create two Recording objects with completely different channels
+    emg1 = Recording()
+    emg2 = Recording()
 
     time = np.linspace(0, 1, 1000)
     signal1 = np.sin(2 * np.pi * 10 * time)
@@ -256,8 +256,8 @@ def test_plot_comparison_no_common_channels():
 
 def test_plot_comparison_different_lengths():
     """Test plot_comparison with signals of different lengths."""
-    emg1 = EMG()
-    emg2 = EMG()
+    emg1 = Recording()
+    emg2 = Recording()
 
     # Create signals with different lengths
     time1 = np.linspace(0, 1, 1000)
@@ -276,9 +276,9 @@ def test_plot_comparison_different_lengths():
 
 def test_plot_comparison_order_based():
     """Test plot_comparison with order-based matching."""
-    # Create two EMG objects with different channel names
-    emg1 = EMG()
-    emg2 = EMG()
+    # Create two Recording objects with different channel names
+    emg1 = Recording()
+    emg2 = Recording()
 
     time = np.linspace(0, 1, 1000)
     signal1 = np.sin(2 * np.pi * 10 * time)

--- a/emgio/tests/test_xdf_importer.py
+++ b/emgio/tests/test_xdf_importer.py
@@ -6,7 +6,7 @@ import tempfile
 import numpy as np
 import pytest
 
-from ..core.emg import EMG
+from ..core.emg import Recording
 from ..importers.xdf import XDFImporter, XDFStreamInfo, XDFSummary, summarize_xdf
 
 # Path to the sample XDF file
@@ -102,8 +102,8 @@ def test_xdf_importer_basic():
 
 
 def test_xdf_importer_from_emg_class():
-    """Test XDF import through EMG.from_file."""
-    emg = EMG.from_file(SAMPLE_XDF_PATH)
+    """Test XDF import through Recording.from_file."""
+    emg = Recording.from_file(SAMPLE_XDF_PATH)
 
     # Check basic loading
     assert emg.signals is not None
@@ -163,7 +163,7 @@ def test_xdf_importer_timestamps():
 def test_xdf_export_roundtrip():
     """Test XDF import and EDF export roundtrip."""
     # Load XDF file
-    emg = EMG.from_file(SAMPLE_XDF_PATH)
+    emg = Recording.from_file(SAMPLE_XDF_PATH)
 
     # Export to EDF
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
@@ -173,7 +173,7 @@ def test_xdf_export_roundtrip():
         emg.to_edf(temp_path, format="edf")
 
         # Reload from EDF
-        emg_reloaded = EMG.from_file(temp_path)
+        emg_reloaded = Recording.from_file(temp_path)
 
         # Check basic structure preserved
         assert len(emg_reloaded.channels) == len(emg.channels)
@@ -245,7 +245,7 @@ def test_multistream_summarize():
 
 def test_multistream_import_all():
     """Test importing all numeric streams from multi-stream file."""
-    emg = EMG.from_file(MULTI_STREAM_XDF_PATH)
+    emg = Recording.from_file(MULTI_STREAM_XDF_PATH)
 
     # Should have channels from EEG, EMG, and Mocap (not Markers - string stream)
     # EEG: 8, EMG: 2, Mocap: 6 = 16 total
@@ -255,32 +255,32 @@ def test_multistream_import_all():
 def test_multistream_import_by_type():
     """Test importing specific stream types from multi-stream file."""
     # Import only EMG
-    emg = EMG.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"])
+    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"])
     assert len(emg.channels) == 2
     channel_names = list(emg.channels.keys())
     assert "EMG_L" in channel_names
     assert "EMG_R" in channel_names
 
     # Import only EEG
-    eeg = EMG.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG"])
+    eeg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG"])
     assert len(eeg.channels) == 8
     assert all("EEG" in name for name in eeg.channels.keys())
 
     # Import only Mocap
-    mocap = EMG.from_file(MULTI_STREAM_XDF_PATH, stream_types=["Mocap"])
+    mocap = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["Mocap"])
     assert len(mocap.channels) == 6
     assert all("Marker" in name for name in mocap.channels.keys())
 
 
 def test_multistream_import_by_name():
     """Test importing specific streams by name from multi-stream file."""
-    emg = EMG.from_file(MULTI_STREAM_XDF_PATH, stream_names=["TestEMG"])
+    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_names=["TestEMG"])
     assert len(emg.channels) == 2
 
 
 def test_multistream_import_multiple_types():
     """Test importing multiple stream types from multi-stream file."""
-    emg = EMG.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG", "EMG"])
+    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG", "EMG"])
 
     # Should have EEG (8) + EMG (2) = 10 channels
     assert len(emg.channels) == 10
@@ -340,7 +340,7 @@ def test_multistream_uses_highest_sample_rate():
     emg_stream = summary.get_stream_by_name("TestEMG")  # 2048 Hz - highest
 
     # Load both streams (EEG at 256 Hz, EMG at 2048 Hz)
-    combined = EMG.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG", "EMG"])
+    combined = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG", "EMG"])
 
     # The number of samples should match the highest rate stream (EMG at 2048 Hz)
     n_samples = len(combined.signals)
@@ -419,7 +419,7 @@ def test_include_timestamps_single_stream():
 
 def test_include_timestamps_multistream():
     """Test include_timestamps option with multi-stream file."""
-    emg = EMG.from_file(MULTI_STREAM_XDF_PATH, include_timestamps=True)
+    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, include_timestamps=True)
 
     channel_names = list(emg.channels.keys())
 
@@ -435,7 +435,7 @@ def test_include_timestamps_multistream():
 
 def test_include_timestamps_by_type():
     """Test include_timestamps with stream type selection."""
-    emg = EMG.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"], include_timestamps=True)
+    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"], include_timestamps=True)
 
     channel_names = list(emg.channels.keys())
 
@@ -447,7 +447,7 @@ def test_include_timestamps_by_type():
 
 def test_include_timestamps_default_false():
     """Test that timestamps are not included by default."""
-    emg = EMG.from_file(SAMPLE_XDF_PATH)
+    emg = Recording.from_file(SAMPLE_XDF_PATH)
 
     channel_names = list(emg.channels.keys())
     ts_channels = [ch for ch in channel_names if "_LSL_timestamps" in ch]
@@ -461,7 +461,7 @@ def test_include_timestamps_export_roundtrip():
     import tempfile
 
     # Load with timestamps
-    emg = EMG.from_file(SAMPLE_XDF_PATH, include_timestamps=True)
+    emg = Recording.from_file(SAMPLE_XDF_PATH, include_timestamps=True)
 
     # Find timestamp channel
     ts_channels = [ch for ch in emg.channels.keys() if "_LSL_timestamps" in ch]
@@ -477,7 +477,7 @@ def test_include_timestamps_export_roundtrip():
         emg.to_edf(temp_path, format="edf")
 
         # Reload from EDF
-        emg_reloaded = EMG.from_file(temp_path)
+        emg_reloaded = Recording.from_file(temp_path)
 
         # Check timestamp channel exists in reloaded data
         # Note: EDF has 16-char limit, so "_LSL_timestamps" may be truncated to "_LSL_t"

--- a/emgio/version.py
+++ b/emgio/version.py
@@ -1,7 +1,7 @@
 """Version information for EMGIO."""
 
-__version__ = "0.4.0"
-__version_info__ = (0, 4, 0)
+__version__ = "0.5.0"
+__version_info__ = (0, 5, 0)
 
 
 def get_version() -> str:

--- a/emgio/visualization/static.py
+++ b/emgio/visualization/static.py
@@ -9,11 +9,11 @@ import numpy as np
 
 # Use TYPE_CHECKING to avoid circular import at runtime
 if TYPE_CHECKING:
-    from ..core.emg import EMG  # Assuming EMG class is in core.emg
+    from ..core.emg import Recording  # Assuming Recording class is in core.emg
 
 
 def plot_signals(
-    emg_object: "EMG",  # Changed first arg to accept EMG object
+    emg_object: "Recording",  # Changed first arg to accept Recording object
     channels: list[str] | None = None,
     time_range: tuple[float, float] | None = None,
     offset_scale: float = 0.8,
@@ -28,7 +28,7 @@ def plot_signals(
     Plot EMG signals in a single plot with vertical offsets.
 
     Args:
-        emg_object: The EMG object containing the signals and metadata.
+        emg_object: The Recording object containing the signals and metadata.
         channels: List of channels to plot. If None, plot all channels.
         time_range: Tuple of (start_time, end_time) to plot. If None, plot all data.
         offset_scale: Portion of allocated space each signal can use (0.0 to 1.0).
@@ -40,7 +40,7 @@ def plot_signals(
         plt_module: Matplotlib pyplot module to use.
     """
     if emg_object.signals is None:
-        raise ValueError("EMG object has no signals loaded.")
+        raise ValueError("Recording object has no signals loaded.")
 
     signals_df = emg_object.signals
 
@@ -147,8 +147,8 @@ def plot_signals(
 
 
 def plot_comparison(
-    emg_original: "EMG",
-    emg_reloaded: "EMG",
+    emg_original: "Recording",
+    emg_reloaded: "Recording",
     channels: list[str] | None = None,
     time_range: tuple[float, float] | None = None,
     detrend: bool = False,
@@ -164,8 +164,8 @@ def plot_comparison(
     Creates subplots for each channel pair.
 
     Args:
-        emg_original: The original EMG object.
-        emg_reloaded: The reloaded EMG object.
+        emg_original: The original Recording object.
+        emg_reloaded: The reloaded Recording object.
         channels: List of original channels to plot. If None, plot common/mapped channels.
         time_range: Tuple of (start_time, end_time) to plot. If None, plot all data.
         detrend: Whether to remove mean from signals before plotting.
@@ -177,10 +177,10 @@ def plot_comparison(
                     match first, then falls back to order-based matching.
         plt_module: Matplotlib pyplot module to use.
     """
-    # Removed local import: from emgio.core.emg import EMG
+    # Removed local import: from emgio.core.emg import Recording
 
     if emg_original.signals is None or emg_reloaded.signals is None:
-        raise ValueError("Both EMG objects must have signals loaded to plot a comparison")
+        raise ValueError("Both Recording objects must have signals loaded to plot a comparison")
 
     original_channel_names = set(emg_original.signals.columns)
     reloaded_channel_names = set(emg_reloaded.signals.columns)

--- a/examples/brainvision/README.md
+++ b/examples/brainvision/README.md
@@ -13,8 +13,8 @@ Regenerate (requires `pybv` + the `meg` extra):
 
 ```python
 import numpy as np, pybv
-from emgio import EMG
-emg = EMG.from_file("examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set", importer="eeglab")
+from emgio import Recording
+emg = Recording.from_file("examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set", importer="eeglab")
 rate = 250
 chans = list(emg.signals.columns)[:8]
 data = emg.signals[chans].to_numpy()[: 5 * rate].T.astype(float)

--- a/examples/csv_detection_test.py
+++ b/examples/csv_detection_test.py
@@ -9,7 +9,7 @@ This example shows:
 
 import os
 
-from emgio import EMG
+from emgio import Recording
 
 
 def test_format_detection():
@@ -27,7 +27,7 @@ def test_format_detection():
         try:
             # This should detect Trigno format and suggest using the Trigno importer
             print("Attempting to load Trigno CSV with generic CSV importer...")
-            EMG.from_file(trigno_csv, importer="csv")
+            Recording.from_file(trigno_csv, importer="csv")
             print("File loaded successfully (you shouldn't see this)")
         except ValueError as e:
             print(f"Format detection message: {str(e)}")
@@ -35,7 +35,7 @@ def test_format_detection():
         # Load with the specialized importer
         print("\nLoading with specialized Trigno importer...")
         try:
-            trigno_emg = EMG.from_file(trigno_csv, importer="trigno")
+            trigno_emg = Recording.from_file(trigno_csv, importer="trigno")
 
             # Print channel information from Trigno importer
             print("\nChannel Information (Trigno Importer):")
@@ -95,7 +95,7 @@ def test_format_detection():
                 },
             }
 
-            generic_emg = EMG.from_file(generic_csv, importer="csv", **csv_params)
+            generic_emg = Recording.from_file(generic_csv, importer="csv", **csv_params)
 
             # Print channel information
             print("\nChannel Information (Generic CSV):")

--- a/examples/csv_example.py
+++ b/examples/csv_example.py
@@ -12,7 +12,7 @@ The file contains unlabeled columns of EMG data with no header.
 
 import os
 
-from emgio import EMG
+from emgio import Recording
 
 
 def main():
@@ -59,13 +59,13 @@ def main():
         }
 
         # Create importer and load the data
-        emg = EMG.from_file(data_path, importer="csv", **csv_params)
+        emg = Recording.from_file(data_path, importer="csv", **csv_params)
 
         # Rename channels and set their types and units
         print("Renaming channels and setting metadata...")
 
-        # # Create a new EMG object with renamed channels
-        # new_emg = EMG()
+        # # Create a new Recording object with renamed channels
+        # new_emg = Recording()
 
         # # Copy metadata
         # for key, value in emg.metadata.items():

--- a/examples/eeglab_example.py
+++ b/examples/eeglab_example.py
@@ -10,7 +10,7 @@ This example shows how to:
 
 import os
 
-from emgio import EMG
+from emgio import Recording
 
 
 def main():
@@ -24,7 +24,7 @@ def main():
 
     # Load the data using EEGLAB importer
     print("Loading EMG data from EEGLAB .set file...")
-    emg = EMG.from_file(data_path, importer="eeglab")
+    emg = Recording.from_file(data_path, importer="eeglab")
 
     # Print metadata
     print("\nMetadata:")
@@ -60,12 +60,12 @@ def main():
         if len(events) > 5:
             print(f"  ... and {len(events) - 5} more events")
 
-    # Select EMG channels only and create a new EMG object
+    # Select EMG channels only and create a new Recording object
     emg_channels = emg.get_channels_by_type("EMG")
     if emg_channels:
         emg_only = emg.select_channels(
             emg_channels
-        )  # Creates a new EMG object with only EMG channels
+        )  # Creates a new Recording object with only EMG channels
 
         # Plot the first 5 seconds of data with different configurations
         print("\nPlotting EMG signals...")

--- a/examples/otb_example.py
+++ b/examples/otb_example.py
@@ -1,13 +1,13 @@
 import matplotlib.pyplot as plt
 
-from emgio.core.emg import EMG
+from emgio.core.emg import Recording
 
 
 def main():
     # Load OTB data
     print("Loading OTB data...")
     # example two: one_sessantaquattro_truncated.otb+, example two: two_mouvi_truncated.otb+
-    emg = EMG.from_file("examples/one_sessantaquattro_truncated.otb+", importer="otb")
+    emg = Recording.from_file("examples/one_sessantaquattro_truncated.otb+", importer="otb")
 
     # Print metadata
     print("\nDevice Information:")
@@ -29,7 +29,7 @@ def main():
     for ch_type, count in channel_types.items():
         print(f"{ch_type}: {count} channels")
 
-    # Create a new EMG object with only EMG channels
+    # Create a new Recording object with only EMG channels
     emg_data = emg.select_channels(channel_type="EMG")
     if emg_data.signals is not None and not emg_data.signals.empty:
         print("\nPlotting EMG channels...")

--- a/examples/trigno_example.ipynb
+++ b/examples/trigno_example.ipynb
@@ -3,27 +3,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Setup and Imports\n",
-    "Import required libraries (os, emgio.EMG, matplotlib.pyplot) and set up the environment for EMG data processing."
-   ]
+   "source": "# Setup and Imports\nImport required libraries (os, emgio.Recording, matplotlib.pyplot) and set up the environment for EMG data processing."
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Import required libraries\n",
-    "import os\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "from emgio import EMG\n",
-    "\n",
-    "# Set up the environment for EMG data processing\n",
-    "# (No additional setup required for this example)"
-   ]
+   "source": "# Import required libraries\nimport os\n\nimport matplotlib.pyplot as plt\n\nfrom emgio import Recording\n\n# Set up the environment for EMG data processing\n# (No additional setup required for this example)"
   },
   {
    "cell_type": "markdown",
@@ -35,82 +22,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading EMG data...\n",
-      "\n",
-      "Available channels:\n",
-      "- Mini sensor 10: EMG 10 (EMG)\n",
-      "  Sampling rate: 1259.259 Hz\n",
-      "  Unit: V\n",
-      "- Mini sensor 10: ACC.X 10 (ACC)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: g\n",
-      "- Mini sensor 10: ACC.Y 10 (ACC)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: g\n",
-      "- Mini sensor 10: ACC.Z 10 (ACC)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: g\n",
-      "- Mini sensor 10: GYRO.X 10 (GYRO)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: °/s\n",
-      "- Mini sensor 10: GYRO.Y 10 (GYRO)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: °/s\n",
-      "- Mini sensor 10: GYRO.Z 10 (GYRO)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: °/s\n",
-      "- Mini sensor 11: EMG 11 (EMG)\n",
-      "  Sampling rate: 1259.259 Hz\n",
-      "  Unit: V\n",
-      "- Mini sensor 11: ACC.X 11 (ACC)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: g\n",
-      "- Mini sensor 11: ACC.Y 11 (ACC)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: g\n",
-      "- Mini sensor 11: ACC.Z 11 (ACC)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: g\n",
-      "- Mini sensor 11: GYRO.X 11 (GYRO)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: °/s\n",
-      "- Mini sensor 11: GYRO.Y 11 (GYRO)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: °/s\n",
-      "- Mini sensor 11: GYRO.Z 11 (GYRO)\n",
-      "  Sampling rate: 148.1481 Hz\n",
-      "  Unit: °/s\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Load EMG Data\n",
-    "\n",
-    "# Sample data path - replace with your actual data path\n",
-    "data_path = \"truncated_trigno_sample.csv\"  # Update this path to your Trigno CSV file\n",
-    "\n",
-    "if not os.path.exists(data_path):\n",
-    "    print(f\"Sample file not found: {data_path}\")\n",
-    "    print(\"Please update the data_path variable with your Trigno CSV file path.\")\n",
-    "else:\n",
-    "    # Load the data using Trigno importer\n",
-    "    print(\"Loading EMG data...\")\n",
-    "    emg = EMG.from_file(data_path, importer=\"trigno\")\n",
-    "\n",
-    "    # Print available channels\n",
-    "    print(\"\\nAvailable channels:\")\n",
-    "    for ch_name, ch_info in emg.channels.items():\n",
-    "        print(f\"- {ch_name} ({ch_info['type']})\")\n",
-    "        print(f\"  Sampling rate: {ch_info['sampling_freq']} Hz\")\n",
-    "        print(f\"  Unit: {ch_info['unit']}\")"
-   ]
+   "outputs": [],
+   "source": "# Load EMG Data\n\n# Sample data path - replace with your actual data path\ndata_path = \"truncated_trigno_sample.csv\"  # Update this path to your Trigno CSV file\n\nif not os.path.exists(data_path):\n    print(f\"Sample file not found: {data_path}\")\n    print(\"Please update the data_path variable with your Trigno CSV file path.\")\nelse:\n    # Load the data using Trigno importer\n    print(\"Loading EMG data...\")\n    emg = Recording.from_file(data_path, importer=\"trigno\")\n\n    # Print available channels\n    print(\"\\nAvailable channels:\")\n    for ch_name, ch_info in emg.channels.items():\n        print(f\"- {ch_name} ({ch_info['type']})\")\n        print(f\"  Sampling rate: {ch_info['sampling_freq']} Hz\")\n        print(f\"  Unit: {ch_info['unit']}\")"
   },
   {
    "cell_type": "markdown",

--- a/examples/trigno_example.py
+++ b/examples/trigno_example.py
@@ -9,7 +9,7 @@ This example shows how to:
 
 import os
 
-from emgio import EMG
+from emgio import Recording
 
 
 def main():
@@ -23,7 +23,7 @@ def main():
 
     # Load the data using Trigno importer
     print("Loading EMG data...")
-    emg = EMG.from_file(data_path, importer="trigno")
+    emg = Recording.from_file(data_path, importer="trigno")
 
     # Print available channels
     print("\nAvailable channels:")
@@ -32,9 +32,11 @@ def main():
         print(f"  Sampling rate: {ch_info['sample_frequency']} Hz")
         print(f"  Dimension: {ch_info['physical_dimension']}")
 
-    # Select EMG channels only and create a new EMG object
+    # Select EMG channels only and create a new Recording object
     emg_channels = [ch for ch, info in emg.channels.items() if info["channel_type"] == "EMG"]
-    emg_only = emg.select_channels(emg_channels)  # Creates a new EMG object with only EMG channels
+    emg_only = emg.select_channels(
+        emg_channels
+    )  # Creates a new Recording object with only EMG channels
     # Original emg object remains unchanged with all channels
 
     # Plot the first 5 seconds of data with different configurations

--- a/examples/verification_example.py
+++ b/examples/verification_example.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-from emgio.core.emg import EMG
+from emgio.core.emg import Recording
 
 # Add the project root to the Python path
 # This allows importing emgio even if it's not installed
@@ -31,14 +31,14 @@ output_path_bdf = os.path.join(os.path.dirname(__file__), output_file_bdf)
 logging.info(f"Loading EMG data from: {input_path}")
 try:
     # Load the EMG data (assuming it's identifiable by the importer)
-    emg_data = EMG.from_file(input_path)
+    emg_data = Recording.from_file(input_path)
     logging.info("EMG data loaded successfully.")
     logging.info(f"Channels found: {list(emg_data.signals.columns)}")
     logging.info(f"Duration: {emg_data.signals.index[-1]:.2f} seconds")
     emg_channels = emg_data.get_channels_by_type("EMG")
     emg_only = emg_data.select_channels(
         emg_channels[:2]
-    )  # Creates a new EMG object with only EMG channels
+    )  # Creates a new Recording object with only EMG channels
 
 
 except FileNotFoundError:

--- a/examples/wfdb_example.py
+++ b/examples/wfdb_example.py
@@ -2,7 +2,7 @@ import os
 
 import matplotlib.pyplot as plt
 
-from emgio.core.emg import EMG
+from emgio.core.emg import Recording
 
 
 def main():
@@ -24,7 +24,7 @@ def main():
     # The importer automatically looks for a corresponding .atr file (e.g., 100.atr)
     # and loads annotations into the emg.events DataFrame if found.
     try:
-        emg = EMG.from_file(file_path, importer="wfdb")
+        emg = Recording.from_file(file_path, importer="wfdb")
     except ValueError as e:
         print(f"Error loading file: {e}")
         print("Ensure the 'wfdb' package is installed ('pip install wfdb')")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,7 @@ nav:
     - WFDB: formats/wfdb.md
     - XDF: formats/xdf.md
   - API Reference:
-    - EMG Class: api/emg.md
+    - Recording Class: api/emg.md
     - Importers:
       - Base Importer: api/importers/base.md
       - Trigno Importer: api/importers/trigno.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emgio"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
## Release 0.5.0 — complete the `EMG` -> `Recording` rename

Finishes the internal class rename so `Recording` is used everywhere, and turns the bare `EMG = Recording` alias into a properly deprecated one. Closes #81.

### What changed
- **Migrated all `EMG`-class references to `Recording`** across importers, exporters, analysis, visualization, CLI, bids, tests, docs, examples, and README — 448 references inventoried, ~420 migrated. The electromyography **modality** term "EMG" (channel-type values, "EMG signal/channel/system", LSL stream names, file paths) is deliberately left untouched.
- **Deprecated the `EMG` alias the right way:** a module `__getattr__` (PEP 562) in `emgio/__init__.py` and `emgio/core/emg.py` resolves `EMG` to `Recording` but emits a `DeprecationWarning`. The alias is scheduled for removal in **biosigio 1.0.0** (with the package rename).
- The CSV importer's "use the trigno importer" hint string and its two test assertions move to `recording = Recording.from_file(...)` in lockstep.

### How it was done
Discovery and migration ran as parallel agents over **disjoint** file groups (no worktrees): an exhaustive inventory distinguished the `EMG` class from the "EMG" modality term, then per-group agents applied the class-token migration while the coupled/alias-defining files were done by hand. An over-/under-migration sweep then confirmed no domain term was wrongly changed and no class reference was left behind.

### Verification (NO MOCKS)
- `ty check emgio` clean (**blocking**) — guarantees no undefined `EMG` remains in source.
- Full suite: **381 passed, 4 skipped**; ruff check + format clean.
- New `test_recording_alias.py` asserts: `emgio.EMG` and `from emgio.core.emg import EMG` both resolve to `Recording` **with** a `DeprecationWarning`, the alias is still constructible, `emgio.Recording` access does **not** warn, and an unknown attribute still raises `AttributeError`.
- Sweeps confirm **zero** over-migration (no `channel_type="Recording"`, "Recording signal", etc.) and **zero** "EMG object" instance mentions remaining.

### Compatibility
`from emgio import EMG` / `emgio.EMG` keep working through 0.5.x (with a deprecation warning). Migrate to `Recording`; `EMG` is removed in 1.0.0.

### Next
0.6.0 = Zarr PRD epic (with Parquet/Arrow folded into the serialization story); v1.0.0 = `emgio` -> `biosigio` package rename + drop the `EMG` alias.