### PR TITLE
CI: migrate JS actions to Node 24 majors (#67)

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,10 +10,10 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
 
     - name: Run codespell
       run: uvx codespell --skip='.git*,.venv,*.svg,*.ipynb,*.dat,*.edf,*.bdf,tests/data,examples' --ignore-words-list='OT' --check-hidden

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,12 +29,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,10 +25,10 @@ jobs:
     name: ruff (lint + format)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -43,10 +43,10 @@ jobs:
     name: ty (type check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
 
     - name: Set up Python
       run: uv python install 3.12
@@ -31,7 +31,7 @@ jobs:
       run: uv run twine check dist/*
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist
         path: dist/
@@ -43,16 +43,16 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
 
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: dist
         path: dist/
@@ -78,7 +78,7 @@ jobs:
       id-token: write
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: dist
         path: dist/
@@ -100,7 +100,7 @@ jobs:
       id-token: write
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: dist
         path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         cache-dependency-glob: "pyproject.toml"
@@ -48,8 +48,8 @@ jobs:
         uv run pytest --cov=biosigio --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## CI: Node 20 → Node 24 (durable fix for #67)

GitHub forces the JS-action default to Node 24 on **2026-06-16** and removes Node 20 in fall 2026. Investigated per-action breaking changes + our exact usage + the Node-24 runtime before changing anything. Closes #67.

### Why bump majors (not the env var)
`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` is **not** a real fix — per `actions/runner#4295` it doesn't silence the deprecation warning (the annotation keys off the *declared* runtime) and it's removed in fall 2026. Bumping the action majors updates the declared runtime, clears the warning, and pulls in the actions' own Node-24 fixes.

### Changes
| action | from | to | why |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | Node 24 (v5+); we only pass `fetch-depth: 0`, unaffected |
| `astral-sh/setup-uv` | v4 | **v7** | Node 24 lands at v7; **not v8** (v8 dropped the floating `@v8` tag → would break `@major` pinning); `enable-cache`/`cache-dependency-glob` inputs unchanged |
| `codecov/codecov-action` | v5 | **v6** | Node 24 + security fix; `token`/`fail_ci_if_error` unchanged |
| `actions/upload-artifact` | v4 | **v7** | Node 24; by-name usage unaffected |
| `actions/download-artifact` | v4 | **v7** | Node 24; by-name usage unaffected; v7 avoids v8's error-on-hash-mismatch |
| `JamesIves/github-pages-deploy-action` | v4 | *(keep)* | already Node 24 (v4.8.0) |
| `pypa/gh-action-pypi-publish` | release/v1 | *(keep)* | composite — immune to the Node deprecation |

Also fixed a **pre-existing latent bug**: `tests.yml` passed `file: ./coverage.xml` to codecov, but `file` (singular) was removed at v4 and silently ignored — corrected to `files:`.

### Safety
All jobs run on `ubuntu-latest` (Node-24-capable), so the runtime move is transparent; no inputs we use changed. **Caveat:** `publish.yml` only runs on tag/release, so its artifact-action bumps aren't exercised by PR CI — will confirm on the next release. The PR-tested workflows validate `checkout@v6` / `setup-uv@v7` / `codecov@v6` on Node 24 here.

CI-only change; no package version bump.