### PR TITLE
Release 0.6.0: serialization & serving consolidation (Zarr PRD-compat + Parquet/Arrow)

### DIFF
--- a/.context/prototypes/biosignal_zarr_PRD.md
+++ b/.context/prototypes/biosignal_zarr_PRD.md
@@ -94,6 +94,19 @@ Key contract points:
 - **`physical = digital * scale + offset`**, per channel, when `dtype="int16"`. For `float32` the scale is 1 and offset is 0.
 - **Events** are stored as onset, duration, and an integer code per event, with a portable code to label map. This stays compact when there are many events with few unique labels.
 
+### Implementation notes (as shipped in emgio 0.6.0)
+
+These clarify the contract to match the reference implementation (`emgio/exporters/zarr.py`, `emgio/importers/zarr.py`). Readers built to this PRD should rely on them:
+
+- **`format_version` is `2`** (`format = "biosigio-zarr"`). Readers should accept a version less than or equal to the one they know and reject a newer one. Version 2 stores `recording_metadata` as a **native JSON object** (directly readable by a browser/zarrita client); version 1 stored it as a JSON string. Both encode non-JSON values (datetime, date, numpy) as typed envelopes `{"__biosigio_type__": "datetime"|"date", "value": ...}`; a reader detects and decodes these.
+- **Group directory names encode the TARGET (served) rate**, not the native rate (e.g. a 500 Hz native EEG group is named `eeg_250hz`). Address groups by the names in the root `channel_groups` attribute, never by reconstructing from a native rate. The native rate is recovered from the group `original_rate` attribute.
+- **`original_rate` has two scopes:** the group-level `original_rate` is the integer-rounded grouping key, while the per-channel `channels[].original_rate` is the true (possibly fractional) acquisition rate. Use the per-channel value for exact provenance.
+- **The `level 0` array also carries an `anti_aliased` boolean** (group-level summary; true if any channel was anti-alias resampled) in addition to the per-channel `channels[].anti_aliased`.
+- **`usable_for_inference` on `level 0`** is true for groups with at least one continuous channel and **false for a group composed solely of discrete channels** (TRIG/SYSCLOCK/CTRL).
+- **`int16` storage rejects non-finite samples** (NaN/inf) with a clear error; use `dtype="float32"` to preserve NaN gaps. A reader can therefore assume an `int16` store has no NaN.
+- **Resampling and grouping operate on rates rounded to the nearest integer Hz**, so for a fractional acquisition rate the effective polyphase ratio is approximate (the exact native rate is preserved in `channels[].original_rate`).
+- The root carries one extra free-text `note` attribute (human-readable provenance); readers may ignore it.
+
 ---
 
 ## 5. Signal-processing requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,8 @@ uv run mkdocs serve                                # Build docs
 ## Project-Specific Guidelines
 
 ### Supported Formats
-- **Import:** EEGLAB .set, Delsys Trigno, OTB, EDF/BDF(+), WFDB, CSV
-- **Export:** EDF/BDF(+) with automatic format selection
+- **Import:** EEGLAB .set, Delsys Trigno, OTB, EDF/BDF(+), WFDB, CSV, XDF, MEG (.fif/CTF .ds, via MNE), BrainVision (.vhdr, via MNE), proprietary electrophysiology (Intan/Blackrock/Spike2/Plexon/Micromed/Neuralynx, via python-neo), and the biosigIO serialization formats (Parquet/Arrow/Feather, Zarr)
+- **Export:** EDF/BDF(+) with automatic format selection; serialization and serving formats: Parquet and Arrow/Feather (lossless columnar, `arrow` extra), Zarr (cloud-native serving store, `zarr` extra)
 
 ### Key Classes
 - `Recording` (emgio/core) — main class for data handling

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The documentation including installation instructions, examples, and API referen
   
 - Export to standardized formats:
   - EDF/BDF(+) with channels.tsv metadata (automatically selects format based on signal properties, preserves annotations)
+
+- Serialization & serving (see [docs](https://neuromechanist.github.io/emgio/formats/serialization/)):
+  - Parquet and Arrow/Feather: lossless columnar round-trip (analytics, fast IPC); requires the `arrow` extra
+  - Zarr: cloud-native serving store (one store serves viewing, inference, and training), a derived downsampled copy; requires the `zarr` extra
   
 - Data manipulation:
   - Channel selection

--- a/docs/api/exporters/tabular.md
+++ b/docs/api/exporters/tabular.md
@@ -1,0 +1,35 @@
+# Tabular Exporter (Parquet / Arrow)
+
+Exports a `Recording` to the columnar biosigIO formats: Parquet (analytics) and
+Arrow/Feather (fast zero-copy IPC). Both are lossless and round-trip via
+`Recording.from_file`. Requires the `arrow` extra (pyarrow).
+
+See [Serialization & Serving Formats](../../formats/serialization.md) for when to
+use each format.
+
+## Module Documentation
+
+::: emgio.exporters.tabular
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file("data.edf")
+rec.to_parquet("out.parquet")   # analytics (DuckDB/Polars/pandas/Spark)
+rec.to_arrow("out.feather")     # fast zero-copy IPC
+
+# Lossless round-trip (auto-detected by extension)
+rt = Recording.from_file("out.parquet")
+```
+
+## Canonical Schema
+
+Both formats embed a self-describing, versioned `biosigio` metadata blob (see
+[`emgio.tabular_schema`](../../formats/serialization.md)) carrying channels,
+events, and recording metadata, so the file reconstructs the `Recording` exactly.

--- a/docs/api/exporters/zarr.md
+++ b/docs/api/exporters/zarr.md
@@ -1,0 +1,27 @@
+# Zarr Exporter (serving store)
+
+Exports a `Recording` to a sharded Zarr v3 serving store: an anti-aliased,
+per-modality-resampled `level 0` inference signal plus a min/max view pyramid for
+rendering. A derived serving copy, not an archival source. Requires the `zarr`
+extra (zarr v3).
+
+See [Zarr Serving Store](../../formats/zarr.md) for the on-disk store contract and
+serving model.
+
+## Module Documentation
+
+::: emgio.exporters.zarr
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file("data.edf")
+rec.to_zarr("out.zarr")                 # int16 by default (per-channel scale/offset)
+rec.to_zarr("lossless.zarr", dtype="float32")
+```

--- a/docs/api/importers/tabular.md
+++ b/docs/api/importers/tabular.md
@@ -1,0 +1,23 @@
+# Tabular Importer (Parquet / Arrow)
+
+Reads the columnar biosigIO formats (`.parquet`, `.feather`, `.arrow`) back into a
+`Recording`, reconstructing signals, channels, events, and metadata losslessly
+from the self-describing `biosigio` schema blob. Requires the `arrow` extra.
+
+## Module Documentation
+
+::: emgio.importers.tabular
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import Recording
+
+# Auto-detected by extension, or force importer="tabular"
+rec = Recording.from_file("out.parquet")
+rec = Recording.from_file("out.feather", importer="tabular")
+```

--- a/docs/api/importers/zarr.md
+++ b/docs/api/importers/zarr.md
@@ -1,0 +1,26 @@
+# Zarr Importer (serving store)
+
+Reconstructs a `Recording` from a biosigIO Zarr store, dequantizing `level 0`
+(`physical = digital * scale + offset`) and restoring channels, events, and
+metadata. The store is a derived serving copy, so reconstruction is at the store's
+canonical (possibly downsampled) rate, not the original full-rate signal. Requires
+the `zarr` extra.
+
+## Module Documentation
+
+::: emgio.importers.zarr
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true
+
+## Usage Example
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file("out.zarr")
+
+# A multi-rate store holds several (modality, rate) groups; pick one:
+eeg = Recording.from_file("rec.zarr", importer="zarr", group="eeg_250hz")
+```

--- a/docs/examples/serialization.md
+++ b/docs/examples/serialization.md
@@ -1,0 +1,138 @@
+# Serialization Round-Trip Examples
+
+This example demonstrates how to serialize a `Recording` to the biosigIO columnar
+and serving formats and read it back: Parquet and Arrow/Feather for lossless,
+analytics-friendly round trips, and Zarr for a cloud-native serving store with a
+multi-resolution view pyramid.
+
+These formats need optional dependencies. Parquet and Arrow/Feather use the
+`arrow` extra (the `pyarrow` package); Zarr uses the `zarr` extra (zarr v3):
+
+```bash
+# With uv (editable dev install)
+uv sync --extra arrow      # Parquet / Arrow / Feather
+uv sync --extra zarr       # Zarr serving store
+
+# Or with pip, into an existing environment
+pip install 'emgio[arrow]'
+pip install 'emgio[zarr]'
+```
+
+The examples below build a small `Recording` in memory so they run without any
+external data file. In practice you would load a recording from any supported
+format (EDF, WFDB, XDF, ...) and serialize that instead.
+
+```python
+import numpy as np
+from emgio import Recording
+
+# Build a small two-channel recording (1 second at 1000 Hz)
+fs = 1000.0
+t = np.arange(fs) / fs
+rec = Recording()
+rec.add_channel('EMG1', np.sin(2 * np.pi * 20 * t), fs, 'mV', 'EMG')
+rec.add_channel('EMG2', np.sin(2 * np.pi * 35 * t), fs, 'mV', 'EMG')
+rec.add_event(onset=0.25, duration=0.10, description='burst')
+```
+
+## Parquet Round-Trip
+
+`Recording.to_parquet()` writes a single self-describing columnar table: signal
+channels become columns (the time index is preserved), and channels, events, and
+recording metadata travel in the file's schema metadata. The round trip is
+**lossless and bit-exact**; sample values are stored verbatim, so no quantization
+or resampling occurs.
+
+```python
+# Export
+rec.to_parquet('out.parquet')
+
+# Read back; the '.parquet' extension selects the tabular importer automatically
+restored = Recording.from_file('out.parquet')
+
+# Signals are recovered exactly
+assert np.array_equal(rec.signals.to_numpy(), restored.signals.to_numpy())
+print(list(restored.channels.keys()))   # ['EMG1', 'EMG2']
+print(restored.events.iloc[0]['description'])  # 'burst'
+```
+
+Parquet is a good choice when you want to query signals with analytics engines
+(DuckDB, Polars, pandas, Spark) while keeping the full biosigIO metadata intact.
+
+## Arrow / Feather Round-Trip
+
+`Recording.to_arrow()` writes the same self-describing schema as Parquet, but in
+the Arrow/Feather inter-process communication (IPC) format for fast, zero-copy
+reads. It is also lossless and bit-exact.
+
+```python
+# Export (.feather or .arrow are both accepted)
+rec.to_arrow('out.feather')
+
+# Read back; the extension selects the tabular importer automatically
+restored = Recording.from_file('out.feather')
+
+assert np.array_equal(rec.signals.to_numpy(), restored.signals.to_numpy())
+```
+
+Both `to_parquet()` and `to_arrow()` return the written file path.
+
+## Zarr Export and Read
+
+`Recording.to_zarr()` writes a sharded Zarr v3 *serving* store. This is a derived
+serving copy, not an archival source: `level 0` of each channel group is the
+anti-aliased, per-modality-resampled inference signal, with a min/max render
+pyramid stacked above it for fast viewing. Channels are grouped by
+`(modality, native rate)`, so a single-rate EMG recording produces one group
+named like `emg_1000hz`.
+
+By default the store uses `int16` with a per-channel scale and offset (half the
+bytes of `float32`). Pass `dtype='float32'` for a lossless store.
+
+```python
+# Lossless store (float32). The default dtype='int16' is smaller but quantized.
+rec.to_zarr('out.zarr', dtype='float32')
+
+# Read back; the '.zarr' extension selects the Zarr importer automatically.
+# With a single channel group, no group= selector is needed.
+served = Recording.from_file('out.zarr')
+print(list(served.channels.keys()))   # ['EMG1', 'EMG2']
+```
+
+### Reading the serving signal, not the original
+
+The Zarr read returns the **downsampled serving signal**, not the original
+full-rate recording. `Recording.from_file` reconstructs `level 0` of the chosen
+group at the store's canonical (possibly downsampled) rate. The view pyramid
+(`view/*`) is render-only and is never read back as signal. Treat the source
+recording (for example a BIDS or EDF archive) as authoritative when you need the
+exact acquisition signal.
+
+```python
+# level 0 rate is the per-modality canonical rate (EMG caps at 1000 Hz by default),
+# capped to never exceed the native rate.
+fs_served = served.channels['EMG1']['sample_frequency']
+print(fs_served)   # 1000.0 here; lower than native for, e.g., a 2048 Hz source
+```
+
+### Selecting a group in a multi-rate store
+
+A store may hold several `(modality, rate)` groups that cannot share emgio's
+single time grid (for example an EEG group at 250 Hz and an EMG group at
+1000 Hz). When more than one group is present, pass the `group=` selector to
+choose which one to reconstruct:
+
+```python
+# Explicit importer plus group selector for a multi-rate store
+emg = Recording.from_file('rec.zarr', importer='zarr', group='emg_1000hz')
+eeg = Recording.from_file('rec.zarr', importer='zarr', group='eeg_250hz')
+```
+
+If you omit `group=` on a multi-group store, `from_file` raises a `ValueError`
+listing the available group names.
+
+## Choosing a Format
+
+For when to reach for Parquet, Arrow/Feather, or Zarr, including the
+lossless-versus-serving trade-offs and the on-disk store contract, see the
+[Serialization Formats](../formats/serialization.md) reference.

--- a/docs/formats/serialization.md
+++ b/docs/formats/serialization.md
@@ -1,0 +1,148 @@
+# Serialization & Serving Formats
+
+Besides EDF/BDF, emgio can serialize a `Recording` to three columnar or array
+formats: Parquet, Arrow/Feather, and Zarr. Each carries enough information to be
+read back without any side files, and all of them round-trip through the same
+entry point, `Recording.from_file`, which auto-detects the format from the file
+extension (`.parquet`, `.feather`, `.arrow`, `.zarr`).
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file('recording.edf')
+
+rec.to_parquet('recording.parquet')   # analytics
+rec.to_arrow('recording.feather')     # fast IPC
+rec.to_zarr('recording.zarr')         # cloud-native serving
+```
+
+## When to Use Which
+
+The three formats solve different jobs. Parquet and Arrow/Feather are
+lossless columnar tables for analysis and interchange; Zarr is a derived,
+downsampled and quantized serving store, not an archival source.
+
+| Format | Best for | Lossless | Notes |
+|--------|----------|----------|-------|
+| Parquet | Analytics (DuckDB, Polars, pandas, Spark) | Yes | Self-describing columnar table; one file per recording |
+| Arrow/Feather | Fast zero-copy inter-process communication (IPC) | Yes | Same schema as Parquet, optimized for speed over compression |
+| Zarr | Cloud-native serving: one store serves viewing, inference, and training | No | Derived, downsampled and quantized serving copy; the Brain Imaging Data Structure (BIDS) and EDF stay authoritative |
+
+Parquet and Arrow keep the full signal: channels become columns, the time index
+is preserved, and channels, events, and recording metadata travel in the file's
+schema. Use them whenever you want the recording back exactly as it was.
+
+Zarr is the serving format. A single conversion produces one cloud-native store
+that all three downstream consumers read directly from object storage: a viewer
+streams a min/max render pyramid, inference reads the anti-aliased base signal,
+and training streams shards of it. Because it is downsampled per modality and
+stored as scaled `int16` by default, it is a derived copy and not the source of
+truth. The original BIDS dataset (or EDF) remains the authoritative, citable
+artifact. See the [Zarr store contract](zarr.md) for the full layout.
+
+## Lossless vs Derived Round-Trip
+
+The two families round-trip differently, and the difference is intentional.
+
+**Parquet and Arrow are lossless.** Reading a `.parquet` or `.feather` file back
+restores the `Recording` exactly: signals (with their time index), channels,
+events, and recording metadata. The file holds everything needed to rebuild the
+object, so import is a faithful inverse of export.
+
+**Zarr is reconstructed, not restored.** The importer rebuilds a `Recording`
+from the store's canonical `level 0` signal, which is the anti-aliased,
+per-modality downsampled inference signal, so the reconstructed sampling rate is
+the store's canonical rate rather than the original acquisition rate. The
+per-channel Zarr-only attributes (the `scale`/`offset` quantization parameters,
+the `usable_for_inference` flags, the render pyramid) are applied during
+dequantization but are not surfaced back onto the reconstructed channels. The
+min/max view pyramid (`view/*`) is render-only and is never read on import.
+
+For both families, `source_file` is reset to the path you read from, while the
+original `source_format` provenance is preserved (a re-imported serialization
+file keeps the format it was originally converted from rather than being
+relabeled as `tabular` or `zarr`).
+
+## Self-Describing Schema
+
+Both families embed a versioned `biosigio` metadata blob so a reader can
+recognize and version-check the file before trusting it.
+
+- **Parquet and Arrow** carry the blob in the Arrow schema metadata
+  (`tabular_schema.FORMAT = "biosigio-tabular"`, `FORMAT_VERSION = 1`). It holds
+  the recording metadata, per-channel info, and events as one JSON object.
+- **Zarr** carries an equivalent blob in the store's root attributes
+  (`FORMAT = "biosigio-zarr"`, `FORMAT_VERSION = 2`), reusing the same metadata
+  encoding so both formats record state the same way.
+
+The encoding is lossless for values that are not native to JSON: datetimes and
+dates become a typed envelope and are reconstructed to their original Python type
+on read, and numpy scalars/arrays are converted to their Python equivalents.
+Metadata that cannot be serialized raises an error rather than being silently
+coerced to a string, because metadata loss is data loss.
+
+## Optional Dependencies
+
+These formats are not part of the core install; install the matching extra.
+
+| Format | Extra | Install |
+|--------|-------|---------|
+| Parquet, Arrow/Feather | `arrow` (pyarrow) | `uv sync --extra arrow` or `pip install 'emgio[arrow]'` |
+| Zarr | `zarr` (zarr v3) | `uv sync --extra zarr` or `pip install 'emgio[zarr]'` |
+
+If the extra is missing, the exporter and importer raise an `ImportError` with
+the exact install command, so you never get a partial or silent failure.
+
+## Round-Trip Examples
+
+### Parquet
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file('recording.edf')
+rec.to_parquet('recording.parquet')
+
+# Auto-detected from the .parquet extension; restored exactly.
+restored = Recording.from_file('recording.parquet')
+```
+
+### Arrow/Feather
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file('recording.edf')
+rec.to_arrow('recording.feather')
+
+restored = Recording.from_file('recording.feather')
+```
+
+### Zarr
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file('recording.edf')
+rec.to_zarr('recording.zarr')
+
+# Reconstructed at the store's canonical (downsampled) level-0 rate.
+served = Recording.from_file('recording.zarr')
+```
+
+A Zarr store can hold several `(modality, rate)` groups that cannot share a
+single time grid. When there is more than one group, pass `group=` to choose
+which to reconstruct:
+
+```python
+served = Recording.from_file('recording.zarr', group='eeg_250hz')
+```
+
+Keep these examples minimal; for the full store layout, tuning knobs, and the
+serving model, see the [Zarr store contract](zarr.md), and for end-to-end
+walk-throughs see the [serialization examples](../examples/serialization.md).
+
+## See Also
+
+- [Zarr Serving Store](zarr.md): the on-disk contract, signal rules, and serving model.
+- [Serialization Examples](../examples/serialization.md): worked round-trip examples.

--- a/docs/formats/zarr.md
+++ b/docs/formats/zarr.md
@@ -1,0 +1,179 @@
+# Zarr Serving Store
+
+EMGIO can export a recording to a biosigIO Zarr serving store: a single, cloud-native store that serves three downstream jobs from one conversion, namely fast interactive viewing on thin clients, edge and batch inference, and training-time streaming. This page documents the store contract and the serving model so the consumers of the store (a web viewer, an inference service, a training loader, a batch converter) can read it correctly. Those consumers are built elsewhere; EMGIO only produces and reads the store.
+
+## Overview
+
+The store is a sharded Zarr version 3 (v3) store with one group per (modality, native rate) pair. Level 0 of every group is the anti-aliased inference signal, resampled to a per-modality canonical rate, with a min/max view pyramid above it for rendering.
+
+The store is a derived serving copy, not an archive. The Brain Imaging Data Structure (BIDS) dataset, and the European Data Format (EDF) files alongside it, remain the authoritative source of truth and the citable artifact. The Zarr store is reproducible from them, and the downsampling parameters are recorded in the store attributes so the derivation is documented.
+
+Zarr is an optional dependency (the `zarr` extra, which installs zarr v3) and is imported lazily. Install it with one of:
+
+```bash
+uv sync --extra zarr        # development install
+pip install 'emgio[zarr]'   # existing environment
+```
+
+Write a store with `Recording.to_zarr`:
+
+```python
+from emgio import Recording
+
+rec = Recording.from_file('recording.edf')
+
+# Defaults: int16 storage, per-modality rate caps, min/max view pyramid
+store_path = rec.to_zarr('recording.zarr')
+print(store_path)  # 'recording.zarr'
+```
+
+## Store layout
+
+One Zarr v3 root group holds the whole recording. Both the writer and the reader honor this layout:
+
+```
+/                              root group
+  attrs: biosigio_version, format="biosigio-zarr", format_version,
+         source_format, modality_rates, dtype, view_downsample,
+         anti_alias_filter, channel_groups, recording_metadata, created_utc
+
+  <modality>_<rate>hz/         one group per (modality, native rate)
+    attrs: modality, rate, original_rate, n_channels, n_samples, channels[]
+    0                          (n_ch, n_time) level-0 signal, sharded
+      attrs: level=0, rate, downsample_factor=1, kind="signal",
+             usable_for_inference, scale[], offset[],
+             physical_formula="physical = digital * scale + offset"
+    view/                      min/max render pyramid (not sharded)
+      1, 2, ...                (2, n_ch, n_time_L), axis0 = [min, max]
+        attrs: level, downsample_factor, rate_effective,
+               kind="minmax_envelope", usable_for_inference=false
+
+  events/
+    onset (f64), duration (f64), code (i32)
+    attrs: label_map {code: description}, n_events
+```
+
+The group name encodes the served (target) rate, not the source rate, for example `eeg_250hz` even when the source was recorded at 500 Hz. The two rates are both kept in the group attributes:
+
+- `group.attrs['rate']` is the served target rate (the rate of level 0).
+- `group.attrs['original_rate']` is the integer-rounded native rate used as the grouping key.
+- Each entry in `group.attrs['channels'][].original_rate` is the true per-channel acquisition rate as a float, so a non-integer source rate (for example 511.7 Hz) is preserved even though the group key rounds it (metadata loss is data loss).
+
+The level-0 array carries the per-channel `scale` and `offset`. Reconstruct physical units with:
+
+```
+physical = digital * scale + offset
+```
+
+Per-channel metadata lives in each group's `channels` attribute, one object per channel with these keys:
+
+`label`, `channel_type`, `modality`, `unit`, `prefilter`, `original_rate`, `target_rate`, `anti_aliased`, `usable_for_inference`, `scale`, `offset`, `row_index`.
+
+The `row_index` maps a channel to its row in the `(n_ch, n_time)` level-0 array.
+
+## Level 0 vs view/*
+
+The two array tiers exist for different jobs and are downsampled by deliberately different rules:
+
+- **Level 0** is the anti-aliased inference signal, one sample per time step at the group's canonical rate. Inference and training read this tier. Its `usable_for_inference` flag is `true` for groups that contain at least one continuous channel and `false` for a group made up entirely of discrete channels.
+- **view/\*** are min/max render envelopes. Each level stores two values per downsample bin, the minimum and the maximum, on axis 0 (`[min, max]`). Envelopes preserve visible transients so brief spikes do not vanish when zoomed out, which is why they are nonlinear and are flagged `usable_for_inference=false`. Never train or run inference on the view tier.
+
+The two downsampling philosophies coexist on purpose: anti-aliased polyphase resampling for level 0, min/max binning for view/*.
+
+## Per-modality rates and dtype
+
+**Rate caps.** Level 0 is resampled to `target = min(native, cap)` per modality, and the store never upsamples. The default caps are:
+
+| Modality | Default cap (Hz) |
+|---|---|
+| EEG | 250 |
+| MEG | 250 |
+| iEEG (SEEG, ECoG, DBS) | 1000 |
+| EMG | 1000 |
+| Other (BEH, MISC, ...) | native (no cap) |
+
+A modality absent from the cap table keeps its native rate. Override the caps per call with the `modality_rates` argument:
+
+```python
+# Keep MEG high-gamma by raising its cap; EEG stays at the default
+rec.to_zarr('recording.zarr', modality_rates={'MEG': 1000, 'EEG': 250})
+```
+
+**Storage dtype.** The default `dtype="int16"` stores each channel with a per-channel `scale` and `offset` (half the bytes of float32; consumers cast on read). int16 cannot represent NaN or inf, so the exporter rejects non-finite samples rather than silently corrupting them; use `dtype="float32"` (lossless, and it keeps NaN) when a channel carries gaps:
+
+```python
+rec.to_zarr('recording.zarr', dtype='float32')
+```
+
+**Discrete channels.** Trigger and clock channel types (`TRIG`, `SYSCLOCK`, `CTRL`) are resampled by nearest sample with no anti-alias filter so step edges survive, and they are flagged `usable_for_inference=false`.
+
+**Heterogeneous channels.** Channels are grouped by (modality, native rate), so each array stays length-consistent. A common single-rate recording yields one group per modality; a genuinely mixed-rate source yields one group per rate, which is faithful rather than silently resampled together.
+
+## Reading a store
+
+Read a store back into a `Recording` with `Recording.from_file`. The `.zarr` extension is auto-detected, or pass `importer='zarr'` explicitly:
+
+```python
+from emgio import Recording
+
+# Extension-inferred
+rec = Recording.from_file('recording.zarr')
+
+# Explicit importer
+rec = Recording.from_file('recording.zarr', importer='zarr')
+```
+
+The importer reads level 0 of one group, applies the `physical = digital * scale + offset` dequantization, and restores channels, events, and recording metadata. The view pyramid is render-only and is never read here.
+
+Because the groups in a store can sit at different rates that cannot share EMGIO's single time grid, the importer reconstructs one group at a time. When a store holds a single group it is selected automatically; when it holds more than one, pass the `group=` selector by group name. Calling `from_file` on a multi-group store without `group=` raises an error that lists the available groups:
+
+```python
+# Multi-group store: choose which (modality, rate) group to reconstruct
+rec = Recording.from_file('recording.zarr', importer='zarr', group='eeg_250hz')
+```
+
+Reconstruction is at the store's canonical (possibly downsampled) level-0 rate, not the original full-rate signal, because the store is the serving copy and BIDS remains the source of truth.
+
+## Format version and provenance
+
+The root group attributes carry the format tag and version so a reader can recognize and version-check a store:
+
+- `format` is `"biosigio-zarr"`.
+- `format_version` is currently `2`. In version 2, `recording_metadata` is a native JSON object, with non-JSON-native values such as datetimes carried in typed envelopes, so a browser or zarrita reader can consume it without a second parse. Version 1 stored `recording_metadata` as a JSON string; the reader still accepts version 1 stores.
+
+A reader should reject a store whose `format_version` is newer than the one it supports rather than guess at an unknown layout. The EMGIO importer does exactly this: it raises if the store's version exceeds the version this build reads.
+
+## Serving model (external)
+
+The viewing, inference, training, and batch-conversion layers live outside EMGIO. EMGIO only writes and reads the store; the sections below summarize the intended serving model so those external consumers can be built against the same contract.
+
+**Reads need no backend.** A Zarr v3 store is objects plus JSON, so a browser reader (zarrita) streams it directly from object storage over HTTPS using ranged GETs. The viewing path has no decode service.
+
+**Cross-Origin Resource Sharing (CORS) is the one hard requirement.** The bucket must allow browser GET, HEAD, and Range requests, and expose the ETag and Content-Length headers.
+
+**A Content Delivery Network (CDN) is recommended for a public production viewer.** A viewport pulls several small chunk objects; an edge CDN with HTTP/2 or HTTP/3 multiplexing shares one connection across those fetches, caches the small, shared coarse pyramid levels at the edge, and collapses request count and origin egress. The viewer code is identical with or without a CDN, since zarrita reads object URLs; ship on object storage plus CORS, then front it with a CDN by changing the base URL. The hot viewing path stays CDN-friendly because the view levels are not sharded.
+
+**Reader contracts** for the three consumers:
+
+- **Viewer:** read the root and group attributes, pick the pyramid level whose `rate_effective` puts roughly one sample per screen pixel, fetch the chunks covering the viewport, and render the min/max band using each channel's `scale` and `offset`. At maximum zoom, read level 0 directly. Group the display by modality and overlay events from the `events` group.
+- **Inference:** read level 0 of the relevant group, apply scale and offset, and window the signal. Never read view/*. For a lower analysis rate, derive it on read from level 0 with an anti-aliased resample rather than persisting a third tier.
+- **Training:** iterate shards of level 0 sequentially, one object per shard and many windows per object, shuffling at the shard level plus a within-shard buffer.
+
+## Default parameters
+
+The exporter defaults follow the store specification. Override any of them as keyword arguments to `to_zarr`:
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `modality_rates` | EEG 250, MEG 250, iEEG 1000, EMG 1000 | Per-modality canonical rate cap |
+| `dtype` | `int16` | Storage type; `float32` for lossless (keeps NaN) |
+| `view_downsample` | 4 | Time decimation factor between pyramid levels |
+| `min_view_samples` | 512 | Stop building pyramid levels at this length |
+| `chunk_seconds` | 4 | Random-access grain |
+| `shard_seconds` | 300 | Sequential-read grain, rounded to whole chunks |
+| `compressor_level` | 5 | zstd compression level (Blosc codec) |
+
+```python
+# A lossless store with a shorter sequential-read grain
+rec.to_zarr('recording.zarr', dtype='float32', shard_seconds=120)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,10 @@ EMGIO simplifies this process by providing a standardized interface for loading,
   - Smart handling of precision requirements
   - BIDS-compatible metadata formatting
   - Annotation export (EDF+/BDF+)
+
+- **Serialization & serving** (see [Serialization & Serving](formats/serialization.md)):
+  - Parquet and Arrow/Feather: lossless columnar round-trip (analytics, fast IPC); `arrow` extra
+  - Zarr: cloud-native serving store (viewing, inference, and training from one store), a derived downsampled copy; `zarr` extra
   
 - **Data manipulation**:
   - Channel selection

--- a/emgio/core/emg.py
+++ b/emgio/core/emg.py
@@ -110,7 +110,9 @@ class Recording:
         """
         Infer the importer to use based on the file extension.
         """
-        extension = os.path.splitext(filepath)[1].lower()
+        # rstrip path separators so a Zarr store passed as a directory with a
+        # trailing slash (e.g. "rec.zarr/") still resolves by its ".zarr" suffix.
+        extension = os.path.splitext(filepath.rstrip("/\\"))[1].lower()
         if extension in {".edf", ".bdf"}:
             return "edf"
         elif extension in {".set"}:
@@ -246,6 +248,11 @@ class Recording:
 
         # Create importer instance and load data
         emg = importer_class().load(filepath, **kwargs)
+
+        # Record provenance: which format this recording came from. setdefault so a
+        # re-imported serialization file (tabular/zarr) keeps the ORIGINAL
+        # source_format restored from its metadata rather than being relabeled.
+        emg.metadata.setdefault("source_format", importer)
 
         # In a BIDS layout, the sibling _channels.tsv is the authoritative source
         # of per-channel type/units; apply it over the importer's header/label
@@ -729,8 +736,8 @@ class Recording:
         """
         from ..exporters.zarr import ZarrExporter
 
-        if self.signals is None:
-            raise ValueError("No signals loaded")
+        # The empty-signal guard lives once, in ZarrExporter.export ("No signals
+        # loaded"), matching the tabular path; no duplicate guard here.
         return ZarrExporter.export(self, filepath, **kwargs)
 
     def set_metadata(self, key: str, value: Any) -> None:

--- a/emgio/exporters/tabular.py
+++ b/emgio/exporters/tabular.py
@@ -8,7 +8,7 @@ optional dependency (the ``arrow`` extra), imported lazily.
 """
 
 from ..core.emg import Recording
-from ..tabular_schema import recording_to_table
+from ..tabular_schema import recording_to_table, require_pyarrow
 
 
 class TabularExporter:
@@ -16,8 +16,16 @@ class TabularExporter:
 
     @staticmethod
     def to_parquet(rec: Recording, filepath: str) -> str:
-        # recording_to_table calls require_pyarrow() (clear install hint) before
-        # we import the pyarrow.parquet submodule.
+        """Write ``rec`` to a self-describing biosigIO Parquet file.
+
+        Args:
+            rec: Source recording.
+            filepath: Output ``.parquet`` path.
+
+        Returns:
+            The written file path.
+        """
+        require_pyarrow()  # clear install hint before touching the pyarrow submodule
         table = recording_to_table(rec)
         import pyarrow.parquet as pq
 
@@ -26,6 +34,16 @@ class TabularExporter:
 
     @staticmethod
     def to_arrow(rec: Recording, filepath: str) -> str:
+        """Write ``rec`` to a biosigIO Arrow/Feather file (fast zero-copy IPC).
+
+        Args:
+            rec: Source recording.
+            filepath: Output ``.feather`` / ``.arrow`` path.
+
+        Returns:
+            The written file path.
+        """
+        require_pyarrow()
         table = recording_to_table(rec)
         import pyarrow.feather as feather
 

--- a/emgio/exporters/zarr.py
+++ b/emgio/exporters/zarr.py
@@ -41,13 +41,14 @@ import numpy as np
 from scipy.signal import resample_poly
 
 from ..core.emg import Recording
-from ..tabular_schema import metadata_to_json
+from ..tabular_schema import metadata_to_mapping
 from ..version import __version__ as _BIOSIGIO_VERSION
 
 # Format tag/version for the root attrs, so a reader can recognize and
-# version-check a biosigIO Zarr store.
+# version-check a biosigIO Zarr store. v2 stores ``recording_metadata`` as a
+# native JSON object (v1 stored it as a JSON string); the reader accepts both.
 FORMAT = "biosigio-zarr"
-FORMAT_VERSION = 1
+FORMAT_VERSION = 2
 
 # Per-modality canonical inference rate (Hz). target = min(native, cap); a
 # modality absent from this map keeps its native rate.
@@ -407,9 +408,10 @@ class ZarrExporter:
                 "view_downsample": view_downsample,
                 "anti_alias_filter": "scipy.signal.resample_poly (polyphase FIR)",
                 "channel_groups": written_groups,
-                # Lossless JSON (datetimes/numpy survive), shared with the tabular
-                # schema, instead of a lossy str() dump.
-                "recording_metadata": metadata_to_json(rec.metadata),
+                # Native JSON object (datetimes/numpy as typed envelopes), shared
+                # with the tabular schema, so a browser/zarrita reader can consume
+                # it directly without a second parse and without a lossy str() dump.
+                "recording_metadata": metadata_to_mapping(rec.metadata),
                 "created_utc": _dt.datetime.now(_dt.UTC).isoformat(),
                 "note": (
                     "Derived serving copy. level 0 of each group is the anti-aliased "

--- a/emgio/importers/tabular.py
+++ b/emgio/importers/tabular.py
@@ -31,4 +31,6 @@ class TabularImporter(BaseImporter):
                 table = feather.read_table(filepath)
         except Exception as e:
             raise ValueError(f"Error reading tabular file {filepath}: {e}") from e
-        return table_to_recording(table)
+        rec = table_to_recording(table)
+        rec.set_metadata("source_file", filepath)
+        return rec

--- a/emgio/importers/zarr.py
+++ b/emgio/importers/zarr.py
@@ -23,8 +23,8 @@ import numpy as np
 import pandas as pd
 
 from ..core.emg import Recording
-from ..exporters.zarr import FORMAT, require_zarr
-from ..tabular_schema import metadata_from_json
+from ..exporters.zarr import FORMAT, FORMAT_VERSION, require_zarr
+from ..tabular_schema import metadata_from_mapping
 from .base import BaseImporter
 
 
@@ -51,6 +51,12 @@ class ZarrImporter(BaseImporter):
             raise ValueError(
                 f"Not a biosigIO Zarr store: root 'format' is {root_attrs.get('format')!r}, "
                 f"expected {FORMAT!r}. Only stores written by emgio's Zarr exporter can be read."
+            )
+        version = root_attrs.get("format_version", 1)
+        if not isinstance(version, int) or version > FORMAT_VERSION:
+            raise ValueError(
+                f"Unsupported biosigIO Zarr store version {version!r}; this build reads up to "
+                f"version {FORMAT_VERSION}. Upgrade emgio to read this store."
             )
 
         signal_groups = [name for name in root.keys() if name != "events"]
@@ -84,8 +90,9 @@ class ZarrImporter(BaseImporter):
         self._add_events(rec, root)
 
         meta_blob = root_attrs.get("recording_metadata")
-        if isinstance(meta_blob, str):
-            rec.metadata = metadata_from_json(meta_blob)
+        if meta_blob is not None:
+            # Accepts both a native object (v2) and a legacy JSON string (v1).
+            rec.metadata = metadata_from_mapping(meta_blob)
         rec.set_metadata("source_file", filepath)
         return rec
 

--- a/emgio/importers/zarr.py
+++ b/emgio/importers/zarr.py
@@ -52,8 +52,14 @@ class ZarrImporter(BaseImporter):
                 f"Not a biosigIO Zarr store: root 'format' is {root_attrs.get('format')!r}, "
                 f"expected {FORMAT!r}. Only stores written by emgio's Zarr exporter can be read."
             )
+        # Accept an integral version (int, or a float like 2.0 from a hand-edited
+        # or non-Python writer); reject non-numeric or a newer store.
         version = root_attrs.get("format_version", 1)
-        if not isinstance(version, int) or version > FORMAT_VERSION:
+        try:
+            is_supported = int(version) == version and int(version) <= FORMAT_VERSION
+        except (TypeError, ValueError):
+            is_supported = False
+        if not is_supported:
             raise ValueError(
                 f"Unsupported biosigIO Zarr store version {version!r}; this build reads up to "
                 f"version {FORMAT_VERSION}. Upgrade emgio to read this store."

--- a/emgio/tabular_schema.py
+++ b/emgio/tabular_schema.py
@@ -26,10 +26,11 @@ if TYPE_CHECKING:
     from .core.emg import Recording
 
 # Schema-metadata key + format tag/version, so a reader can recognize and
-# version-check a biosigIO tabular file.
+# version-check a biosigIO tabular file. (``FORMAT_VERSION`` mirrors the Zarr
+# exporter's constant name so the two serialization formats read in parallel.)
 METADATA_KEY = b"biosigio"
 FORMAT = "biosigio-tabular"
-VERSION = 1
+FORMAT_VERSION = 1
 
 
 def require_pyarrow():
@@ -101,11 +102,32 @@ def metadata_from_json(blob: str) -> dict:
     return json.loads(blob, object_hook=_json_object_hook)
 
 
+def metadata_to_mapping(metadata) -> dict:
+    """Encode metadata as a JSON-native dict (datetimes/numpy as typed envelopes).
+
+    Like :func:`metadata_to_json` but returns the parsed object rather than a
+    string, so it can be stored directly as a Zarr attribute that a browser /
+    zarrita reader can consume without a second JSON parse.
+    """
+    return json.loads(metadata_to_json(metadata))
+
+
+def metadata_from_mapping(obj) -> dict:
+    """Reconstruct metadata from either a mapping (new) or a JSON string (legacy).
+
+    Zarr stores < 0.6 wrote ``recording_metadata`` as a JSON string; 0.6+ stores
+    it as a native object. Accept both so older stores still round-trip.
+    """
+    if isinstance(obj, str):
+        return metadata_from_json(obj)
+    return json.loads(json.dumps(obj), object_hook=_json_object_hook)
+
+
 def recording_to_table(rec: Recording) -> pa.Table:
     """Build a pyarrow Table from a Recording (signals + biosigio metadata blob)."""
     pa = require_pyarrow()
     if rec.signals is None:
-        raise ValueError("No signals to serialize")
+        raise ValueError("No signals loaded")
 
     table = pa.Table.from_pandas(rec.signals, preserve_index=True)
     events = (
@@ -114,7 +136,7 @@ def recording_to_table(rec: Recording) -> pa.Table:
     blob = json.dumps(
         {
             "format": FORMAT,
-            "version": VERSION,
+            "version": FORMAT_VERSION,
             "metadata": dict(rec.metadata),
             "channels": {name: dict(info) for name, info in rec.channels.items()},
             "events": events,
@@ -138,10 +160,10 @@ def table_to_recording(table: pa.Table) -> Recording:
     meta = json.loads(blob, object_hook=_json_object_hook)
     if meta.get("format") != FORMAT:
         raise ValueError(f"Unexpected tabular format tag: {meta.get('format')!r}")
-    if meta.get("version") != VERSION:
+    if meta.get("version") != FORMAT_VERSION:
         raise ValueError(
             f"Unsupported biosigIO tabular schema version {meta.get('version')!r} "
-            f"(this build reads version {VERSION})."
+            f"(this build reads version {FORMAT_VERSION})."
         )
 
     rec = Recording()

--- a/emgio/tests/test_serialization.py
+++ b/emgio/tests/test_serialization.py
@@ -1,0 +1,125 @@
+"""Cross-format serialization-consolidation tests (0.6.0).
+
+NO MOCKS: real Recordings (synthetic real signals) and real files/stores. Covers
+the behaviors shared by the Parquet/Arrow/Zarr serialization story: source_format
+provenance, Zarr ``recording_metadata`` as a native object (with v1 JSON-string
+back-compat), Zarr ``format_version`` validation, ``.zarr`` trailing-slash
+inference, and the unified empty-signal error message.
+"""
+
+import datetime
+import pathlib
+
+import numpy as np
+import pytest
+
+from emgio import Recording
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EMG_EDF = _REPO / "examples/bids/emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
+_STARTDATE = datetime.datetime(2026, 5, 31, 9, 30, 0)
+
+
+def _rec():
+    rec = Recording()
+    rec.add_channel("C1", np.sin(np.arange(500) / 7.0), 250, "uV", "EEG")
+    rec.set_metadata("startdate", _STARTDATE)
+    return rec
+
+
+# --- source_format provenance (set centrally in from_file) ---
+
+
+@pytest.mark.skipif(not EMG_EDF.exists(), reason="EMG fixture missing")
+def test_from_file_sets_source_format():
+    rec = Recording.from_file(str(EMG_EDF))
+    assert rec.metadata["source_format"] == "edf"
+
+
+def test_fresh_tabular_import_gets_tabular_source_format(tmp_path):
+    pytest.importorskip("pyarrow")
+    out = tmp_path / "r.parquet"
+    _rec().to_parquet(str(out))
+    rt = Recording.from_file(str(out))
+    assert rt.metadata["source_format"] == "tabular"
+
+
+def test_reimport_preserves_original_source_format(tmp_path):
+    pytest.importorskip("pyarrow")
+    rec = _rec()
+    rec.set_metadata("source_format", "edf")  # as if loaded from EDF then re-serialized
+    out = tmp_path / "r.parquet"
+    rec.to_parquet(str(out))
+    rt = Recording.from_file(str(out))
+    assert rt.metadata["source_format"] == "edf"  # not relabeled to "tabular"
+
+
+# --- Zarr recording_metadata as a native, browser-readable object ---
+
+
+def test_zarr_recording_metadata_is_native_object(tmp_path):
+    zarr = pytest.importorskip("zarr")
+    out = _rec().to_zarr(str(tmp_path / "r"))
+    root = zarr.open_group(store=zarr.storage.LocalStore(out), mode="r")
+    md = dict(root.attrs)["recording_metadata"]
+    assert isinstance(md, dict)  # a native object, not a JSON-encoded string
+    # datetime is a typed envelope a zarrita/JS reader can detect and decode
+    assert md["startdate"]["__biosigio_type__"] == "datetime"
+
+    rt = Recording.from_file(out)
+    assert rt.metadata["startdate"] == _STARTDATE
+    assert type(rt.metadata["startdate"]) is datetime.datetime
+
+
+def test_zarr_reads_legacy_v1_string_metadata(tmp_path):
+    """A pre-0.6 store wrote recording_metadata as a JSON string; still reads."""
+    zarr = pytest.importorskip("zarr")
+    from emgio.tabular_schema import metadata_to_json
+
+    rec = _rec()
+    out = rec.to_zarr(str(tmp_path / "r"))
+    root = zarr.open_group(store=zarr.storage.LocalStore(out), mode="a")
+    root.attrs["recording_metadata"] = metadata_to_json(rec.metadata)  # v1 form
+    root.attrs["format_version"] = 1
+    rt = Recording.from_file(out)
+    assert rt.metadata["startdate"] == _STARTDATE
+
+
+def test_zarr_rejects_future_format_version(tmp_path):
+    zarr = pytest.importorskip("zarr")
+    out = _rec().to_zarr(str(tmp_path / "r"))
+    root = zarr.open_group(store=zarr.storage.LocalStore(out), mode="a")
+    root.attrs["format_version"] = 99
+    with pytest.raises(ValueError, match="Unsupported biosigIO Zarr store version"):
+        Recording.from_file(out)
+
+
+# --- .zarr directory inference robust to a trailing slash ---
+
+
+def test_zarr_trailing_slash_infers_importer(tmp_path):
+    pytest.importorskip("zarr")
+    out = _rec().to_zarr(str(tmp_path / "r"))
+    rt = Recording.from_file(out + "/")  # directory path with trailing separator
+    assert isinstance(rt, Recording)
+    assert rt.signals is not None and "C1" in rt.signals.columns
+
+
+def test_infer_importer_zarr_trailing_slash():
+    assert Recording._infer_importer("store.zarr/") == "zarr"
+    assert Recording._infer_importer("store.zarr") == "zarr"
+
+
+# --- unified empty-signal error message across the serialization writers ---
+
+
+def test_empty_recording_to_parquet_unified_message(tmp_path):
+    pytest.importorskip("pyarrow")
+    with pytest.raises(ValueError, match="No signals loaded"):
+        Recording().to_parquet(str(tmp_path / "x.parquet"))
+
+
+def test_empty_recording_to_zarr_unified_message(tmp_path):
+    pytest.importorskip("zarr")
+    with pytest.raises(ValueError, match="No signals loaded"):
+        Recording().to_zarr(str(tmp_path / "x"))

--- a/emgio/tests/test_serialization.py
+++ b/emgio/tests/test_serialization.py
@@ -119,6 +119,12 @@ def test_empty_recording_to_parquet_unified_message(tmp_path):
         Recording().to_parquet(str(tmp_path / "x.parquet"))
 
 
+def test_empty_recording_to_arrow_unified_message(tmp_path):
+    pytest.importorskip("pyarrow")
+    with pytest.raises(ValueError, match="No signals loaded"):
+        Recording().to_arrow(str(tmp_path / "x.feather"))
+
+
 def test_empty_recording_to_zarr_unified_message(tmp_path):
     pytest.importorskip("zarr")
     with pytest.raises(ValueError, match="No signals loaded"):

--- a/emgio/tests/test_tabular.py
+++ b/emgio/tests/test_tabular.py
@@ -48,11 +48,15 @@ def test_tabular_roundtrip_is_lossless(tmp_path, ext, method):
     assert rt.events["onset"].dtype == np.float64
 
     # Recording metadata preserved with TYPES intact (e.g. startdate stays a
-    # datetime, not silently coerced to a string).
+    # datetime, not silently coerced to a string). source_file is the exception:
+    # like every importer, TabularImporter resets it to the path it just read.
     for key, value in rec.metadata.items():
+        if key == "source_file":
+            continue
         assert key in rt.metadata, f"metadata key {key!r} dropped"
         assert type(rt.metadata[key]) is type(value), f"metadata[{key!r}] type changed"
         assert rt.metadata[key] == value, f"metadata[{key!r}] value changed"
+    assert rt.metadata["source_file"] == str(out)
 
 
 @requires_emg

--- a/emgio/version.py
+++ b/emgio/version.py
@@ -1,7 +1,7 @@
 """Version information for EMGIO."""
 
-__version__ = "0.5.0"
-__version_info__ = (0, 5, 0)
+__version__ = "0.6.0"
+__version_info__ = (0, 6, 0)
 
 
 def get_version() -> str:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,9 @@ nav:
     - CSV: formats/csv.md
     - WFDB: formats/wfdb.md
     - XDF: formats/xdf.md
+  - Serialization & Serving:
+    - Overview (Parquet/Arrow/Zarr): formats/serialization.md
+    - Zarr Serving Store: formats/zarr.md
   - API Reference:
     - Recording Class: api/emg.md
     - Importers:
@@ -95,8 +98,12 @@ nav:
       - CSV Importer: api/importers/csv.md
       - WFDB Importer: api/importers/wfdb.md
       - XDF Importer: api/importers/xdf.md
+      - Tabular Importer (Parquet/Arrow): api/importers/tabular.md
+      - Zarr Importer: api/importers/zarr.md
     - Exporters:
       - EDF/BDF Exporter: api/exporters/edf.md
+      - Tabular Exporter (Parquet/Arrow): api/exporters/tabular.md
+      - Zarr Exporter: api/exporters/zarr.md
     - Analysis:
       - Verification: api/analysis/verification.md
     - Visualization:
@@ -109,6 +116,7 @@ nav:
     - Converting Jupyter Notebooks: examples/notebooks.md
     - WFDB Example: examples/wfdb.md
     - XDF Example: examples/xdf.md
+    - Serialization Round-Trip: examples/serialization.md
   - Contributing: contributing.md
 
 extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emgio"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
## Release 0.6.0 — one serialization & serving story

Makes emgio the home for the **serialization & serving exports**: the Zarr export kept faithful to the PRD serving contract (so an external viewer / NEMAR batch job / serving infra can read emgio's output), with **Parquet and Arrow folded in** alongside it. emgio is deliberately NOT the home for the full PRD (the M3 NEMAR batch converter, M4 web viewer, M5 serving infra live elsewhere). Closes #83.

Grounded in a 3-way audit (Zarr-vs-PRD contract, exporter API consistency, docs gaps); the structural Zarr↔PRD match was already faithful, so this PR is the focused PRD-compat + consolidation + docs work.

### Code (PRD-compat + consolidation)
- **`source_format` provenance**: set centrally in `Recording.from_file` (setdefault), so it is no longer always `"n/a"`. A re-imported serialization file keeps its ORIGINAL source format rather than being relabeled.
- **Zarr `recording_metadata` is now a native JSON object** (directly readable by a browser/zarrita client) with typed envelopes only for datetime/numpy; the reader accepts both the object (v2) and the legacy JSON string (v1). `FORMAT_VERSION` → 2; `ZarrImporter` now validates `format_version` and rejects a newer store.
- **Unified empty-signal guard** to one message (`"No signals loaded"`) across the writers; dropped the duplicate in `Recording.to_zarr`.
- **`TabularImporter` sets `source_file`** on read (symmetry with every other importer); **`.zarr` inference** is robust to trailing-slash directory paths; explicit `require_pyarrow()` + Args/Returns docstrings in `TabularExporter`; aligned tabular `VERSION` → `FORMAT_VERSION` naming.

### Docs (the unified story)
New **Serialization & Serving** section: `formats/serialization.md` (overview + when-to-use decision matrix), `formats/zarr.md` (store contract, level-0 vs view/*, per-modality rates, dtype, serving model, format_version), `examples/serialization.md` (Parquet/Arrow/Zarr round-trips + the `group=` selector), and 4 mkdocstrings API pages — all wired into the mkdocs nav. README / docs index / AGENTS feature lists updated. PRD sections 4–5 aligned to the as-shipped implementation (level-0 `anti_aliased` attr, discrete-group `usable_for_inference`, group-name = target rate, int16 NaN rejection, `recording_metadata` encoding, `original_rate` dual meaning).

### Testing (NO MOCKS)
`emgio/tests/test_serialization.py` (10 tests): source_format provenance (fresh + preserved-on-reimport), Zarr native-object metadata round-trip (datetime survives) + a real v1-downgraded store for back-compat, `format_version` rejection, `.zarr` trailing-slash inference, unified empty-signal message for both writers. Updated `test_tabular.py` for the new `source_file`-on-read behavior.

- Full suite: **391 passed, 4 skipped**; `ty check emgio` clean (blocking); ruff check + format clean; `mkdocs build --strict` succeeds.

### Compatibility
Existing 0.4/0.5 Zarr stores (v1, string `recording_metadata`) still read. New stores are v2.

### Next
v1.0.0 = `emgio` → `biosigio` package rename + removal of the deprecated `EMG` alias.