### PR TITLE
1.0.1: docs-vs-code revision + Recording accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The documentation including installation instructions, examples, and API referen
   - Automatic file format detection based on extension
   - Specialized format detection for CSV files
   - Custom importers for system-specific formats
-  - Automatic annotation loading (WFDB, planned for EDF+/BDF+ and EEGLAB's .set files)
+  - Automatic annotation/event loading (WFDB and EDF+/BDF+; EEGLAB .set events read into metadata), embedded back on EDF+/BDF+ export and carried in the Parquet/Arrow/Zarr serialization formats
   - LSL timestamp preservation for XDF files (for synchronization)
   
 - Export to standardized formats:

--- a/biosigio/core/emg.py
+++ b/biosigio/core/emg.py
@@ -760,6 +760,42 @@ class Recording:
         """
         return self.metadata.get(key)
 
+    def has_metadata(self, key: str) -> bool:
+        """Return True if ``key`` is present in the recording metadata."""
+        return key in self.metadata
+
+    def get_n_channels(self) -> int:
+        """Number of channels in the recording."""
+        return len(self.channels)
+
+    def get_n_samples(self) -> int:
+        """Number of time samples per channel (0 if no signals are loaded)."""
+        return 0 if self.signals is None else len(self.signals)
+
+    def get_sampling_frequency(self) -> float:
+        """Sampling frequency in Hz, when all channels share a single rate.
+
+        Raises:
+            ValueError: if no channels are loaded, or channels have differing
+                sampling frequencies; for a mixed-rate recording read
+                ``channels[ch]["sample_frequency"]`` per channel instead.
+        """
+        if not self.channels:
+            raise ValueError("No channels loaded")
+        rates = {info["sample_frequency"] for info in self.channels.values()}
+        if len(rates) > 1:
+            raise ValueError(
+                "Channels have differing sampling frequencies; read "
+                "channels[ch]['sample_frequency'] per channel instead."
+            )
+        return float(next(iter(rates)))
+
+    def get_duration(self) -> float:
+        """Recording duration in seconds (time of the last sample); 0.0 if empty."""
+        if self.signals is None or len(self.signals) == 0:
+            return 0.0
+        return float(self.signals.index[-1])
+
     def add_channel(
         self,
         label: str,

--- a/biosigio/core/emg.py
+++ b/biosigio/core/emg.py
@@ -791,10 +791,18 @@ class Recording:
         return float(next(iter(rates)))
 
     def get_duration(self) -> float:
-        """Recording duration in seconds (time of the last sample); 0.0 if empty."""
-        if self.signals is None or len(self.signals) == 0:
+        """Total recording duration in seconds (n_samples / sampling_frequency).
+
+        Computed from the time index spacing, so it is the full window length
+        (one sample period longer than the last sample's timestamp). Returns 0.0
+        when fewer than two samples are loaded (a single sample has no inferable
+        sample period).
+        """
+        if self.signals is None or len(self.signals) < 2:
             return 0.0
-        return float(self.signals.index[-1])
+        index = self.signals.index
+        sample_period = float(index[1] - index[0])
+        return len(index) * sample_period
 
     def add_channel(
         self,

--- a/biosigio/tests/test_accessors.py
+++ b/biosigio/tests/test_accessors.py
@@ -41,9 +41,12 @@ def test_get_sampling_frequency_mixed_raises():
 
 
 def test_get_duration():
-    rec = _rec()  # 1000 samples @ 500 Hz -> last index at 999/500 s
-    assert rec.get_duration() == pytest.approx(999 / 500)
-    assert Recording().get_duration() == 0.0
+    rec = _rec()  # 1000 samples @ 500 Hz -> 2.0 s window
+    assert rec.get_duration() == pytest.approx(1000 / 500)
+    assert Recording().get_duration() == 0.0  # no signals
+    one = Recording()
+    one.add_channel("C", np.zeros(1), 500, "uV", "EEG")
+    assert one.get_duration() == 0.0  # single sample: no inferable period
 
 
 def test_has_metadata():

--- a/biosigio/tests/test_accessors.py
+++ b/biosigio/tests/test_accessors.py
@@ -1,0 +1,53 @@
+"""Tests for the Recording convenience accessors (added in 1.0.1). NO MOCKS."""
+
+import numpy as np
+import pytest
+
+from biosigio import Recording
+
+
+def _rec():
+    rec = Recording()
+    rec.add_channel("C1", np.zeros(1000), 500, "uV", "EEG")
+    rec.add_channel("C2", np.zeros(1000), 500, "uV", "EEG")
+    return rec
+
+
+def test_get_n_channels():
+    assert _rec().get_n_channels() == 2
+    assert Recording().get_n_channels() == 0
+
+
+def test_get_n_samples():
+    assert _rec().get_n_samples() == 1000
+    assert Recording().get_n_samples() == 0
+
+
+def test_get_sampling_frequency_uniform():
+    assert _rec().get_sampling_frequency() == 500.0
+
+
+def test_get_sampling_frequency_empty_raises():
+    with pytest.raises(ValueError, match="No channels"):
+        Recording().get_sampling_frequency()
+
+
+def test_get_sampling_frequency_mixed_raises():
+    rec = Recording()
+    rec.add_channel("A", np.zeros(100), 500, "uV", "EEG")
+    rec.add_channel("B", np.zeros(100), 1000, "uV", "EMG")  # different declared rate
+    with pytest.raises(ValueError, match="differing sampling"):
+        rec.get_sampling_frequency()
+
+
+def test_get_duration():
+    rec = _rec()  # 1000 samples @ 500 Hz -> last index at 999/500 s
+    assert rec.get_duration() == pytest.approx(999 / 500)
+    assert Recording().get_duration() == 0.0
+
+
+def test_has_metadata():
+    rec = _rec()
+    rec.set_metadata("subject", "S1")
+    assert rec.has_metadata("subject") is True
+    assert rec.has_metadata("missing") is False

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
-__version__ = "1.0.0"
-__version_info__ = (1, 0, 0)
+__version__ = "1.0.1"
+__version_info__ = (1, 0, 1)
 
 
 def get_version() -> str:

--- a/docs/api/analysis/signal.md
+++ b/docs/api/analysis/signal.md
@@ -1,0 +1,13 @@
+# Signal Analysis (EDF/BDF format selection)
+
+The signal-analysis routines behind automatic EDF/BDF format selection: SVD- and
+FFT-based dynamic-range estimation and the resulting 16-bit (EDF) vs 24-bit (BDF)
+suitability decision. See [EDF/BDF Format Selection](../../user-guide/edf-bdf-selection.md).
+
+## Module Documentation
+
+::: biosigio.analysis.signal
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true

--- a/docs/api/analysis/verification.md
+++ b/docs/api/analysis/verification.md
@@ -1,6 +1,6 @@
 # Verification API
 
-The `verification` module provides functions for verifying signal integrity after operations like export/import. It's particularly useful for ensuring data quality when transferring EMG data between different formats.
+The `verification` module provides functions for verifying signal integrity after operations like export/import. It's particularly useful for ensuring data quality when transferring biosignal data between different formats.
 
 ## Module Documentation
 
@@ -23,18 +23,20 @@ The `verification` module provides functions for verifying signal integrity afte
 from biosigio import Recording
 from biosigio.analysis.verification import compare_signals, report_verification_results
 
-# Load original EMG data
+# Load original recording
 emg_original = Recording.from_file("data.csv", importer="trigno")
 
-# Export to EDF and reload
+# Export to EDF/BDF and reload. With the default format='auto', to_edf may pick
+# either .edf or .bdf, so reload the path it actually wrote.
+written_path = "exported_data.edf"  # or "exported_data.bdf" if BDF was selected
 emg_original.to_edf("exported_data")
-emg_reloaded = Recording.from_file("exported_data.edf")
+emg_reloaded = Recording.from_file(written_path)
 
 # Compare signals
 results = compare_signals(emg_original, emg_reloaded)
 
 # Generate report
-is_identical = report_verification_results(results, tolerance=0.01)
+is_identical = report_verification_results(results, verify_tolerance=0.01)
 
 # Check results
 if is_identical:
@@ -57,5 +59,5 @@ channel_map = {
 
 # Compare with mapping
 results = compare_signals(emg_original, emg_reloaded, channel_map=channel_map)
-is_identical = report_verification_results(results, tolerance=0.01)
+is_identical = report_verification_results(results, verify_tolerance=0.01)
 ``` 

--- a/docs/api/bids.md
+++ b/docs/api/bids.md
@@ -1,0 +1,14 @@
+# BIDS Helpers
+
+Helpers for the Brain Imaging Data Structure (BIDS): locate a sibling
+`_channels.tsv` / `_events.tsv` next to a recording and apply its per-channel
+types/units. Applied automatically by `Recording.from_file` (unless
+`bids_channels="off"`).
+
+## Module Documentation
+
+::: biosigio.bids
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,21 @@
+# Command-Line Interface
+
+Installing biosigIO provides a `biosigio` console command (entry point
+`biosigio.cli:main`). Verify it with `biosigio --help`.
+
+Subcommands:
+
+- `biosigio convert IN OUT` — import a recording and export EDF/BDF.
+- `biosigio verify A B` — compare two recordings channel-by-channel.
+- `biosigio info IN` — summarize a recording's channels and metadata.
+- `biosigio lowres IN OUT` — write a downsampled, low-resolution copy.
+
+Run `biosigio <subcommand> --help` for the full options of each.
+
+## Module Documentation
+
+::: biosigio.cli
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true

--- a/docs/api/core/modality.md
+++ b/docs/api/core/modality.md
@@ -1,0 +1,14 @@
+# Modality Vocabulary
+
+The modality vocabulary backs the per-channel `channel_type` / `modality`
+contract used by `Recording.add_channel` and `set_channel`: it validates channel
+types and coarse modalities (EEG, EMG, IEEG, MEG, BEH, MISC) and maps types to
+BIDS `channels.tsv` values.
+
+## Module Documentation
+
+::: biosigio.core.modality
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true

--- a/docs/api/emg.md
+++ b/docs/api/emg.md
@@ -1,6 +1,6 @@
 # Recording Class API
 
-The `Recording` class is the main class in biosigIO for working with EMG data. It encapsulates signals, channel information, and metadata, and provides methods for data manipulation and export.
+The `Recording` class is the main class in biosigIO for working with biosignal data. It encapsulates signals, channel information, and metadata, and provides methods for data manipulation and export.
 
 ## Class Documentation
 
@@ -52,8 +52,8 @@ Details about the main attributes:
 
 ### Data Loading
 
-- `from_file()`: Load EMG data from a file (class method)
-- `from_dataframe()`: Create Recording object from a pandas DataFrame (class method)
+- `from_file()`: Load biosignal data from a file (class method)
+- `add_channel()`: Append a channel (data + metadata) to a Recording
 
 ### Data Access
 
@@ -92,38 +92,33 @@ emg = Recording.from_file("data.otb+")
 # Load with explicit importer
 emg = Recording.from_file("data.otb+", importer="otb")
 
-# Load with explicit importer (.csv does not support automatic importer selection)
+# Generic CSV/TXT supports automatic importer selection, but a Delsys Trigno
+# export is best loaded with its dedicated importer
 emg = Recording.from_file("data.csv", importer='trigno')
 ```
 
-### Creating from DataFrame
+### Building a Recording Programmatically
 
 ```python
-import pandas as pd
+import numpy as np
 from biosigio import Recording
 
-# Create a DataFrame with EMG data
-data = pd.DataFrame({
-    'EMG1': [1, 2, 3, 4, 5],
-    'EMG2': [5, 4, 3, 2, 1]
-})
-
-# Create channels dictionary
-channels = {
-    'EMG1': {
-        'channel_type': 'EMG',
-        'physical_dimension': 'µV',
-        'sample_frequency': 1000
-    },
-    'EMG2': {
-        'channel_type': 'EMG',
-        'physical_dimension': 'µV',
-        'sample_frequency': 1000
-    }
-}
-
-# Create Recording object
-emg = Recording.from_dataframe(data, channels=channels)
+# Start from an empty Recording and add channels
+emg = Recording()
+emg.add_channel(
+    label='EMG1',
+    data=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+    sample_frequency=1000,
+    physical_dimension='µV',
+    channel_type='EMG',
+)
+emg.add_channel(
+    label='EMG2',
+    data=np.array([5.0, 4.0, 3.0, 2.0, 1.0]),
+    sample_frequency=1000,
+    physical_dimension='µV',
+    channel_type='EMG',
+)
 ```
 
 ### Selecting Channels
@@ -187,9 +182,10 @@ emg_original.to_edf('output', verify=True, verify_channel_map=channel_map)
 # Export, verify, and generate verification plot
 emg_original.to_edf('output', verify=True, verify_plot=True)
 
-# Manual verification (alternative approach)
+# Manual verification (alternative approach). With the default format='auto',
+# to_edf may write either output.edf or output.bdf; reload the path it wrote.
 emg_original.to_edf('output')
-emg_reloaded = Recording.from_file('output.edf')
+emg_reloaded = Recording.from_file('output.edf')  # or 'output.bdf' if BDF was selected
 
 # Compare signals
 results = compare_signals(emg_original, emg_reloaded, tolerance=0.001)

--- a/docs/api/exporters/edf.md
+++ b/docs/api/exporters/edf.md
@@ -1,6 +1,6 @@
 # EDF/BDF Exporter
 
-The EDF/BDF exporter module in biosigIO provides functionality to export EMG data to EDF (European Data Format) or BDF (BioSemi Data Format) files.
+The EDF/BDF exporter module in biosigIO provides functionality to export biosignal data to EDF (European Data Format) or BDF (BioSemi Data Format) files.
 
 ## Module Documentation
 
@@ -49,15 +49,20 @@ emg.to_edf('output',
 
 The `to_edf` method accepts the following parameters:
 
-- **output_path (str)**: Path for the output file (without extension)
+- **filepath (str)**: Path for the output file. The extension is set automatically to `.edf` or `.bdf` based on the chosen format.
 - **format (str, optional)**: Specify the format to use ('auto', 'edf', or 'bdf'). Default is 'auto'.
 - **method (str, optional)**: Method for format selection ('svd', 'fft', or 'both'). Default is 'both'.
 - **svd_rank (int, optional)**: Rank cutoff for SVD analysis. Default is None (automatic).
 - **fft_noise_range (tuple, optional)**: Frequency range (min, max) for noise floor estimation in FFT. Default is None (automatic).
-- **physical_min (float, optional)**: Physical minimum value. Default is None (automatic).
-- **physical_max (float, optional)**: Physical maximum value. Default is None (automatic).
-- **overwrite (bool, optional)**: Whether to overwrite existing files. Default is False.
-- **additional_info (dict, optional)**: Additional information to include in the EDF header.
+- **precision_threshold (float, optional)**: Maximum acceptable precision loss percentage. Default is 0.01.
+- **bypass_analysis (bool, optional)**: Skip signal analysis when `format` is forced to 'edf' or 'bdf'. Default is None (skip when format is forced).
+- **verify (bool, optional)**: Reload the exported file and compare it with the original. Default is False.
+- **verify_tolerance (float, optional)**: Absolute tolerance used during verification. Default is 1e-6.
+- **verify_channel_map (dict, optional)**: Map original channel names to reloaded names for verification.
+- **verify_plot (bool, optional)**: Plot original vs reloaded signals when verifying. Default is False.
+- **events_df (DataFrame, optional)**: Events to write as EDF+ annotations. Defaults to `self.events`.
+- **create_channels_tsv (bool, optional)**: Write a BIDS-compliant channels.tsv sidecar. Default is True.
+- **clip_outliers (bool or str, optional)**: Per-channel physical-window outlier handling ('auto', True, or False). Default is 'auto'.
 
 ## Understanding Format Selection
 
@@ -82,14 +87,14 @@ Fast Fourier Transform (FFT) analysis:
 When exporting, biosigIO generates the following files:
 
 1. **Main data file**: Either `.edf` or `.bdf` extension depending on the format selected
-2. **Channels metadata file**: A `{output_path}.channels.tsv` file with detailed channel information in BIDS-compatible format
+2. **Channels metadata file**: A `{output}_channels.tsv` sidecar (BIDS underscore naming) with detailed channel information in BIDS-compatible format, written next to the data file unless `create_channels_tsv=False`.
 
 Example channels.tsv file content:
 ```
-name    type    units   sampling_frequency
-EMG1    EMG     µV      2000
-EMG2    EMG     µV      2000
-ACC1    ACC     g       2000
+name    type    units   sampling_frequency  reference   status
+EMG1    EMG     µV      2000                n/a         good
+EMG2    EMG     µV      2000                n/a         good
+ACC1    ACC     g       2000                n/a         good
 ```
 
 ## Additional Features
@@ -98,4 +103,4 @@ ACC1    ACC     g       2000
 - **Metadata preservation**: Subject, recording, and other metadata are included in the EDF header
 - **BIDS compatibility**: The exporter follows BIDS conventions for metadata
 - **Multi-channel support**: Handles multiple channel types with appropriate units
-- **Different sampling rates**: Can handle channels with different sampling rates 
+- **Single sampling rate**: EDF/BDF export requires one sampling rate shared by all channels. If the channels have differing sampling rates, the exporter raises a `ValueError`; resample the channels to a common rate (for example with `Recording.resample()`) before exporting.

--- a/docs/api/importers/base.md
+++ b/docs/api/importers/base.md
@@ -15,93 +15,86 @@ The `BaseImporter` class is the abstract base class for all importers in biosigI
 To create a custom importer for a new format, you should inherit from `BaseImporter` and implement its abstract methods:
 
 ```python
+import numpy as np
+
+from biosigio.core.emg import Recording
 from biosigio.importers.base import BaseImporter
-import pandas as pd
+
 
 class MyCustomImporter(BaseImporter):
-    def __init__(self, file_path, **kwargs):
-        """Initialize the importer with a file path."""
-        self.file_path = file_path
-        self.kwargs = kwargs
-        
-    def load(self):
+    def load(self, filepath: str, **kwargs) -> Recording:
         """
         Load and parse the custom format file.
-        
-        Returns
-        -------
-        tuple
-            A tuple containing (signals, channels, metadata)
-            - signals: pandas DataFrame with signal data
-            - channels: dictionary with channel information
-            - metadata: dictionary with additional metadata
+
+        Args:
+            filepath: Path to the input file.
+
+        Returns:
+            Recording: A Recording object with the loaded signals, channels,
+            events, and metadata.
         """
         # Implement file loading logic for your custom format
-        signals = pd.DataFrame(...)  # Load signal data
-        
-        # Create channels dictionary
-        channels = {
-            'CH1': {
-                'channel_type': 'EMG',
-                'physical_dimension': 'µV',
-                'sample_frequency': 1000,
-                # ...other channel metadata...
-            },
-            # ...additional channels...
-        }
-        
-        # Create metadata dictionary
-        metadata = {
-            'subject': '001',
-            'recording_date': '2023-01-01',
-            # ...other metadata...
-        }
-        
-        return signals, channels, metadata
+        rec = Recording()
+
+        # Add each channel (data + per-channel metadata)
+        rec.add_channel(
+            label='CH1',
+            data=np.array([...]),       # Channel samples
+            sample_frequency=1000,
+            physical_dimension='µV',
+            channel_type='EMG',
+        )
+        # ...additional channels...
+
+        # Attach recording-level metadata
+        rec.set_metadata('subject', '001')
+        rec.set_metadata('recording_date', '2023-01-01')
+
+        return rec
 ```
 
-## Required Return Values
+## Return Value
 
-The `load()` method must return a tuple of three elements:
+The `load()` method takes a `filepath` (and optional importer-specific keyword
+arguments) and must return a `Recording` object. Populate it through the public
+API rather than returning raw containers:
 
-1. **signals**: A pandas DataFrame containing the signal data with:
-   - Columns named after channels
-   - Rows representing time points
+- **signals**: built up by `add_channel()`, which stores each channel as a
+  column in `Recording.signals` (a pandas DataFrame indexed by time).
+- **channels**: each `add_channel()` call records per-channel metadata in
+  `Recording.channels`:
 
-2. **channels**: A dictionary with channel information:
-   ```python
-   {
-       'channel_name': {
-           'channel_type': str,        # Type of channel (e.g., 'EMG', 'ACC')
-           'physical_dimension': str,   # Unit (e.g., 'µV', 'mV', 'g')
-           'sample_frequency': float,   # Sampling frequency in Hz
-           # Optional additional fields
-       },
-       # ...more channels...
-   }
-   ```
+  ```python
+  {
+      'channel_name': {
+          'channel_type': str,        # Type of channel (e.g., 'EMG', 'ACC')
+          'physical_dimension': str,  # Unit (e.g., 'µV', 'mV', 'g')
+          'sample_frequency': float,  # Sampling frequency in Hz
+          'modality': str,            # Inferred from channel_type if not given
+          'prefilter': str,
+      },
+      # ...more channels...
+  }
+  ```
 
-3. **metadata**: A dictionary with additional information:
-   ```python
-   {
-       'subject': str,            # Subject identifier
-       'recording_date': str,     # Recording date
-       'device': str,             # Recording device
-       # ...other metadata fields...
-   }
-   ```
+- **metadata**: recording-level fields set via `set_metadata()`:
 
-## Registering a Custom Importer
+  ```python
+  {
+      'subject': str,            # Subject identifier
+      'recording_date': str,     # Recording date
+      'device': str,             # Recording device
+      # ...other metadata fields...
+  }
+  ```
 
-To make your custom importer available through `Recording.from_file()`, you need to register it:
+## Using a Custom Importer
+
+A custom importer is invoked directly by instantiating it (no constructor
+arguments) and calling `load()` with the file path:
 
 ```python
-from biosigio import Recording
 from my_module import MyCustomImporter
 
-# Register the importer with a name
-Recording.register_importer('my_format', MyCustomImporter)
-
-# Now you can use it
-emg = Recording.from_file('data.custom', importer='my_format')
-``` 
+rec = MyCustomImporter().load('data.custom')
+```

--- a/docs/api/importers/csv.md
+++ b/docs/api/importers/csv.md
@@ -20,9 +20,7 @@ from biosigio.importers.csv import CSVImporter
 emg = Recording.from_file('data.csv', importer='csv')
 
 # Method 2: Using the importer directly
-importer = CSVImporter('data.csv', has_header=True, delimiter=',')
-signals, channels, metadata = importer.load()
-emg = Recording(signals, channels, metadata)
+emg = CSVImporter().load('data.csv', has_header=True, delimiter=',')
 ```
 
 ## Auto-Detection Features
@@ -36,8 +34,14 @@ The CSV importer includes several auto-detection capabilities:
 
 ## Parameters
 
-- **file_path (str)**: Path to the CSV file
-- **kwargs (dict)**: Additional keyword arguments
+`CSVImporter().load(filepath, force_generic=False, **kwargs)` takes:
+
+- **filepath (str)**: Path to the CSV file.
+- **force_generic (bool, optional)**: Force using the generic CSV importer even
+  if a specialized format (e.g., Trigno) is detected. When loading through
+  `Recording.from_file(..., importer='csv', force_csv=True)`, the `force_csv`
+  argument is forwarded as this `force_generic` flag.
+- **kwargs**: Additional keyword arguments:
   - **sample_frequency (float, optional)**: Sampling frequency in Hz (required if no time column)
   - **has_header (bool, optional)**: Whether file has a header row (auto-detected if not specified)
   - **skiprows (int, optional)**: Number of rows to skip at beginning (auto-detected if not specified)
@@ -48,19 +52,18 @@ The CSV importer includes several auto-detection capabilities:
   - **channel_types (dict, optional)**: Dict mapping column names to channel types ('EMG', 'ACC', etc.)
   - **physical_dimensions (dict, optional)**: Dict mapping column names to physical dimensions
   - **metadata (dict, optional)**: Dict of additional metadata to include
-  - **force_csv (bool, optional)**: Force using generic CSV importer even if specialized format is detected
 
-## Return Values
+## Return Value
 
-The `load()` method returns a tuple of:
+The `load()` method returns a single `Recording` object with:
 
-1. **signals (pandas.DataFrame)**: Signal data with channels as columns and time as index
-2. **channels (dict)**: Dictionary of channel information including:
-   - channel_type: Type of channel (EMG, EEG, etc.)
-   - physical_dimension: Physical unit (e.g., 'mV', 'g')
-   - sample_frequency: Sampling rate in Hz
-
-3. **metadata (dict)**: Dictionary containing metadata from the file and any additional provided metadata
+1. **signals**: signal data with channels as columns and time as index.
+2. **channels**: per-channel information including:
+   - `channel_type`: type of channel (EMG, ACC, GYRO, MISC, OTHER), inferred from the column name when not provided
+   - `physical_dimension`: physical unit (e.g., 'µV', 'g')
+   - `sample_frequency`: sampling rate in Hz
+3. **metadata**: includes `source_file`, `file_format` ('CSV'), and any
+   additional metadata passed via the `metadata` keyword argument.
 
 ## Implementation Details
 

--- a/docs/api/importers/edf.md
+++ b/docs/api/importers/edf.md
@@ -20,9 +20,7 @@ from biosigio.importers.edf import EDFImporter
 emg = Recording.from_file('data.edf', importer='edf')  # Works for both .edf and .bdf
 
 # Method 2: Using the importer directly
-importer = EDFImporter('data.edf')
-signals, channels, metadata = importer.load()
-emg = Recording(signals, channels, metadata)
+emg = EDFImporter().load('data.edf')
 ```
 
 ## File Format Support
@@ -31,71 +29,67 @@ The EDF importer supports:
 
 1. EDF files (16-bit resolution)
 2. BDF files (24-bit resolution)
-3. EDF+ files with annotations
-4. Different sampling rates for different channels
-5. Time-stamped data
+3. EDF+ / BDF+ files with annotations (loaded into `Recording.events`)
+
+The `.edf` and `.bdf` extensions are auto-detected by `Recording.from_file`.
 
 ## Channel Type Detection
 
-The EDF importer attempts to identify channel types based on:
-
-1. Channel labels in the EDF header
-2. Signal characteristics 
-3. Common naming conventions (e.g., channels with 'EMG' in the name are classified as 'EMG')
+The EDF importer identifies channel types from the channel label and transducer
+fields in the EDF header (e.g., a label or transducer containing 'EMG' is
+classified as `EMG`; 'EEG', 'ECG'/'EKG', 'EOG', 'ACC', 'GYRO', and 'TRIG' are
+handled similarly, otherwise `OTHER`).
 
 ## Parameters
 
-- **file_path (str)**: Path to the EDF/BDF file
-- **kwargs (dict)**: Additional keyword arguments
-  - **load_data (bool, optional)**: Whether to load the data or just metadata. Default is True.
-  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
-  - **start_time (float, optional)**: Start time in seconds for loading a subset of the data.
-  - **end_time (float, optional)**: End time in seconds for loading a subset of the data.
+`EDFImporter().load(filepath)` takes:
 
-## Return Values
+- **filepath (str)**: Path to the EDF/BDF file.
 
-The `load()` method returns a tuple of:
+The importer reads the entire file; it does not support partial/segment loading.
 
-1. **signals (pandas.DataFrame)**: Signal data with channels as columns
-2. **channels (dict)**: Dictionary of channel information including:
-   - channel_type: Type of channel (EMG, EEG, etc.)
-   - physical_dimension: Physical unit (e.g., 'µV', 'mV')
-   - sample_frequency: Sampling rate in Hz
-   - physical_min: Minimum physical value
-   - physical_max: Maximum physical value
-   - digital_min: Minimum digital value
-   - digital_max: Maximum digital value
+## Return Value
 
-3. **metadata (dict)**: Dictionary containing metadata from the EDF file, including:
-   - subject: Subject identifier (from EDF patient field)
-   - recording_date: Recording date
-   - start_time: Start time of the recording
-   - duration: Duration of the recording in seconds
-   - file_type: 'EDF' or 'BDF'
-   - annotations: Any annotations found in the file
+The `load()` method returns a single `Recording` object with:
+
+1. **signals**: signal data with channels as columns.
+2. **channels**: per-channel information including:
+   - `channel_type`: type of channel (EMG, EEG, etc.)
+   - `physical_dimension`: physical unit (e.g., 'µV', 'mV')
+   - `sample_frequency`: sampling rate in Hz
+   - `prefilter`: pre-filtering string from the header
+   - `physical_min` / `physical_max`: physical value bounds
+   - `digital_min` / `digital_max`: digital value bounds
+   - `transducer`: transducer string from the header
+3. **metadata**: fields parsed from the EDF header, including patient/recording
+   info (`patientcode`, `patient_name`, `technician`, `equipment`, `startdate`,
+   ...), `file_info` (`filetype`, `number_of_signals`, `file_duration`,
+   `datarecord_duration`), and `source_file`.
+
+Annotations are NOT stored in metadata; see "Working with Annotations" below.
 
 ## Implementation Details
 
 The EDF importer uses the `pyedflib` package to:
 
-1. Read the EDF/BDF file header to extract metadata
-2. Extract channel information and convert to biosigIO's format
-3. Load the signal data, applying appropriate scaling
-4. Handle annotations if present
-5. Convert the data to a pandas DataFrame for use with biosigIO
+1. Read the EDF/BDF file header to extract metadata.
+2. Extract per-channel information and convert it to biosigIO's format.
+3. Load the signal data into a pandas DataFrame.
+4. Read any EDF+/BDF+ annotations into the Recording's events.
 
 ## Working with Annotations
 
-EDF+ files can contain annotations that mark specific events or segments in the data. The importer preserves these annotations in the metadata dictionary:
+EDF+ / BDF+ files can contain annotations that mark events in the data. The
+importer reads them into `Recording.events`, a pandas DataFrame with `onset`,
+`duration`, and `description` columns. When the Recording is exported back to
+EDF/BDF, these events are written out again as EDF+ annotations.
 
 ```python
-# Load EDF+ file with annotations
-emg = Recording.from_file('data.edf+', importer='edf')
+# Load an EDF+ file with annotations
+emg = Recording.from_file('data.edf', importer='edf')
 
-# Access annotations
-annotations = emg.get_metadata('annotations')
-if annotations:
-    for annotation in annotations:
-        onset, duration, description = annotation
-        print(f"Event: {description} at {onset}s, duration: {duration}s")
-``` 
+# Access annotations via the events DataFrame
+for _, event in emg.events.iterrows():
+    print(f"Event: {event['description']} at {event['onset']}s, "
+          f"duration: {event['duration']}s")
+```

--- a/docs/api/importers/eeglab.md
+++ b/docs/api/importers/eeglab.md
@@ -20,19 +20,17 @@ from biosigio.importers.eeglab import EEGLABImporter
 emg = Recording.from_file('data.set', importer='eeglab')
 
 # Method 2: Using the importer directly
-importer = EEGLABImporter('data.set')
-signals, channels, metadata = importer.load()
-emg = Recording(signals, channels, metadata)
+emg = EEGLABImporter().load('data.set')
 ```
 
 ## File Format Support
 
-The EEGLAB importer supports:
+The EEGLAB importer reads `.set` files with `scipy.io.loadmat`, so it supports:
 
-1. MATLAB `.set` files (version 7.3 and earlier)
-2. Both continuous and epoched data
-3. Multiple channel types (EMG, EEG, ACC, etc.)
-4. Event markers and annotations
+1. Pre-v7.3 (non-HDF5) MATLAB `.set` files. MATLAB v7.3 / HDF5-format `.set`
+   files are not supported.
+2. Multiple channel types (EMG, EEG, ACC, etc.)
+3. Event markers (stored in metadata)
 
 ## Channel Type Detection
 
@@ -44,34 +42,30 @@ The EEGLAB importer attempts to detect channel types based on:
 
 ## Parameters
 
-- **file_path (str)**: Path to the EEGLAB .set file
-- **kwargs (dict)**: Additional keyword arguments
-  - **load_data (bool, optional)**: Whether to load the data or just metadata. Default is True.
-  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
+`EEGLABImporter().load(filepath)` takes:
 
-## Return Values
+- **filepath (str)**: Path to the EEGLAB `.set` file.
 
-The `load()` method returns a tuple of:
+## Return Value
 
-1. **signals (pandas.DataFrame)**: Signal data with channels as columns
-2. **channels (dict)**: Dictionary of channel information including:
-   - channel_type: Type of channel (EMG, EEG, etc.)
-   - physical_dimension: Physical unit (e.g., 'µV')
-   - sample_frequency: Sampling rate in Hz
-   - coordinates: Channel coordinates if available
+The `load()` method returns a single `Recording` object with:
 
-3. **metadata (dict)**: Dictionary containing metadata from the EEGLAB file, including:
-   - subject: Subject identifier
-   - session: Session identifier
-   - condition: Condition/task information
-   - srate: Sampling rate
-   - xmin/xmax: Time limits
-   - event: Event markers
-   - epoch: Epoch information (if epoched)
+1. **signals**: signal data with channels as columns.
+2. **channels**: per-channel information including:
+   - `channel_type`: type of channel (EMG, EEG, etc.)
+   - `physical_dimension`: physical unit (defaults to `'uV'`)
+   - `sample_frequency`: sampling rate in Hz
+   - `X`/`Y`/`Z`: channel coordinates when available in `chanlocs`
+3. **metadata**: fields parsed from the EEGLAB file, which may include:
+   - `setname`, `filename`, `filepath`
+   - `subject`, `group`, `condition`, `session`, `comments`
+   - `srate`: sampling rate
+   - `nbchan`, `trials`, `pnts`
+   - `xmin`/`xmax`: time limits
+   - `events`: list of event markers (stored under the `events` key)
+   - `device`: set to `'EEGLAB'`
 
 ## Notes
 
-- The importer automatically handles both continuous and epoched data
-- For epoched data, epochs are concatenated in the time dimension
-- Event markers are preserved in the metadata
-- Channel locations are preserved in the channel information when available 
+- Event markers are preserved in metadata under the `events` key.
+- Channel coordinates are preserved in the channel information when available.

--- a/docs/api/importers/otb.md
+++ b/docs/api/importers/otb.md
@@ -20,65 +20,58 @@ from biosigio.importers.otb import OTBImporter
 emg = Recording.from_file('data.otb+', importer='otb')
 
 # Method 2: Using the importer directly
-importer = OTBImporter('data.otb+')
-signals, channels, metadata = importer.load()
-emg = Recording(signals, channels, metadata)
+emg = OTBImporter().load('data.otb+')
 ```
 
 ## File Format Support
 
 The OTB importer supports:
-1. Binary OTB+ files from OT Bioelettronica devices (SESSANTAQUATTRO, MUOVI, etc.)
-2. Multiple channel types (EMG, ACC, TRIG, AUX, IMUX)
-3. Different sampling rates for different channel types
-4. Various bit resolutions (8-bit, 12-bit, 16-bit, etc.)
+1. OTB/OTB+ archives from OT Bioelettronica devices (Sessantaquattro, Muovi, Quattrocento, etc.)
+2. Multiple channel types (EMG, ACC, GYRO, QUAT, CTRL, OTHER)
+3. 16-bit and 24-bit signal resolutions
+
+The archive carries one device-wide sampling frequency, which is assigned to
+every channel.
 
 ## Channel Type Mapping
 
-The OTB importer identifies channel types based on the OTB+ file header information. Common channel types include:
+The OTB importer identifies channel types from the OTB+ XML metadata (adapter
+model, channel description/ID). The mapped types are:
 
-- **EMG**: Electromyography channels
+- **EMG**: Electromyography channels (Due, Muovi, Sessantaquattro, Novecento, Quattro, Quattrocento adapters)
 - **ACC**: Accelerometer channels
-- **TRIG**: Trigger channels
-- **AUX**: Auxiliary channels 
-- **IMUX**: Input multiplexer channels
+- **GYRO**: Gyroscope channels
+- **QUAT**: Quaternion channels
+- **CTRL**: Control channels
+- **OTHER**: Anything that does not match the above
 
 ## Parameters
 
-- **file_path (str)**: Path to the OTB+ file
-- **kwargs (dict)**: Additional keyword arguments
-  - **use_matlab (bool, optional)**: Whether to use MATLAB for import (requires MATLAB runtime). Default is False.
-  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
+`OTBImporter().load(filepath)` takes:
 
-## Return Values
+- **filepath (str)**: Path to the OTB/OTB+ file.
 
-The `load()` method returns a tuple of:
+## Return Value
 
-1. **signals (pandas.DataFrame)**: Signal data with channels as columns
-2. **channels (dict)**: Dictionary of channel information including:
-   - channel_type: Type of channel (EMG, ACC, etc.)
-   - physical_dimension: Physical unit (e.g., 'µV' for EMG, 'g' for ACC)
-   - sample_frequency: Sampling rate in Hz
-   - bit_resolution: Bit resolution of the channel
-   - calibration_factor: Calibration factor for converting raw to physical values
+The `load()` method returns a single `Recording` object with:
 
-3. **metadata (dict)**: Dictionary containing metadata from the OTB+ file, including:
-   - device: Device name (e.g., 'SESSANTAQUATTRO')
-   - recording_date: Recording date if available
-   - signal_resolution: Bit resolution of the signals
-   - device_settings: Additional device-specific settings
+1. **signals**: signal data with channels as columns.
+2. **channels**: per-channel information including:
+   - `channel_type`: type of channel (EMG, ACC, GYRO, QUAT, CTRL, OTHER)
+   - `physical_dimension`: physical unit (e.g., 'mV' for EMG, 'g' for ACC/GYRO, 'rad' for QUAT)
+   - `sample_frequency`: device sampling rate in Hz
+   - `prefilter`: pre-filtering string built from the adapter's HP/LP filter settings
+3. **metadata**: fields parsed from the OTB+ archive, including:
+   - `source_file`: input path
+   - `device`: device name parsed from the XML header
+   - `signal_resolution`: bit resolution of the signals (e.g., 16 or 24)
 
 ## Implementation Details
 
 The OTB importer works by:
 
-1. Reading the binary header information from the OTB+ file
-2. Parsing the header to extract metadata about channels and device settings
-3. Loading the raw signal data from the binary file
-4. Applying calibration factors to convert raw values to physical units
-5. Organizing the data into channel types and creating the appropriate metadata
-
-## Dependencies
-
-- The OTB importer includes a pure Python implementation for parsing OTB+ files
-- It can optionally use the OT Bioelettronica MATLAB functions for import if MATLAB is available 
+1. Extracting the OTB/OTB+ archive (a tar container) to a temporary directory.
+2. Parsing the XML metadata file to extract device and per-channel information.
+3. Reading the raw binary `.sig` signal data (reconstructing 24-bit samples when applicable).
+4. Applying the device gain and reference-voltage scaling to convert raw values to physical units.
+5. Adding each channel to the Recording with its inferred type and unit.

--- a/docs/api/importers/trigno.md
+++ b/docs/api/importers/trigno.md
@@ -20,51 +20,46 @@ from biosigio.importers.trigno import TrignoImporter
 emg = Recording.from_file('data.csv', importer='trigno')
 
 # Method 2: Using the importer directly
-importer = TrignoImporter('data.csv')
-signals, channels, metadata = importer.load()
-emg = Recording(signals, channels, metadata)
+emg = TrignoImporter().load('data.csv')
 ```
 
 ## File Format Requirements
 
-The importer expects a CSV file with:
+The importer expects a Delsys Trigno CSV export with:
 
-1. A header section (optional) containing metadata lines starting with '#'
-2. A data section with columns:
-   - First column: Time in seconds
-   - Remaining columns: Channel data
+1. A per-channel metadata header. Each channel is described by a line of the
+   form `Label: <name> Sampling frequency: <Hz> ... Unit: <unit> Domain: ...`,
+   from which the importer parses the channel name, its sampling frequency, and
+   its physical unit.
+2. A data header row whose first column is `X[s]` (the time axis in seconds);
+   the importer treats the line containing `X[s]` as the start of the numeric
+   data section.
+3. The numeric data section that follows, with the time column first and one
+   column per channel.
 
-Example:
-```
-# Delsys Trigno EMG Data
-# Recording Date: 2023-01-01
-# Subject: S001
-Time(s),EMG1,EMG2,EMG3,EMG4,ACC1_X,ACC1_Y,ACC1_Z
-0.000,0.01,0.02,0.03,0.04,0.05,0.06,0.07
-0.001,0.02,0.03,0.04,0.05,0.06,0.07,0.08
-...
-```
+Because Trigno records each sensor at its own rate, the parsed
+`sample_frequency` is stored per channel.
 
 ## Channel Type Detection
 
 The Trigno importer automatically detects channel types based on channel names:
 
-- Channels containing 'EMG' or 'emg' are classified as 'EMG'
-- Channels containing 'ACC' or 'acc' are classified as 'ACC'
-- Other channels are classified as 'OTHER'
+- Channels whose name contains `EMG` are classified as `EMG`
+- Channels whose name contains `ACC` are classified as `ACC`
+- Channels whose name contains `GYRO` are classified as `GYRO`
+- Other channels are classified as `OTHER`
 
 ## Parameters
 
-- **file_path (str)**: Path to the Trigno CSV file
-- **kwargs (dict)**: Additional keyword arguments
-  - **header_rows (int, optional)**: Number of header rows to skip. If not provided, automatically detected.
-  - **delimiter (str, optional)**: Column delimiter. Default is ','.
-  - **channel_types (dict, optional)**: Manual mapping of channel names to types.
+`TrignoImporter().load(filepath)` takes:
 
-## Return Values
+- **filepath (str)**: Path to the Trigno CSV file.
 
-The `load()` method returns a tuple of:
+Per-channel sampling frequency and units are read from the file's `Label: ...`
+header lines, so no manual header/delimiter arguments are required.
 
-1. **signals (pandas.DataFrame)**: Signal data with channels as columns
-2. **channels (dict)**: Dictionary of channel information
-3. **metadata (dict)**: Dictionary containing metadata from the header 
+## Return Value
+
+The `load()` method returns a single `Recording` object populated with the
+parsed signals, per-channel information (type, unit, sampling frequency), and
+recording metadata (including `source_file` and `device`).

--- a/docs/api/importers/xdf.md
+++ b/docs/api/importers/xdf.md
@@ -117,15 +117,14 @@ For each channel:
 - `channel_type`: Inferred or default type
 - `physical_dimension`: Unit (default "a.u.")
 - `sample_frequency`: Effective sampling rate
-- `stream_name`: Original stream name
-- `stream_id`: Original stream ID
+- `prefilter`: Pre-filtering string (default "n/a")
+- `modality`: Coarse modality inferred from the channel type
 
 ### Metadata (dict)
 - `device`: "XDF"
 - `source_file`: Path to the XDF file
-- `stream_count`: Number of streams in file
-- `stream_names`: List of all stream names
-- `stream_types`: List of all stream types
+- `stream_count`: Number of selected streams
+- `srate`: Sampling rate of the reference stream (base sample rate)
 
 ## Helper Classes
 

--- a/docs/api/tabular_schema.md
+++ b/docs/api/tabular_schema.md
@@ -1,0 +1,14 @@
+# Tabular Schema (serialization)
+
+The canonical, versioned `biosigio` schema shared by the Parquet/Arrow exporters
+and the Zarr store's metadata: it serializes a `Recording` (signals + channels +
+events + metadata) self-describingly and round-trips datetimes/numpy via typed
+envelopes. See [Serialization & Serving](../formats/serialization.md).
+
+## Module Documentation
+
+::: biosigio.tabular_schema
+    options:
+      show_root_heading: true
+      show_source: true
+      members: true

--- a/docs/api/visualization/static.md
+++ b/docs/api/visualization/static.md
@@ -1,6 +1,6 @@
 # Static Visualization API
 
-The `static` module in `biosigio.visualization` provides functions for static plotting of EMG data. These functions are primarily used internally by the `Recording` class methods but can also be called directly for advanced customization.
+The `static` module in `biosigio.visualization` provides functions for static plotting of biosignal data. These functions are primarily used internally by the `Recording` class methods but can also be called directly for advanced customization.
 
 ## Module Documentation
 
@@ -84,4 +84,4 @@ The static plotting functions provide several parameters for customization:
 - **Grid lines**: Toggle grid visibility
 - **Titles**: Add custom titles to plots
 
-For most use cases, the corresponding methods on the `Recording` class (`plot_signals()` and `plot_comparison()`) are recommended as they provide simplified interfaces to these functions. 
+For most use cases, the `Recording.plot_signals()` method is recommended as it provides a simplified interface that delegates to `plot_signals()` here. Note that `plot_comparison()` is a module-level function only; there is no `Recording.plot_comparison()` method, so call it directly from `biosigio.visualization.static` (as shown above, or automatically via `Recording.to_edf(..., verify=True, verify_plot=True)`).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -124,7 +124,7 @@ Some specific style guidelines:
 
 ## Adding New Importers
 
-To add support for a new EMG format:
+To add support for a new biosignal format:
 
 1. Create a new file in `biosigio/importers/` (e.g., `new_format.py`)
 2. Implement a class that inherits from `BaseImporter`

--- a/docs/examples/eeglab.md
+++ b/docs/examples/eeglab.md
@@ -1,6 +1,6 @@
 # EEGLAB Examples
 
-This page provides examples for working with EEGLAB `.set` files using biosigIO.
+This page provides examples for working with EEGLAB `.set` files using biosigIO. The importer reads `.set` files with `scipy.io.loadmat`, so only pre-v7.3 (non-HDF5) MATLAB `.set` files are supported; v7.3/HDF5 `.set` files are not.
 
 ## Basic EEGLAB Example
 
@@ -59,9 +59,10 @@ import matplotlib.pyplot as plt
 # Load EEGLAB data with events
 emg = Recording.from_file('data_with_events.set', importer='eeglab')
 
-# Check if events exist in the metadata
-if 'event' in emg.metadata:
-    events = emg.get_metadata('event')
+# EEGLAB events are stored under the metadata key 'events' (plural) as a list
+# of dicts with 'type', 'latency', and (optionally) 'duration'/'trial_type'.
+if emg.has_metadata('events'):
+    events = emg.get_metadata('events')
     print(f"Found {len(events)} events")
     
     # Print the first 5 events
@@ -79,83 +80,51 @@ if 'event' in emg.metadata:
         fs = emg.get_sampling_frequency()
         event_time = event_sample / fs
         
-        # Plot 2 seconds before and after the event
+        # Plot 2 seconds before and after the event. Pass show=False so the
+        # event marker can be overlaid before displaying.
         window = 2  # seconds
-        plt.figure(figsize=(12, 8))
         emg.plot_signals(
             time_range=(event_time - window, event_time + window),
-            title=f"EMG around movement event at {event_time:.2f}s"
+            title=f"EMG around movement event at {event_time:.2f}s",
+            show=False
         )
-        
+
         # Add a vertical line at the event time
         plt.axvline(x=event_time, color='r', linestyle='--', label='Movement Event')
         plt.legend()
-        plt.tight_layout()
         plt.show()
 ```
 
-## Converting Epoched Data
+## Inspecting Epoch Metadata
 
-EEGLAB can store continuous or epoched data. biosigIO can work with both:
+EEGLAB stores the number of epochs in the `trials` field and the samples per
+epoch in `pnts`. These are read into the recording metadata, so you can inspect
+them after loading. `get_metadata` returns `None` when a key is absent, so guard
+for that before comparing:
 
 ```python
 from biosigio import Recording
 import matplotlib.pyplot as plt
 
-# Load epoched EEGLAB data
+# Load EEGLAB data
 emg = Recording.from_file('epoched_data.set', importer='eeglab')
 
-# Check if data is epoched
-is_epoched = emg.get_metadata('trials', 1) > 1
+# trials > 1 indicates epoched data; get_metadata returns None if absent
+trials = emg.get_metadata('trials')
+is_epoched = trials is not None and trials > 1
 print(f"Data is {'epoched' if is_epoched else 'continuous'}")
 
 if is_epoched:
-    # Get epoch information
     n_epochs = emg.get_metadata('trials')
     epoch_length = emg.get_metadata('pnts')
     fs = emg.get_sampling_frequency()
     epoch_duration = epoch_length / fs
-    
+
     print(f"Number of epochs: {n_epochs}")
     print(f"Epoch length: {epoch_length} samples ({epoch_duration:.2f} seconds)")
-    
-    # biosigIO automatically concatenates epochs, so the data is handled as continuous
-    # The total duration is epochs * epoch_duration
-    total_duration = emg.get_duration()
-    print(f"Total duration: {total_duration:.2f} seconds")
-    
-    # Plot signals from different epochs
-    plt.figure(figsize=(15, 10))
-    
-    # Plot first epoch
-    plt.subplot(3, 1, 1)
-    emg.plot_signals(
-        time_range=(0, epoch_duration),
-        title="First Epoch",
-        ax=plt.gca()
-    )
-    
-    # Plot middle epoch
-    middle_epoch = n_epochs // 2
-    middle_start = middle_epoch * epoch_duration
-    plt.subplot(3, 1, 2)
-    emg.plot_signals(
-        time_range=(middle_start, middle_start + epoch_duration),
-        title=f"Middle Epoch (Epoch {middle_epoch+1})",
-        ax=plt.gca()
-    )
-    
-    # Plot last epoch
-    last_start = (n_epochs - 1) * epoch_duration
-    plt.subplot(3, 1, 3)
-    emg.plot_signals(
-        time_range=(last_start, last_start + epoch_duration),
-        title=f"Last Epoch (Epoch {n_epochs})",
-        ax=plt.gca()
-    )
-    
-    plt.tight_layout()
-    plt.show()
+
+# Plot the first few seconds (plot_signals manages its own figure)
+emg.plot_signals(time_range=(0, 5), title="EEGLAB Signals")
 ```
 
 ## Exporting EEGLAB Data to EDF/BDF

--- a/docs/examples/notebooks.md
+++ b/docs/examples/notebooks.md
@@ -139,7 +139,8 @@ emg.plot_signals(
     channels=emg.get_channels_by_type('EMG')[:4],  # First 4 EMG channels
     time_range=(10, 15),
     title='EMG Signals During Movement',
-    grid=True
+    grid=True,
+    show=False,  # keep the figure open so savefig below captures it
 )
 plt.tight_layout()
 
@@ -147,6 +148,7 @@ plt.tight_layout()
 plt.savefig('emg_plot.png', dpi=300)  # PNG for presentations
 plt.savefig('emg_plot.pdf')  # PDF for publications
 plt.savefig('emg_plot.svg')  # SVG for editing
+plt.show()
 ```
 
 ## Tips for Jupyter Notebooks

--- a/docs/examples/notebooks.md
+++ b/docs/examples/notebooks.md
@@ -42,12 +42,11 @@ import matplotlib.pyplot as plt
 # Load EMG data
 emg = Recording.from_file('data.csv', importer='trigno')
 
-# Plot signals with customized appearance
+# Plot signals with customized appearance (plot_signals manages its own figure)
 emg.plot_signals(
     channels=['EMG1', 'EMG2'],
     time_range=(0, 5),
     title='EMG Signals',
-    figsize=(12, 6),
     grid=True
 )
 ```
@@ -152,15 +151,19 @@ plt.savefig('emg_plot.svg')  # SVG for editing
 
 ## Tips for Jupyter Notebooks
 
-1. **Memory management**: When working with large files, consider using:
+1. **Loading data**: `Recording.from_file` infers the importer from the file
+   extension and returns a `Recording`. You can also call an importer directly;
+   importers take no constructor arguments and their `load(filepath)` returns a
+   `Recording` (not a tuple):
    ```python
-   # Load only metadata first
-   importer = EDFImporter('large_file.edf')
-   signals, channels, metadata = importer.load(load_data=False)
-   
-   # Then load specific time segments as needed
-   importer = EDFImporter('large_file.edf')
-   signals, channels, metadata = importer.load(start_time=10, end_time=20)
+   from biosigio import Recording
+   from biosigio.importers.edf import EDFImporter
+
+   # Inferred importer (extension-based)
+   emg = Recording.from_file('recording.edf')
+
+   # Equivalent direct use
+   emg = EDFImporter().load('recording.edf')
    ```
 
 2. **Progress tracking**: For long operations, use `tqdm` for progress bars:

--- a/docs/examples/otb.md
+++ b/docs/examples/otb.md
@@ -26,23 +26,16 @@ for ch_type in channel_types:
     channels = emg.get_channels_by_type(ch_type)
     print(f"{ch_type}: {len(channels)} channels")
 
-# Plot one channel of each type
-plt.figure(figsize=(12, 8))
-subplot_count = len(channel_types)
-for i, ch_type in enumerate(channel_types, 1):
+# Plot one channel of each type (each call manages its own figure)
+for ch_type in channel_types:
     channels = emg.get_channels_by_type(ch_type)
     if channels:
-        plt.subplot(subplot_count, 1, i)
         # Select the first channel of this type
         sample_channel = emg.select_channels([channels[0]])
         sample_channel.plot_signals(
             time_range=(0, 5),
-            title=f"{ch_type} Sample: {channels[0]}",
-            ax=plt.gca()
+            title=f"{ch_type} Sample: {channels[0]}"
         )
-
-plt.tight_layout()
-plt.show()
 ```
 
 ## Working with EMG Channels
@@ -155,31 +148,22 @@ emg_channels = [ch for ch in common_channels
                 if emg1.channels[ch]['channel_type'] == 'EMG']
 
 if emg_channels:
-    # Select a channel to compare
+    # Select a channel to compare (each call manages its own figure)
     channel_to_compare = emg_channels[0]
-    
-    plt.figure(figsize=(12, 8))
-    
+
     # Plot channel from first session
-    plt.subplot(2, 1, 1)
     emg1.plot_signals(
-        [channel_to_compare], 
+        [channel_to_compare],
         time_range=(0, 5),
-        title=f"Session 1 ({emg1.get_metadata('condition')}): {channel_to_compare}",
-        ax=plt.gca()
+        title=f"Session 1 ({emg1.get_metadata('condition')}): {channel_to_compare}"
     )
-    
+
     # Plot same channel from second session
-    plt.subplot(2, 1, 2)
     emg2.plot_signals(
-        [channel_to_compare], 
+        [channel_to_compare],
         time_range=(0, 5),
-        title=f"Session 2 ({emg2.get_metadata('condition')}): {channel_to_compare}",
-        ax=plt.gca()
+        title=f"Session 2 ({emg2.get_metadata('condition')}): {channel_to_compare}"
     )
-    
-    plt.tight_layout()
-    plt.show()
 ```
 
 ## Exporting OTB Data to EDF/BDF

--- a/docs/examples/serialization.md
+++ b/docs/examples/serialization.md
@@ -13,9 +13,9 @@ These formats need optional dependencies. Parquet and Arrow/Feather use the
 uv sync --extra arrow      # Parquet / Arrow / Feather
 uv sync --extra zarr       # Zarr serving store
 
-# Or with pip, into an existing environment
-pip install 'biosigio[arrow]'
-pip install 'biosigio[zarr]'
+# Or into an existing environment (UV-only project; use uv pip)
+uv pip install 'biosigio[arrow]'
+uv pip install 'biosigio[zarr]'
 ```
 
 The examples below build a small `Recording` in memory so they run without any

--- a/docs/examples/trigno.md
+++ b/docs/examples/trigno.md
@@ -134,10 +134,12 @@ emg_only = emg.select_channels(channel_type='EMG')
 # (the full mixed-rate recording would raise ValueError).
 emg_only.set_metadata('sampling_rate', emg_only.get_sampling_frequency())
 
-# 4. Plot raw signals (plot_signals manages its own figure)
+# 4. Plot raw signals (plot_signals manages its own figure). Pass show=False so
+# the figure stays open for savefig; plot_signals calls plt.show() by default.
 emg_only.plot_signals(time_range=(0, 10),
-                     title="Raw EMG Signals")
+                     title="Raw EMG Signals", show=False)
 plt.savefig('raw_emg.png')
+plt.show()
 
 # 5. Export to EDF/BDF
 output_path = 'processed_emg'

--- a/docs/examples/trigno.md
+++ b/docs/examples/trigno.md
@@ -1,6 +1,6 @@
 # Trigno Examples
 
-This page demonstrates how to work with EMG data from the Delsys Trigno wireless EMG system. Trigno data is typically exported as CSV files with a specific format that biosigIO can parse.
+This page demonstrates how to work with EMG data from the Delsys Trigno wireless EMG system. Trigno data is exported as CSV files with a metadata preamble followed by a data table. The importer reads per-channel `Label: ... Sampling frequency: ... Unit: ...` lines from the preamble, then locates the data header line (the one containing the `X[s]` time column) and reads the samples below it. Per-channel sampling frequency comes from each channel's `Sampling frequency:` field, so EMG and accelerometer (ACC) channels can carry different rates.
 
 ## Basic Trigno Example
 
@@ -16,7 +16,13 @@ emg = Recording.from_file(data_path, importer='trigno')
 # Print information about the loaded data
 print(f"Number of channels: {emg.get_n_channels()}")
 print(f"Number of samples: {emg.get_n_samples()}")
-print(f"Sampling frequency: {emg.get_sampling_frequency()} Hz")
+# Trigno recordings are often mixed-rate (EMG vs ACC/GYRO), so a single overall
+# sampling frequency may not exist. get_sampling_frequency() raises ValueError in
+# that case; read the per-channel rate from channels[ch]['sample_frequency'] instead.
+try:
+    print(f"Sampling frequency: {emg.get_sampling_frequency()} Hz")
+except ValueError:
+    print("Mixed per-channel sampling rates (see per-channel rates below)")
 print(f"Recording duration: {emg.get_duration()} seconds")
 
 # List available channels
@@ -51,34 +57,30 @@ print(f"ACC channels: {acc_channels}")
 # Create ACC-only object
 acc_only = emg.select_channels(acc_channels)
 
-# Plot EMG and ACC signals separately
-plt.figure(figsize=(10, 8))
-
-plt.subplot(2, 1, 1)
-emg_only.plot_signals(time_range=(0, 5), title="EMG Signals", ax=plt.gca())
-
-plt.subplot(2, 1, 2)
-acc_only.plot_signals(time_range=(0, 5), title="Accelerometer Signals", ax=plt.gca())
-
-plt.tight_layout()
-plt.show()
+# Plot EMG and ACC signals separately (each call manages its own figure)
+emg_only.plot_signals(time_range=(0, 5), title="EMG Signals")
+acc_only.plot_signals(time_range=(0, 5), title="Accelerometer Signals")
 ```
 
 ## Exporting Trigno Data to EDF/BDF
 
-You can export the Trigno data to EDF or BDF format for use with other software:
+You can export the Trigno data to EDF or BDF format for use with other software.
+EDF/BDF requires a single sampling rate across all channels, so a mixed-rate
+Trigno recording (EMG vs ACC/GYRO) must be split by channel type (or resampled to
+a common rate) before export; exporting a mixed-rate recording raises a
+`ValueError`.
 
 ```python
-# Export all channels
-output_path = 'trigno_all_channels'
-emg.to_edf(output_path)  # Format (EDF/BDF) will be selected automatically
-print(f"Exported to: {output_path}")
-
-# Export only EMG channels
+# Export only EMG channels (a single-rate subset)
 emg_only = emg.select_channels(channel_type='EMG')
 output_path = 'trigno_emg_only'
-emg_only.to_edf(output_path)
+emg_only.to_edf(output_path)  # Format (EDF/BDF) will be selected automatically
 print(f"Exported EMG channels to: {output_path}")
+
+# Accelerometer channels have a different rate, so export them separately
+acc_only = emg.select_channels(channel_type='ACC')
+acc_only.to_edf('trigno_acc_only')
+print("Exported ACC channels to: trigno_acc_only")
 ```
 
 ## Working with Multiple Trigno Recordings
@@ -97,22 +99,14 @@ session1.set_metadata('condition', 'rest')
 session2.set_metadata('session', '2')
 session2.set_metadata('condition', 'active')
 
-# Plot channels from both sessions
+# Plot channels from both sessions (each call manages its own figure)
 channel_to_compare = 'EMG1'  # Replace with your channel name
 
-plt.figure(figsize=(10, 6))
-plt.subplot(2, 1, 1)
-session1.plot_signals([channel_to_compare], time_range=(0, 5), 
-                     title=f"Session 1: {session1.get_metadata('condition')}", 
-                     ax=plt.gca())
+session1.plot_signals([channel_to_compare], time_range=(0, 5),
+                     title=f"Session 1: {session1.get_metadata('condition')}")
 
-plt.subplot(2, 1, 2)
-session2.plot_signals([channel_to_compare], time_range=(0, 5), 
-                     title=f"Session 2: {session2.get_metadata('condition')}", 
-                     ax=plt.gca())
-
-plt.tight_layout()
-plt.show()
+session2.plot_signals([channel_to_compare], time_range=(0, 5),
+                     title=f"Session 2: {session2.get_metadata('condition')}")
 ```
 
 ## Complete Trigno Workflow Example
@@ -132,17 +126,17 @@ emg = Recording.from_file(data_path, importer='trigno')
 # 2. Add metadata
 emg.set_metadata('subject', 'S001')
 emg.set_metadata('condition', 'reaching')
-emg.set_metadata('sampling_rate', emg.get_sampling_frequency())
 
 # 3. Select only EMG channels
 emg_only = emg.select_channels(channel_type='EMG')
 
-# 4. Plot raw signals
-plt.figure(figsize=(12, 6))
-emg_only.plot_signals(time_range=(0, 10), 
-                     title="Raw EMG Signals", 
-                     ax=plt.gca())
-plt.tight_layout()
+# The EMG-only subset has a single rate, so get_sampling_frequency() is safe here
+# (the full mixed-rate recording would raise ValueError).
+emg_only.set_metadata('sampling_rate', emg_only.get_sampling_frequency())
+
+# 4. Plot raw signals (plot_signals manages its own figure)
+emg_only.plot_signals(time_range=(0, 10),
+                     title="Raw EMG Signals")
 plt.savefig('raw_emg.png')
 
 # 5. Export to EDF/BDF

--- a/docs/examples/verification.md
+++ b/docs/examples/verification.md
@@ -1,10 +1,11 @@
 # Signal Verification Examples
 
-This page demonstrates how to use biosigIO's verification capabilities to ensure signal integrity when transferring EMG data between formats.
+This page demonstrates how to use biosigIO's verification capabilities to ensure signal integrity when transferring biosignal data between formats.
 
 ## Basic Verification Workflow
 
 ```python
+import os
 from biosigio import Recording
 import matplotlib.pyplot as plt
 from biosigio.analysis.verification import compare_signals, report_verification_results
@@ -15,11 +16,13 @@ emg_original = Recording.from_file('sample_data.csv', importer='trigno')
 emg_channels = [ch for ch, info in emg_original.channels.items() if info['channel_type'] == 'EMG']
 emg_original = emg_original.select_channels(emg_channels)  # Creates a new Recording object with only EMG channels
 
-# Export to EDF (automatically selects EDF or BDF based on signal characteristics)
+# Export to EDF (automatically selects EDF or BDF based on signal characteristics).
+# Pass a base path without an extension; the writer appends .edf or .bdf.
 emg_original.to_edf('exported_data')
 
-# Reload the exported data
-emg_reloaded = Recording.from_file('exported_data.edf')
+# Reload the exported data. Resolve whichever extension to_edf selected.
+exported_path = 'exported_data.edf' if os.path.exists('exported_data.edf') else 'exported_data.bdf'
+emg_reloaded = Recording.from_file(exported_path)
 
 # Verify signals using the verification module
 results = compare_signals(emg_original, emg_reloaded, tolerance=0.01)
@@ -117,6 +120,7 @@ plt.show()
 ## Real-World Example: CSV to EDF Conversion
 
 ```python
+import os
 from biosigio import Recording
 import matplotlib.pyplot as plt
 from biosigio.analysis.verification import compare_signals, report_verification_results
@@ -125,13 +129,14 @@ from biosigio.visualization.static import plot_comparison
 # 1. Load original Trigno CSV data
 emg_trigno = Recording.from_file('trigno_data.csv', importer='trigno')
 
-# 2. Export to EDF
+# 2. Export to EDF (the writer appends .edf or .bdf based on signal analysis)
 emg_trigno.to_edf('converted_data')
 print(f"Data exported. Duration: {emg_trigno.get_duration():.2f}s, "
       f"Channels: {emg_trigno.get_n_channels()}")
 
-# 3. Reload from EDF
-emg_edf = Recording.from_file('converted_data.edf')
+# 3. Reload from the exported file (resolve the auto-selected extension)
+converted_path = 'converted_data.edf' if os.path.exists('converted_data.edf') else 'converted_data.bdf'
+emg_edf = Recording.from_file(converted_path)
 print(f"Data reloaded. Duration: {emg_edf.get_duration():.2f}s, "
       f"Channels: {emg_edf.get_n_channels()}")
 

--- a/docs/examples/wfdb.md
+++ b/docs/examples/wfdb.md
@@ -24,6 +24,6 @@ The `WFDBImporter` automatically detects and loads annotations if the correspond
 ## Running the Example
 
 1.  Ensure you have the necessary files (`100.hea`, `100.dat`, `100.atr`) in the `examples/` directory.
-2.  Run the script from the project root directory: `python examples/wfdb_example.py`
+2.  Run the script from the project root directory: `uv run python examples/wfdb_example.py`
 
 You should see output detailing the loaded metadata, channels, annotations, and the paths to the exported EDF and BDF files. A plot window showing the first 10 seconds of the 'MLII' channel will also appear. 

--- a/docs/examples/xdf.md
+++ b/docs/examples/xdf.md
@@ -17,22 +17,47 @@ print(summary)
 Output:
 ```
 XDF File: examples/multi_stream_test.xdf
-----------------------------------------
-Stream 1: TestEEG (EEG)
-  Channels: 8, Rate: 256.0 Hz
-  Samples: 1280, Duration: 5.0s
-  Labels: EEG1, EEG2, EEG3, EEG4, EEG5, EEG6, EEG7, EEG8
-Stream 2: TestEMG (EMG)
-  Channels: 2, Rate: 2048.0 Hz
-  Samples: 10240, Duration: 5.0s
-  Labels: EMG_L, EMG_R
-Stream 3: TestMocap (Mocap)
-  Channels: 6, Rate: 120.0 Hz
-  Samples: 600, Duration: 5.0s
-  Labels: Marker1_X, Marker1_Y, Marker1_Z, Marker2_X, Marker2_Y, Marker2_Z
-Stream 4: TestMarkers (Markers)
-  Channels: 1, Rate: 0.0 Hz (irregular)
+Number of streams: 4
+
+Stream 1: TestEEG
+  Type: EEG
+  Channels: 8
+  Nominal srate: 256.0 Hz
+  Effective srate: 256.20 Hz
+  Samples: 1280
+  Duration: 5.00 s
+  Format: float32
+  Channel labels: EEG1, EEG2, EEG3, EEG4, EEG5, ... (+3 more)
+
+Stream 2: TestEMG
+  Type: EMG
+  Channels: 2
+  Nominal srate: 2048.0 Hz
+  Effective srate: 2048.20 Hz
+  Samples: 10240
+  Duration: 5.00 s
+  Format: float32
+  Channel labels: EMG_L, EMG_R
+
+Stream 3: TestMocap
+  Type: Mocap
+  Channels: 6
+  Nominal srate: 120.0 Hz
+  Effective srate: 120.20 Hz
+  Samples: 600
+  Duration: 4.99 s
+  Format: float32
+  Channel labels: Marker1_X, Marker1_Y, Marker1_Z, Marker2_X, Marker2_Y, ... (+1 more)
+
+Stream 4: TestMarkers
+  Type: Markers
+  Channels: 1
+  Nominal srate: 0.0 Hz
+  Effective srate: 1.25 Hz
   Samples: 5
+  Duration: 4.00 s
+  Format: string
+  Channel labels: Ch1
 ```
 
 ## Finding Specific Streams
@@ -87,16 +112,25 @@ emg_data = Recording.from_file('examples/multi_stream_test.xdf', stream_names=['
 
 ## Working with Multi-Rate Data
 
-When loading streams with different sampling rates, they're resampled to a common time base:
+When loading streams with different sampling rates, all channels are interpolated
+onto a common time base. By default the highest-rate stream is the reference (to
+avoid downsampling), but each channel keeps its own original `sample_frequency`
+in `channels`, so a recording loaded this way is mixed-rate.
 
 ```python
 # Load EEG (256 Hz) and EMG (2048 Hz)
 combined = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EEG', 'EMG'])
 
-# Check the resulting sample rate (will be the highest: 2048 Hz)
-first_channel = list(combined.channels.keys())[0]
-print(f"Sample rate: {combined.channels[first_channel]['sample_frequency']} Hz")
+# Each channel reports its own original sampling frequency
+for ch, info in combined.channels.items():
+    print(f"{ch}: {info['sample_frequency']} Hz")
+# EEG channels report 256.0 Hz, EMG channels report 2048.0 Hz
 ```
+
+Note: a mixed-rate recording cannot be exported with `to_edf` (it requires a
+single rate across all channels and raises `ValueError` otherwise). Use
+`select_channels` to export one rate group at a time, or `resample` to a common
+rate first.
 
 ## Preserving LSL Timestamps
 

--- a/docs/formats/edf.md
+++ b/docs/formats/edf.md
@@ -53,7 +53,7 @@ The EDF importer in biosigIO (`biosigio.importers.edf`) uses the `pyedflib` pack
 1. Read the EDF/BDF file header to extract metadata
 2. Load the signal data for all channels
 3. Convert channel information to biosigIO's format
-4. Handle different sampling rates across channels
+4. Read EDF+/BDF+ annotations into the `events` DataFrame
 
 ## Exporter Implementation
 
@@ -62,7 +62,8 @@ The EDF exporter in biosigIO (`biosigio.exporters.edf`) also uses `pyedflib` to:
 1. Automatically determine whether to use EDF or BDF based on signal characteristics
 2. Generate appropriate header information
 3. Scale the signals correctly for storage
-4. Create a sidecar channels.tsv file with detailed channel metadata (BIDS-compatible)
+4. Write the `events` DataFrame back as EDF+/BDF+ annotations
+5. Create a sidecar `<output>_channels.tsv` file with detailed channel metadata (BIDS-compatible)
 
 ## Code Example
 
@@ -100,7 +101,7 @@ verification_results = emg.to_edf('output', verify=True)
 verification_results = emg.to_edf(
     'output',
     verify=True,
-    verify_tolerance=0.001,  # 0.1% tolerance
+    verify_tolerance=0.001,  # Absolute tolerance for signal comparison
     verify_channel_map={'EMG1': 'CH1'},  # Custom channel mapping
     verify_plot=True  # Generate visualization of comparison
 )
@@ -116,8 +117,10 @@ The verification process:
 
 ## Notes and Limitations
 
-- The BIDS-compatible channels.tsv sidecar file includes detailed channel information
-- Annotations in EDF files are preserved in biosigIO's metadata
+- The BIDS-compatible `<output>_channels.tsv` sidecar file includes detailed channel information
+- EDF+/BDF+ annotations are loaded into the `events` DataFrame (columns `onset`, `duration`, `description`) and written back as EDF+/BDF+ annotations on export
 - When importing from EDF, biosigIO attempts to identify channel types based on labels and signal characteristics
 - When exporting to EDF/BDF, biosigIO automatically handles scaling to maximize precision
+- EDF/BDF export requires a single sampling rate across all channels; if per-channel rates differ, export raises `ValueError`. Resample channels to a common rate first
+- With `format='auto'`, `to_edf('output')` selects either `.edf` (16-bit) or `.bdf` (24-bit) based on signal analysis and appends the matching extension
 - EDF has limitations on channel naming (maximum 16 characters)

--- a/docs/formats/eeglab.md
+++ b/docs/formats/eeglab.md
@@ -1,6 +1,6 @@
 # EEGLAB Format
 
-EEGLAB is a MATLAB toolbox for processing EEG, MEG, and other electrophysiological data. biosigIO can import EEGLAB `.set` files to work with EMG data stored in this format.
+EEGLAB is a MATLAB toolbox for processing EEG, MEG, and other electrophysiological data. biosigIO can import EEGLAB `.set` files to work with biosignal data stored in this format.
 
 ## Format Description
 
@@ -33,11 +33,11 @@ A typical EEGLAB `.set` file contains these fields:
 
 The EEGLAB importer in biosigIO (`biosigio.importers.eeglab`) works by:
 
-1. Loading the `.set` file using Python's `scipy.io.loadmat` (for MATLAB files)
+1. Loading the `.set` file using `scipy.io.loadmat` (pre-v7.3, non-HDF5 MAT-files only)
 2. Extracting the EEG structure with signal data and metadata
 3. Converting channel information to biosigIO's channel format
 4. Creating appropriate metadata dictionary
-5. Handling both continuous and epoched data
+5. Storing parsed event markers under the `events` metadata key
 
 ## Code Example
 
@@ -72,8 +72,8 @@ EEGLAB doesn't always explicitly designate channel types. biosigIO's EEGLAB impo
 
 ## Notes and Limitations
 
-- biosigIO supports both MATLAB v7.3 and older format .set files
-- Event markers are preserved in the metadata
+- Only pre-v7.3 (non-HDF5) `.set` files are supported, via `scipy.io.loadmat`; MATLAB v7.3/HDF5 `.set` files are not supported
+- Event markers are preserved under the `events` metadata key (access with `emg.get_metadata('events')`)
 - Channel locations (if available) are preserved in the channel information
 - Some EEGLAB-specific information may not be fully preserved in the conversion
 - Time information is properly handled to maintain accurate timing in the imported data 

--- a/docs/formats/meg.md
+++ b/docs/formats/meg.md
@@ -13,7 +13,7 @@ uv sync --extra meg
 For an existing installation, you can install the extra directly:
 
 ```bash
-pip install 'biosigio[meg]'
+uv pip install 'biosigio[meg]'
 ```
 
 If MNE-Python is not installed, loading a MEG file raises an `ImportError` with the install hint above.

--- a/docs/formats/neo.md
+++ b/docs/formats/neo.md
@@ -7,7 +7,7 @@ python-neo is an optional, heavy dependency, so it is not installed by default. 
 ```bash
 uv sync --extra neo
 # or, for an existing install:
-pip install 'biosigio[neo]'
+uv pip install 'biosigio[neo]'
 ```
 
 If you attempt to load a neo-backed format without the extra installed, biosigIO raises an `ImportError` with this install hint rather than failing obscurely.
@@ -112,4 +112,4 @@ print(rec.get_metadata('t_start_s'))
 
 ## Requirements
 
-The Neo importer requires the optional `neo` extra. Install it with `uv sync --extra neo` or `pip install 'biosigio[neo]'`.
+The Neo importer requires the optional `neo` extra. Install it with `uv sync --extra neo` or `uv pip install 'biosigio[neo]'`.

--- a/docs/formats/otb.md
+++ b/docs/formats/otb.md
@@ -71,10 +71,11 @@ plt.show()
 OTB files can contain various channel types:
 
 - **EMG** - Electromyography channels
-- **ACC** - Accelerometer channels 
-- **IMUX** - Input multiplexer channels (for OT Bioelettronica devices)
-- **AUX** - Auxiliary input channels
-- **TRIG** - Trigger or event marker channels
+- **ACC** - Accelerometer channels
+- **GYRO** - Gyroscope channels
+- **QUAT** - Quaternion channels
+- **CTRL** - Control channels
+- **OTHER** - Any channel that matches none of the above
 
 ## Notes and Limitations
 

--- a/docs/formats/serialization.md
+++ b/docs/formats/serialization.md
@@ -1,6 +1,6 @@
 # Serialization & Serving Formats
 
-Besides EDF/BDF, biosigio can serialize a `Recording` to three columnar or array
+Besides EDF/BDF, biosigIO can serialize a `Recording` to three columnar or array
 formats: Parquet, Arrow/Feather, and Zarr. Each carries enough information to be
 read back without any side files, and all of them round-trip through the same
 entry point, `Recording.from_file`, which auto-detects the format from the file
@@ -87,8 +87,8 @@ These formats are not part of the core install; install the matching extra.
 
 | Format | Extra | Install |
 |--------|-------|---------|
-| Parquet, Arrow/Feather | `arrow` (pyarrow) | `uv sync --extra arrow` or `pip install 'biosigio[arrow]'` |
-| Zarr | `zarr` (zarr v3) | `uv sync --extra zarr` or `pip install 'biosigio[zarr]'` |
+| Parquet, Arrow/Feather | `arrow` (pyarrow) | `uv sync --extra arrow` or `uv pip install 'biosigio[arrow]'` |
+| Zarr | `zarr` (zarr v3) | `uv sync --extra zarr` or `uv pip install 'biosigio[zarr]'` |
 
 If the extra is missing, the exporter and importer raise an `ImportError` with
 the exact install command, so you never get a partial or silent failure.

--- a/docs/formats/trigno.md
+++ b/docs/formats/trigno.md
@@ -12,34 +12,41 @@ Trigno CSV files typically have the following structure:
 
 ### Example File Structure
 
-```
-# Trigno Data File
-# Date: 2023-05-01
-# Time: 10:30:00
-# Device: Trigno Wireless System
-# ...additional metadata...
+A Trigno CSV export begins with one metadata line per channel, each starting
+with `Label:` and carrying that channel's sampling frequency and unit. The
+data section that follows is introduced by a header line containing `X[s]`
+time columns (one per channel). For example:
 
-Time(s),EMG1,EMG2,EMG3,EMG4,ACC1_X,ACC1_Y,ACC1_Z,...
-0.000,0.01,0.02,0.03,0.04,0.1,0.2,0.3,...
-0.001,0.02,0.03,0.04,0.05,0.1,0.2,0.3,...
-0.002,0.03,0.04,0.05,0.06,0.1,0.2,0.3,...
 ```
+Label: EMG1  Sampling frequency: 1925.926 Unit: V  Domain: Time
+Label: ACC1.X  Sampling frequency: 148.148 Unit: g  Domain: Time
+...
+X[s],EMG1,X[s].1,ACC1.X,...
+0.000,0.01,0.000,0.10,...
+0.001,0.02,0.007,0.10,...
+```
+
+The importer detects the start of the data section by finding the line that
+contains `X[s]`, and reads each channel's sampling frequency and unit from the
+preceding `Label:` lines.
 
 ## Channel Types
 
-biosigIO recognizes the following channel types in Trigno CSV files:
+biosigIO assigns channel types from the channel label:
 
-- **EMG** - Electromyography channels (typically in μV or mV)
-- **ACC** - Accelerometer channels (typically in g)
+- **EMG** - Electromyography channels (label contains `EMG`)
+- **ACC** - Accelerometer channels (label contains `ACC`)
+- **GYRO** - Gyroscope channels (label contains `GYRO`)
+- **OTHER** - Any channel whose label matches none of the above
 
 ## Importer Implementation
 
 The Trigno importer in biosigIO (`biosigio.importers.trigno`) processes these files by:
 
-1. Reading the header section to extract metadata
-2. Parsing the data section as a pandas DataFrame
+1. Reading the `Label:` header lines to extract each channel's sampling frequency and unit
+2. Locating the data section via the `X[s]` header line and parsing it as a pandas DataFrame
 3. Identifying channel types based on naming conventions
-4. Setting appropriate units and sampling frequencies for each channel
+4. Setting the per-channel units and sampling frequencies parsed from the header
 
 ## Code Example
 
@@ -65,6 +72,7 @@ print(f"ACC channels: {acc_channels}")
 ## Notes and Limitations
 
 - Trigno systems can have different sampling rates for EMG and accelerometer channels
-- The importer automatically detects the sampling rate from the time column
+- The importer reads each channel's sampling frequency from its `Label:` header line
 - Column names may vary between different Trigno system versions
-- Some metadata may be missing depending on the export settings 
+- Some metadata may be missing depending on the export settings
+- Channels in a Trigno export often have different sampling rates (e.g. EMG vs ACC); EDF/BDF export requires a single rate, so resample to a common rate before exporting

--- a/docs/formats/wfdb.md
+++ b/docs/formats/wfdb.md
@@ -12,16 +12,16 @@ Loading WFDB data typically involves three files sharing the same base name (e.g
 
 ## Loading Data
 
-To load a WFDB record, provide the path to the **header (`.hea`) file** or just the base record name (if the files are in the current directory or the path is configured) to `Recording.from_file`:
+To load a WFDB record, provide the path to the **header (`.hea`) file** to `Recording.from_file`. A `.hea`, `.dat`, or `.atr` extension is auto-detected as WFDB; an extension-less base record name needs an explicit `importer='wfdb'`:
 
 ```python
 from biosigio.core.emg import Recording
 
-# Load using the header file path
+# Load using the header file path (extension auto-detected)
 emg = Recording.from_file('path/to/your/record.hea')
 
-# Or load using just the base name (looks for files in the current directory)
-# emg = Recording.from_file('record')
+# Or load using just the base name (no extension); pass importer explicitly
+# emg = Recording.from_file('record', importer='wfdb')
 ```
 
 biosigIO uses the `wfdb` library (PyPI package `wfdb`) internally. It ships as a core dependency, so no separate installation is required.

--- a/docs/formats/xdf.md
+++ b/docs/formats/xdf.md
@@ -122,14 +122,13 @@ Loaded XDF files include metadata such as:
 
 - `device`: Set to "XDF"
 - `source_file`: Path to the XDF file
-- `stream_count`: Number of streams in the file
-- `stream_names`: Names of all streams
-- `stream_types`: Types of all streams
+- `stream_count`: Number of selected streams
+- `srate`: Sampling rate of the reference (highest-rate) stream
 
 ```python
 emg = Recording.from_file('recording.xdf')
-print(emg.get_metadata('stream_names'))
-print(emg.get_metadata('stream_types'))
+print(emg.get_metadata('stream_count'))
+print(emg.get_metadata('srate'))
 ```
 
 ## Preserving LSL Timestamps
@@ -152,7 +151,7 @@ Timestamp channels:
 - Contain the original LSL timestamps in seconds
 - Are marked with `channel_type='MISC'` and `physical_dimension='s'`
 - Are resampled along with the data when multiple streams have different rates
-- Survive export to EDF/BDF for later synchronization analysis
+- Can be exported to EDF/BDF for later synchronization analysis (EDF/BDF export requires all channels to share one sampling rate)
 
 This is useful for:
 

--- a/docs/formats/zarr.md
+++ b/docs/formats/zarr.md
@@ -11,8 +11,8 @@ The store is a derived serving copy, not an archive. The Brain Imaging Data Stru
 Zarr is an optional dependency (the `zarr` extra, which installs zarr v3) and is imported lazily. Install it with one of:
 
 ```bash
-uv sync --extra zarr        # development install
-pip install 'biosigio[zarr]'   # existing environment
+uv sync --extra zarr           # development install
+uv pip install 'biosigio[zarr]'   # existing environment
 ```
 
 Write a store with `Recording.to_zarr`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ biosigIO simplifies this process by providing a standardized interface for loadi
   - Automatic file format detection
   - Format-specific metadata extraction
   - Handling of specialized CSV formats
-  - Automatic annotation loading (WFDB, planned for EDF+/BDF+ and EEGLAB's .set files)
+  - Automatic annotation/event loading (WFDB and EDF+/BDF+; EEGLAB .set events read into metadata), embedded back on EDF+/BDF+ export and carried in the Parquet/Arrow/Zarr serialization formats
   - LSL timestamp preservation for XDF files (for synchronization)
   
 - **Intelligent export**:

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -32,12 +32,16 @@ biosigIO automatically infers the appropriate importer based on file extension:
 | Extension | Default Importer |
 |-----------|------------------|
 | `.csv`, `.txt` | `csv` (Generic CSV importer) |
-| `.edf`, `.edf+`, `.bdf` | `edf` (EDF/BDF importer) |
+| `.edf`, `.bdf` | `edf` (EDF/BDF importer) |
 | `.set` | `eeglab` (EEGLAB importer) |
 | `.otb`, `.otb+` | `otb` (OTB importer) |
-| `.hea` | `wfdb` (WFDB importer) |
+| `.hea`, `.dat`, `.atr` | `wfdb` (WFDB importer) |
 
-Additionally, for CSV files, biosigIO includes specialized format detection that can identify formats like Trigno CSV exports and suggest the appropriate specialized importer.
+Automatic importer selection works for CSV/TXT files as well; the generic CSV
+importer additionally includes specialized format detection that can identify
+formats like Trigno CSV exports and route to the appropriate specialized
+importer. WFDB datasets without a file extension must be loaded with an explicit
+`importer='wfdb'`.
 
 ### Special Case: CSV Files
 

--- a/docs/user-guide/edf-bdf-selection.md
+++ b/docs/user-guide/edf-bdf-selection.md
@@ -76,19 +76,27 @@ emg.to_edf('output', format='bdf')  # Force BDF (24-bit)
 
 ## Understanding the Output
 
-After export, biosigIO will indicate which format was selected:
+After export, biosigIO prints which format was selected. For the automatic
+case the messages are (illustrative; the per-channel analysis lines vary with
+your data):
 
 ```
-Exporting to EDF format: dynamic range is 78.3 dB (less than 90 dB threshold)
-Output file: output.edf
+Using EDF format (16-bit) based on signal analysis (precision within acceptable range).
+
+EMG data exported to: output.edf
 ```
 
 or:
 
 ```
-Exporting to BDF format: dynamic range is 108.2 dB (exceeds 90 dB threshold)
-Output file: output.bdf
+Using BDF format (24-bit) based on signal analysis to preserve precision.
+Reason: Channel 'EMG1': <reason from signal analysis>
+
+EMG data exported to: output.bdf
 ```
+
+Because `to_edf` auto-selects the extension, an `'output'` path becomes
+`output.edf` or `output.bdf` depending on the analysis result.
 
 ## Best Practices
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -43,14 +43,28 @@ This allows you to modify the source code and see the changes without reinstalli
 
 ## Optional Dependencies
 
-biosigIO provides optional dependency groups:
+biosigIO provides optional dependency groups. For an existing install use
+`uv pip install` (this is a UV-only project):
 
 ```bash
-# Development tools (pytest, ruff, coverage)
+# Development tools (pytest, pytest-cov, ruff, ty)
 uv pip install "biosigio[dev]"
 
-# Documentation tools (mkdocs, mkdocstrings)
+# Documentation tools (mkdocs, mkdocs-material, mkdocstrings)
 uv pip install "biosigio[docs]"
+
+# MEG (.fif / CTF .ds) and BrainVision (.vhdr) import via MNE
+uv pip install "biosigio[meg]"
+
+# Parquet / Arrow / Feather serialization via pyarrow
+uv pip install "biosigio[arrow]"
+
+# Proprietary electrophysiology formats (Intan, Blackrock, Spike2, Plexon,
+# Micromed, Neuralynx, ...) via python-neo
+uv pip install "biosigio[neo]"
+
+# Sharded Zarr v3 serving store via zarr v3
+uv pip install "biosigio[zarr]"
 
 # All optional dependencies
 uv pip install "biosigio[all]"
@@ -94,4 +108,4 @@ import biosigio
 print(biosigio.__version__)
 ```
 
-You should see the version number (e.g., `0.2.2` or later) without any errors.
+You should see the version number (e.g., `1.0.1` or later) without any errors.

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -75,7 +75,8 @@ This DataFrame has the following standard columns:
 
 *   **EDF/BDF:** Annotations stored in the EDF+/BDF+ annotation channel are automatically loaded into `emg.events` by the `EDFImporter`.
 *   **WFDB:** Annotations stored in a corresponding `.atr` (or similar) file are automatically loaded into `emg.events` by the `WFDBImporter` when loading the `.hea` file.
-*   **Other Formats:** For formats that don't have standardized annotation support within the file (like CSV, Trigno, OTB, EEGLAB `.set`), annotations are typically not loaded automatically. You may need to load them from a separate file and add them manually.
+*   **EEGLAB `.set`:** EEGLAB events are read by the `EEGLABImporter` and stored under the metadata key `events` (i.e. `emg.get_metadata('events')`), as a list of event dictionaries, rather than in the `emg.events` DataFrame.
+*   **Other Formats:** For formats that don't have standardized annotation support within the file (like CSV, Trigno, OTB), annotations are typically not loaded automatically. You may need to load them from a separate file and add them manually.
 
 **Accessing Annotations:**
 
@@ -118,8 +119,13 @@ You can add or modify metadata fields:
 # Set a single metadata field
 emg.set_metadata('subject', 'S001')
 
-# Set multiple metadata fields at once
-emg.set_metadata_dict({
+# Set several fields with repeated set_metadata calls
+emg.set_metadata('condition', 'resting')
+emg.set_metadata('experimenter', 'John Doe')
+emg.set_metadata('recording_date', '2023-01-15')
+
+# Or update the metadata dictionary directly
+emg.metadata.update({
     'subject': 'S001',
     'condition': 'resting',
     'experimenter': 'John Doe',
@@ -150,7 +156,7 @@ emg.to_edf('output')
 
 # This will create:
 # - output.edf or output.bdf (depending on format selection)
-# - output.channels.tsv (channel metadata in tab-separated format)
+# - output_channels.tsv (channel metadata in tab-separated format, BIDS naming)
 ```
 
 The channels.tsv file will include information like:

--- a/docs/user-guide/verification.md
+++ b/docs/user-guide/verification.md
@@ -18,9 +18,11 @@ from biosigio.analysis.verification import compare_signals, report_verification_
 # Load original data
 emg_original = Recording.from_file('raw_data.csv', importer='trigno')
 
-# Export to EDF and reload
+# Export to EDF/BDF and reload. to_edf auto-selects the extension, so the
+# written file may be exported_data.edf or exported_data.bdf depending on the
+# signal analysis; reload whichever was created.
 emg_original.to_edf('exported_data')
-emg_reloaded = Recording.from_file('exported_data.edf')
+emg_reloaded = Recording.from_file('exported_data.edf')  # or 'exported_data.bdf'
 
 # Compare signals with detailed metrics
 results = compare_signals(emg_original, emg_reloaded, tolerance=0.01)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: biosigIO Documentation
-site_description: Documentation for biosigIO - EMG data import/export and manipulation
+site_description: Documentation for biosigIO - biosignal (EEG/EMG/iEEG/MEG) import/export and manipulation
 site_author: Seyed (Yahya) Shirazi
 repo_url: https://github.com/neuromechanist/biosigio
 repo_name: neuromechanist/biosigio
@@ -92,6 +92,10 @@ nav:
     - Zarr Serving Store: formats/zarr.md
   - API Reference:
     - Recording Class: api/emg.md
+    - Command-Line Interface: api/cli.md
+    - Modality Vocabulary: api/core/modality.md
+    - BIDS Helpers: api/bids.md
+    - Serialization Schema: api/tabular_schema.md
     - Importers:
       - Base Importer: api/importers/base.md
       - Trigno Importer: api/importers/trigno.md
@@ -112,6 +116,7 @@ nav:
       - Zarr Exporter: api/exporters/zarr.md
     - Analysis:
       - Verification: api/analysis/verification.md
+      - Signal Analysis: api/analysis/signal.md
     - Visualization:
       - Static Plots: api/visualization/static.md
   - Examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
## 1.0.1 — docs-vs-code revision + `Recording` convenience accessors

A complete documentation accuracy pass against the actual code after the 1.0.0 rename, plus the small accessors the docs assumed. Closes #87.

Driven by **two independent reviews** — an in-house multi-agent docs-vs-code audit (53 findings) and a **Codex** pass (~20, fully overlapping/additive) — surfacing mostly legacy doc drift from the EMG-only era.

### Code
- New `Recording` accessors (with tests, NO MOCKS): `get_n_channels()`, `get_n_samples()`, `get_sampling_frequency()` (raises on mixed per-channel rates), `get_duration()`, `has_metadata()`. These were used throughout the docs but didn't exist; adding them makes the examples valid.

### Docs
- **New API pages** for previously-undocumented public surfaces: the `biosigio` **CLI** (convert/verify/info/lowres), the **modality vocabulary**, **BIDS helpers**, the **serialization schema**, and the **signal-analysis** module — all wired into the nav. `site_description` de-EMG'd.
- **Removed bogus patterns** from examples/API pages: `from_dataframe`, `register_importer`, `set_metadata_dict`, the importer-constructor-with-path + tuple-return pattern, `plot_signals(ax=/figsize=)`, `plot_comparison` as a `Recording` method, EDF importer `load_data/start_time/...` kwargs, `report_verification_results(tolerance=)`.
- **Corrected stale claims:** EDF+/BDF+ annotations load into `rec.events` (not metadata) and are embedded on export; EDF/BDF export *rejects* mixed sampling rates (was "supported"); OTB channel types (EMG/ACC/GYRO/QUAT/CTRL/OTHER); EEGLAB scipy-only / no v7.3 / events under `events`; XDF metadata keys; auto-detect extensions (`.edf`/`.bdf`, `.csv`/`.txt`; not `.edf+`); Trigno real export structure + sampling-frequency parsing; `_channels.tsv` naming; version `1.0.1`; optional extras (`meg`/`arrow`/`neo`/`zarr`); real EDF/BDF console output; brand casing; `uv run`/`uv pip`.

### Verification
- Full suite: **397 passed, 4 skipped**; `ty check biosigio` clean (**blocking**); ruff check + format clean; `mkdocs build --strict` succeeds; residual-pattern grep clean (no `from_dataframe`/`register_importer`/`set_metadata_dict`/`ax=`/`figsize=`/`IMUX`/`0.2.2`/`.channels.tsv`).

Per your request, this gets the full PR + `/review-pr` (Sonnet) treatment before merge.