### PR TITLE
1.0.2: load EEGLAB events into Recording.events

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The documentation including installation instructions, examples, and API referen
   - Automatic file format detection based on extension
   - Specialized format detection for CSV files
   - Custom importers for system-specific formats
-  - Automatic annotation/event loading (WFDB and EDF+/BDF+; EEGLAB .set events read into metadata), embedded back on EDF+/BDF+ export and carried in the Parquet/Arrow/Zarr serialization formats
+  - Automatic annotation/event loading (WFDB, EDF+/BDF+, and EEGLAB .set) into the events table, embedded back on EDF+/BDF+ export and carried in the Parquet/Arrow/Zarr serialization formats
   - LSL timestamp preservation for XDF files (for synchronization)
   
 - Export to standardized formats:

--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -210,10 +210,6 @@ class EEGLABImporter(BaseImporter):
                     event_info["duration"] = (
                         float(field_value[0][0]) if field_value[0].size > 0 else 0
                     )
-                elif field == "trial_type" and field_value.size > 0:
-                    event_info["trial_type"] = (
-                        str(field_value[0]) if field_value[0].size > 0 else ""
-                    )
 
             # Add to list if it has required fields
             if "latency" in event_info and "type" in event_info:
@@ -248,7 +244,9 @@ class EEGLABImporter(BaseImporter):
 
             # Sampling rate (used for the event onset/duration conversion below and
             # for the signal time index).
-            srate = float(metadata.get("srate", 1000))
+            # Fall back to 1000 Hz when srate is absent OR present-but-zero (an
+            # empty srate field), so the event/time-index divisions never hit 0.
+            srate = float(metadata.get("srate", 1000)) or 1000.0
 
             # Process channel information
             if "chanlocs" in data and data["chanlocs"].size > 0:

--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -236,15 +236,19 @@ class EEGLABImporter(BaseImporter):
             data = loadmat(filepath)
 
             # Create Recording object
-            emg = Recording()
+            rec = Recording()
 
             # Extract and store metadata
             metadata = self._extract_metadata(data)
             for key, value in metadata.items():
-                emg.set_metadata(key, value)
+                rec.set_metadata(key, value)
 
             # Store source file information
-            emg.set_metadata("source_file", filepath)
+            rec.set_metadata("source_file", filepath)
+
+            # Sampling rate (used for the event onset/duration conversion below and
+            # for the signal time index).
+            srate = float(metadata.get("srate", 1000))
 
             # Process channel information
             if "chanlocs" in data and data["chanlocs"].size > 0:
@@ -255,18 +259,21 @@ class EEGLABImporter(BaseImporter):
                 for i in range(metadata.get("nbchan", 0)):
                     channel_info_list.append({"label": f"Channel{i + 1}", "channel_type": "OTHER"})
 
-            # Process event information
+            # Process event information into the standard events table. EEGLAB
+            # stores event latency/duration in samples (latency is 1-based), so
+            # convert to seconds; the event ``type`` becomes the description.
             if "event" in data and data["event"].size > 0:
-                event_list = self._process_events(data["event"])
-                emg.set_metadata("events", event_list)
+                for ev in self._process_events(data["event"]):
+                    rec.add_event(
+                        onset=(ev["latency"] - 1) / srate,
+                        duration=ev.get("duration", 0.0) / srate,
+                        description=ev["type"],
+                    )
 
             # Extract signal data
             if "data" in data and data["data"].size > 0:
                 # Get data array
                 signal_data = data["data"]
-
-                # Get sampling rate
-                srate = metadata.get("srate", 1000)
 
                 # Derive the time index in seconds from the sample count. EEGLAB's
                 # `times` field is in milliseconds, so dividing it by srate (the old
@@ -288,7 +295,7 @@ class EEGLABImporter(BaseImporter):
                         df[channel_label] = channel_data
 
                 # Set signals DataFrame
-                emg.signals = df
+                rec.signals = df
 
                 # Add channel information
                 for i, channel_info in enumerate(channel_info_list):
@@ -297,7 +304,7 @@ class EEGLABImporter(BaseImporter):
 
                         # Add channel info (no silent EMG default; carry modality)
                         ch_type = channel_info.get("channel_type", "OTHER")
-                        emg.channels[channel_label] = {
+                        rec.channels[channel_label] = {
                             "sample_frequency": srate,
                             "physical_dimension": "uV",  # Default unit for EEG/EMG
                             "prefilter": "n/a",
@@ -307,13 +314,13 @@ class EEGLABImporter(BaseImporter):
 
                         # Add additional channel metadata
                         if "X" in channel_info:
-                            emg.channels[channel_label]["X"] = channel_info["X"]
+                            rec.channels[channel_label]["X"] = channel_info["X"]
                         if "Y" in channel_info:
-                            emg.channels[channel_label]["Y"] = channel_info["Y"]
+                            rec.channels[channel_label]["Y"] = channel_info["Y"]
                         if "Z" in channel_info:
-                            emg.channels[channel_label]["Z"] = channel_info["Z"]
+                            rec.channels[channel_label]["Z"] = channel_info["Z"]
 
-            return emg
+            return rec
 
         except Exception as e:
             raise ValueError(f"Error reading EEGLAB .set file: {str(e)}") from e

--- a/biosigio/tests/test_eeglab_bids_fixture.py
+++ b/biosigio/tests/test_eeglab_bids_fixture.py
@@ -42,6 +42,5 @@ def test_eeglab_bids_eeg_fixture_imports():
     # milliseconds/srate mis-scaling (which gave ~240 s for a 60 s recording).
     assert emg.signals.index[-1] == pytest.approx((n - 1) / 250, rel=1e-6)
 
-    # Events were parsed from the .set event struct.
-    events = emg.get_metadata("events")
-    assert events is not None and len(events) == 3
+    # Events were parsed from the .set event struct into the events table.
+    assert emg.events is not None and len(emg.events) == 3

--- a/biosigio/tests/test_eeglab_bids_fixture.py
+++ b/biosigio/tests/test_eeglab_bids_fixture.py
@@ -43,4 +43,4 @@ def test_eeglab_bids_eeg_fixture_imports():
     assert emg.signals.index[-1] == pytest.approx((n - 1) / 250, rel=1e-6)
 
     # Events were parsed from the .set event struct into the events table.
-    assert emg.events is not None and len(emg.events) == 3
+    assert not emg.events.empty and len(emg.events) == 3

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -146,7 +146,7 @@ def test_eeglab_importer(sample_eeglab_set):
 
     # Events are loaded into the events table (onset/duration in seconds), not metadata.
     assert "events" not in emg.metadata
-    assert emg.events is not None
+    assert not emg.events.empty
     assert len(emg.events) == 5
     assert list(emg.events["description"]) == [f"{i + 1}" for i in range(5)]
     # EEGLAB latency is 1-based samples -> seconds at 1000 Hz: (i*200+100 - 1) / 1000.
@@ -207,7 +207,7 @@ def test_eeglab_event_processing(sample_eeglab_set):
 
     # Events are loaded into the events table (onset/duration in seconds), not metadata.
     assert "events" not in emg.metadata
-    assert emg.events is not None
+    assert not emg.events.empty
     assert len(emg.events) == 5
     # The EEGLAB event `type` becomes the description.
     assert list(emg.events["description"]) == [f"{i + 1}" for i in range(5)]

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -144,13 +144,15 @@ def test_eeglab_importer(sample_eeglab_set):
         assert ch_info["sample_frequency"] == 1000
         assert ch_info["physical_dimension"] == "uV"
 
-    # Check if events were loaded
-    assert "events" in emg.metadata
-    events = emg.metadata["events"]
-    assert len(events) == 5
-    for i, event in enumerate(events):
-        assert event["latency"] == i * 200 + 100
-        assert event["type"] == f"{i + 1}"
+    # Events are loaded into the events table (onset/duration in seconds), not metadata.
+    assert "events" not in emg.metadata
+    assert emg.events is not None
+    assert len(emg.events) == 5
+    assert list(emg.events["description"]) == [f"{i + 1}" for i in range(5)]
+    # EEGLAB latency is 1-based samples -> seconds at 1000 Hz: (i*200+100 - 1) / 1000.
+    expected_onsets = [(i * 200 + 100 - 1) / 1000 for i in range(5)]
+    assert emg.events["onset"].tolist() == pytest.approx(expected_onsets)
+    assert (emg.events["duration"] == 0.0).all()
 
 
 def test_eeglab_file_not_found():
@@ -203,17 +205,15 @@ def test_eeglab_event_processing(sample_eeglab_set):
     importer = EEGLABImporter()
     emg = importer.load(sample_eeglab_set)
 
-    # Check if events were loaded
-    assert "events" in emg.metadata
-    events = emg.metadata["events"]
-    assert len(events) == 5
-
-    # Check event properties
-    for i, event in enumerate(events):
-        assert event["latency"] == i * 200 + 100
-        assert event["type"] == f"{i + 1}"
-        assert "trial_type" in event
-        assert event["trial_type"] == f"key/{chr(97 + i)}"
+    # Events are loaded into the events table (onset/duration in seconds), not metadata.
+    assert "events" not in emg.metadata
+    assert emg.events is not None
+    assert len(emg.events) == 5
+    # The EEGLAB event `type` becomes the description.
+    assert list(emg.events["description"]) == [f"{i + 1}" for i in range(5)]
+    # latency (1-based samples) -> seconds at 1000 Hz: (i*200+100 - 1) / 1000.
+    expected_onsets = [(i * 200 + 100 - 1) / 1000 for i in range(5)]
+    assert emg.events["onset"].tolist() == pytest.approx(expected_onsets)
 
 
 def test_eeglab_to_edf_export(sample_eeglab_set):

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
-__version__ = "1.0.1"
-__version_info__ = (1, 0, 1)
+__version__ = "1.0.2"
+__version_info__ = (1, 0, 2)
 
 
 def get_version() -> str:

--- a/docs/examples/eeglab.md
+++ b/docs/examples/eeglab.md
@@ -62,7 +62,7 @@ emg = Recording.from_file('data_with_events.set', importer='eeglab')
 # EEGLAB events are loaded into emg.events (a DataFrame: onset/duration in
 # seconds, description = the EEGLAB event 'type'). The latency (samples) is
 # converted to an onset in seconds on import.
-if emg.events is not None and not emg.events.empty:
+if not emg.events.empty:
     print(f"Found {len(emg.events)} events")
 
     # Print the first 5 events
@@ -71,14 +71,12 @@ if emg.events is not None and not emg.events.empty:
     # Extract specific event types by description
     movement_events = emg.events[emg.events['description'] == 'movement']
     print(f"Found {len(movement_events)} movement events")
-    
-    # Plot signals around an event
-    if movement_events:
-        # Get the timestamp of the first movement event (convert from samples to seconds)
-        event_sample = movement_events[0].get('latency')
-        fs = emg.get_sampling_frequency()
-        event_time = event_sample / fs
-        
+
+    # Plot signals around the first movement event
+    if not movement_events.empty:
+        # Onsets are already in seconds.
+        event_time = movement_events.iloc[0]['onset']
+
         # Plot 2 seconds before and after the event. Pass show=False so the
         # event marker can be overlaid before displaying.
         window = 2  # seconds

--- a/docs/examples/eeglab.md
+++ b/docs/examples/eeglab.md
@@ -59,18 +59,17 @@ import matplotlib.pyplot as plt
 # Load EEGLAB data with events
 emg = Recording.from_file('data_with_events.set', importer='eeglab')
 
-# EEGLAB events are stored under the metadata key 'events' (plural) as a list
-# of dicts with 'type', 'latency', and (optionally) 'duration'/'trial_type'.
-if emg.has_metadata('events'):
-    events = emg.get_metadata('events')
-    print(f"Found {len(events)} events")
-    
+# EEGLAB events are loaded into emg.events (a DataFrame: onset/duration in
+# seconds, description = the EEGLAB event 'type'). The latency (samples) is
+# converted to an onset in seconds on import.
+if emg.events is not None and not emg.events.empty:
+    print(f"Found {len(emg.events)} events")
+
     # Print the first 5 events
-    for i, event in enumerate(events[:5]):
-        print(f"Event {i+1}: Type={event.get('type')}, Latency={event.get('latency')}")
-    
-    # Extract specific event types
-    movement_events = [e for e in events if e.get('type') == 'movement']
+    print(emg.events.head(5).to_string(index=False))
+
+    # Extract specific event types by description
+    movement_events = emg.events[emg.events['description'] == 'movement']
     print(f"Found {len(movement_events)} movement events")
     
     # Plot signals around an event

--- a/docs/formats/eeglab.md
+++ b/docs/formats/eeglab.md
@@ -37,7 +37,7 @@ The EEGLAB importer in biosigIO (`biosigio.importers.eeglab`) works by:
 2. Extracting the EEG structure with signal data and metadata
 3. Converting channel information to biosigIO's channel format
 4. Creating appropriate metadata dictionary
-5. Storing parsed event markers under the `events` metadata key
+5. Loading event markers into the recording's `events` table (onset/duration in seconds)
 
 ## Code Example
 
@@ -73,7 +73,7 @@ EEGLAB doesn't always explicitly designate channel types. biosigIO's EEGLAB impo
 ## Notes and Limitations
 
 - Only pre-v7.3 (non-HDF5) `.set` files are supported, via `scipy.io.loadmat`; MATLAB v7.3/HDF5 `.set` files are not supported
-- Event markers are preserved under the `events` metadata key (access with `emg.get_metadata('events')`)
+- Event markers are loaded into the `events` table (`rec.events`): EEGLAB event latency/duration (samples) are converted to onset/duration in seconds and the event `type` becomes the description
 - Channel locations (if available) are preserved in the channel information
 - Some EEGLAB-specific information may not be fully preserved in the conversion
 - Time information is properly handled to maintain accurate timing in the imported data 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ biosigIO simplifies this process by providing a standardized interface for loadi
   - Automatic file format detection
   - Format-specific metadata extraction
   - Handling of specialized CSV formats
-  - Automatic annotation/event loading (WFDB and EDF+/BDF+; EEGLAB .set events read into metadata), embedded back on EDF+/BDF+ export and carried in the Parquet/Arrow/Zarr serialization formats
+  - Automatic annotation/event loading (WFDB, EDF+/BDF+, and EEGLAB .set) into the events table, embedded back on EDF+/BDF+ export and carried in the Parquet/Arrow/Zarr serialization formats
   - LSL timestamp preservation for XDF files (for synchronization)
   
 - **Intelligent export**:

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -75,7 +75,7 @@ This DataFrame has the following standard columns:
 
 *   **EDF/BDF:** Annotations stored in the EDF+/BDF+ annotation channel are automatically loaded into `emg.events` by the `EDFImporter`.
 *   **WFDB:** Annotations stored in a corresponding `.atr` (or similar) file are automatically loaded into `emg.events` by the `WFDBImporter` when loading the `.hea` file.
-*   **EEGLAB `.set`:** EEGLAB events are read by the `EEGLABImporter` and stored under the metadata key `events` (i.e. `emg.get_metadata('events')`), as a list of event dictionaries, rather than in the `emg.events` DataFrame.
+*   **EEGLAB `.set`:** EEGLAB events are loaded into `emg.events` by the `EEGLABImporter`; the event latency/duration (samples) are converted to onset/duration in seconds and the event `type` becomes the description.
 *   **Other Formats:** For formats that don't have standardized annotation support within the file (like CSV, Trigno, OTB), annotations are typically not loaded automatically. You may need to load them from a separate file and add them manually.
 
 **Accessing Annotations:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
## 1.0.2 — EEGLAB `.set` events into `Recording.events`

Fixes the one inconsistency flagged in the docs review: the EEGLAB importer parsed event markers but stored them in `metadata['events']` (a list of dicts) instead of the standard `Recording.events` DataFrame. Closes #90.

### Change
- EEGLAB events now populate `Recording.events` via `add_event`: the 1-based sample latency becomes an onset in seconds `(latency - 1) / srate`, duration (samples) → seconds, and the EEGLAB event `type` → the description. The `metadata['events']` stash is removed (no back-compat shim).
- This makes EEGLAB consistent with the EDF+/BDF+ and WFDB importers, and means EEGLAB events are now carried by the EDF/Parquet/Arrow/Zarr exporters (which read `rec.events`).
- The importer's local variable `emg` was renamed to `rec` (the `core.emg` module import is untouched). The broader `emg`→`rec` variable cleanup across docs/code/tests is tracked separately in **#89**.
- Updated the EEGLAB importer tests + docs (formats/eeglab, user-guide/metadata, examples/eeglab, README, index).

### Verification
Real fixture confirms: `wristbandEMG_truncated.set` now yields 21 rows in `rec.events`; the BIDS EEG fixture yields 3. Full suite **397 passed, 4 skipped**; `ty check biosigio` clean (blocking); ruff check + format clean; `mkdocs build --strict` succeeds.

Per the cadence, this gets `/review-pr` (Sonnet) before merge.