### PR TITLE
1.0.3: rename the legacy emg variable to rec (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,23 +76,23 @@ uv pip install .
 from biosigio import Recording
 
 # Load data with automatic format detection
-emg = Recording.from_file('data.csv')  # Format detected from file extension
+rec = Recording.from_file('data.csv')  # Format detected from file extension
 
 # Load data with explicit importer
-emg = Recording.from_file('data.csv', importer='trigno')
+rec = Recording.from_file('data.csv', importer='trigno')
 
 # Plot specific channels
-emg.plot_signals(['EMG1', 'EMG2'])
+rec.plot_signals(['EMG1', 'EMG2'])
 
 # Export to EDF or BDF (format automatically determined)
-emg.to_edf('output.edf')
+rec.to_edf('output.edf')
 ```
 
 ### Generic CSV Import
 
 ```python
 # Import a generic CSV file
-emg = Recording.from_file('data.csv', importer='csv',
+rec = Recording.from_file('data.csv', importer='csv',
                    sample_frequency=1000,  # Required if no time column
                    has_header=True,        # Whether file has header row
                    channel_names=['EMG_L', 'EMG_R', 'ACC_X'])
@@ -102,24 +102,24 @@ emg = Recording.from_file('data.csv', importer='csv',
 
 ```python
 # Select specific channels
-subset_emg = emg.select_channels(['EMG1', 'EMG2', 'ACC1'])
+subset_rec = rec.select_channels(['EMG1', 'EMG2', 'ACC1'])
 
 # Select all channels of a specific type
-emg_only = emg.select_channels(channel_type='EMG')
+emg_only = rec.select_channels(channel_type='EMG')
 
 # Plot selected channels
-subset_emg.plot_signals()
+subset_rec.plot_signals()
 ```
 
 ### Metadata Handling
 
 ```python
 # Set metadata
-emg.set_metadata('subject', 'S001')
-emg.set_metadata('condition', 'resting')
+rec.set_metadata('subject', 'S001')
+rec.set_metadata('condition', 'resting')
 
 # Get metadata
-subject = emg.get_metadata('subject')
+subject = rec.get_metadata('subject')
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ rec = Recording.from_file('data.csv', importer='csv',
 
 ```python
 # Select specific channels
-subset_rec = rec.select_channels(['EMG1', 'EMG2', 'ACC1'])
+subset_emg = rec.select_channels(['EMG1', 'EMG2', 'ACC1'])
 
 # Select all channels of a specific type
 emg_only = rec.select_channels(channel_type='EMG')
 
 # Plot selected channels
-subset_rec.plot_signals()
+subset_emg.plot_signals()
 ```
 
 ### Metadata Handling

--- a/biosigio/analysis/verification.py
+++ b/biosigio/analysis/verification.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 
 
 def compare_signals(
-    emg_original: "Recording",
-    emg_reloaded: "Recording",
+    rec_original: "Recording",
+    rec_reloaded: "Recording",
     tolerance: float = 0.01,  # Default tolerance 1% for NRMSE and Max Norm Abs Diff
     channel_map: dict[str, str] | None = None,
 ) -> dict:
@@ -24,8 +24,8 @@ def compare_signals(
     Does NOT perform logging/printing.
 
     Args:
-        emg_original: The original Recording object before export.
-        emg_reloaded: The Recording object reloaded from the exported file.
+        rec_original: The original Recording object before export.
+        rec_reloaded: The Recording object reloaded from the exported file.
         tolerance: Relative tolerance for comparisons (default: 0.001 or 0.1%).
                    Used for NRMSE, Max Norm Abs Diff, and identity check.
         channel_map: Optional dictionary mapping original channel names (keys)
@@ -40,10 +40,10 @@ def compare_signals(
     # Removed local import: from biosigio.core.emg import Recording
 
     results = {}
-    if emg_original.signals is None or emg_reloaded.signals is None:
+    if rec_original.signals is None or rec_reloaded.signals is None:
         raise ValueError("No signals loaded in one or both Recording objects to compare")
-    original_channels = set(emg_original.signals.columns)
-    reloaded_channels = set(emg_reloaded.signals.columns)
+    original_channels = set(rec_original.signals.columns)
+    reloaded_channels = set(rec_reloaded.signals.columns)
 
     # Initialize channel summary
     channel_summary = {
@@ -108,8 +108,8 @@ def compare_signals(
 
     # Compare each channel pair
     for orig_channel, reloaded_channel in channel_pairs:
-        sig_orig = emg_original.signals[orig_channel].values
-        sig_reloaded = emg_reloaded.signals[reloaded_channel].values
+        sig_orig = rec_original.signals[orig_channel].values
+        sig_reloaded = rec_reloaded.signals[reloaded_channel].values
 
         # Basic check for length mismatch
         if len(sig_orig) != len(sig_reloaded):

--- a/biosigio/bids.py
+++ b/biosigio/bids.py
@@ -58,15 +58,15 @@ def find_events_tsv(data_filepath: str) -> str | None:
     return _find_sidecar(data_filepath, "events")
 
 
-def apply_channels_tsv(emg: Recording, channels_tsv_path: str) -> int:
-    """Override per-channel ``type``/``units`` in ``emg`` from a ``_channels.tsv``.
+def apply_channels_tsv(rec: Recording, channels_tsv_path: str) -> int:
+    """Override per-channel ``type``/``units`` in ``rec`` from a ``_channels.tsv``.
 
     Rows are matched to channels by the ``name`` column; ``n/a`` and empty
     values are skipped (the importer-inferred value is kept). An unrecognized
     ``type`` is warned about and skipped rather than raising.
 
     Args:
-        emg: The Recording object to update in place.
+        rec: The Recording object to update in place.
         channels_tsv_path: Path to the BIDS ``_channels.tsv``.
 
     Returns:
@@ -80,7 +80,7 @@ def apply_channels_tsv(emg: Recording, channels_tsv_path: str) -> int:
     updated = 0
     for _, row in df.iterrows():
         name = str(row["name"]).strip()
-        if name not in emg.channels:
+        if name not in rec.channels:
             continue
         kwargs: dict[str, str] = {}
         ctype = str(row.get("type", "")).strip()
@@ -92,7 +92,7 @@ def apply_channels_tsv(emg: Recording, channels_tsv_path: str) -> int:
         if not kwargs:
             continue
         try:
-            emg.set_channel(name, **kwargs)
+            rec.set_channel(name, **kwargs)
             updated += 1
         except ValueError:
             logging.warning(

--- a/biosigio/cli.py
+++ b/biosigio/cli.py
@@ -84,11 +84,11 @@ def _is_unknown(info: dict) -> bool:
     return info.get("channel_type", "OTHER") in _UNKNOWN_CHANNEL_TYPES
 
 
-def _unknown_channels(emg: Recording) -> list[str]:
-    return [name for name, info in emg.channels.items() if _is_unknown(info)]
+def _unknown_channels(rec: Recording) -> list[str]:
+    return [name for name, info in rec.channels.items() if _is_unknown(info)]
 
 
-def _apply_modality(emg: Recording, modality: str) -> None:
+def _apply_modality(rec: Recording, modality: str) -> None:
     """Fill the modality of UNKNOWN channels only; never override detected ones.
 
     Source-detected modalities win; omitting --modality (this is not called)
@@ -100,7 +100,7 @@ def _apply_modality(emg: Recording, modality: str) -> None:
             EXIT_USAGE,
             f"unknown --modality '{modality}'; choose one of {sorted(VALID_MODALITIES)}",
         )
-    for info in emg.channels.values():
+    for info in rec.channels.values():
         if _is_unknown(info):
             info["modality"] = canonical
 
@@ -140,17 +140,17 @@ def _written_path(requested: str) -> str:
 
 
 def cmd_convert(args: argparse.Namespace) -> int:
-    emg = _load_emg(args.input)
+    rec = _load_emg(args.input)
     if args.modality:
-        _apply_modality(emg, args.modality)
+        _apply_modality(rec, args.modality)
 
-    unknown = _unknown_channels(emg)
+    unknown = _unknown_channels(rec)
     if unknown:
         logger.warning("channels with unknown modality: %s", ", ".join(unknown))
 
     try:
         with _quiet_stdout():
-            emg.to_edf(
+            rec.to_edf(
                 args.output,
                 format=args.format,
                 create_channels_tsv=not args.no_channels_tsv,
@@ -170,7 +170,7 @@ def cmd_convert(args: argparse.Namespace) -> int:
         try:
             with _quiet_stdout():
                 reloaded = Recording.from_file(written)
-            results = compare_signals(emg, reloaded, tolerance=args.verify_tolerance)
+            results = compare_signals(rec, reloaded, tolerance=args.verify_tolerance)
         except Exception as e:
             raise CliError(EXIT_RUNTIME, f"verify reload failed: {e}") from e
         if not _all_identical(results):
@@ -224,14 +224,14 @@ def cmd_verify(args: argparse.Namespace) -> int:
 
 
 def cmd_info(args: argparse.Namespace) -> int:
-    emg = _load_emg(args.input)
-    rates = sorted({float(i["sample_frequency"]) for i in emg.channels.values()})
-    n_samples = int(emg.signals.shape[0]) if emg.signals is not None else 0
+    rec = _load_emg(args.input)
+    rates = sorted({float(i["sample_frequency"]) for i in rec.channels.values()})
+    n_samples = int(rec.signals.shape[0]) if rec.signals is not None else 0
     max_rate = max(rates) if rates else 0.0
     duration = round(n_samples / max_rate, 6) if max_rate else 0.0
-    n_events = int(len(emg.events)) if emg.events is not None else 0
+    n_events = int(len(rec.events)) if rec.events is not None else 0
     events_tsv = find_events_tsv(args.input)
-    unknown = _unknown_channels(emg)
+    unknown = _unknown_channels(rec)
 
     channels = [
         {
@@ -242,7 +242,7 @@ def cmd_info(args: argparse.Namespace) -> int:
             "sample_frequency": float(info["sample_frequency"]),
             "unit": info.get("physical_dimension"),
         }
-        for name, info in emg.channels.items()
+        for name, info in rec.channels.items()
     ]
 
     if unknown:
@@ -281,11 +281,11 @@ def cmd_lowres(args: argparse.Namespace) -> int:
     scaling/format bracketing in the EDF exporter. ``--bits 16`` -> EDF (16-bit),
     ``--bits 24`` -> BDF (24-bit). Default is "double low-res": 16-bit + 100 Hz.
     """
-    emg = _load_emg(args.input)
+    rec = _load_emg(args.input)
     if args.modality:
-        _apply_modality(emg, args.modality)
+        _apply_modality(rec, args.modality)
 
-    rates = sorted({float(i["sample_frequency"]) for i in emg.channels.values()})
+    rates = sorted({float(i["sample_frequency"]) for i in rec.channels.values()})
     source_rate = max(rates) if rates else 0.0
 
     # Skip the resample step when the source is already at or below the target
@@ -298,14 +298,14 @@ def cmd_lowres(args: argparse.Namespace) -> int:
         )
     else:
         try:
-            emg = emg.resample(args.rate)
+            rec = rec.resample(args.rate)
         except ValueError as e:
             raise CliError(EXIT_RUNTIME, f"resample failed: {e}") from e
 
     fmt = "edf" if args.bits == 16 else "bdf"
     try:
         with _quiet_stdout():
-            emg.to_edf(
+            rec.to_edf(
                 args.output,
                 format=fmt,
                 create_channels_tsv=not args.no_channels_tsv,

--- a/biosigio/core/emg.py
+++ b/biosigio/core/emg.py
@@ -293,7 +293,7 @@ class Recording:
             emg_only = rec.select_channels(channel_type='EMG')
 
             # Select specific EMG channels only, this example does not select ACC channels
-            rec_subset = rec.select_channels(['EMG1', 'ACC1'], channel_type='EMG')
+            emg_subset = rec.select_channels(['EMG1', 'ACC1'], channel_type='EMG')
         """
         if self.signals is None:
             raise ValueError("No signals loaded")

--- a/biosigio/core/emg.py
+++ b/biosigio/core/emg.py
@@ -91,7 +91,7 @@ class Recording:
         """
         # Delegate to the static plotting function in visualization module
         static_plot_signals(
-            emg_object=self,
+            rec_object=self,
             channels=channels,
             time_range=time_range,
             offset_scale=offset_scale,
@@ -245,12 +245,12 @@ class Recording:
         importer_class = getattr(importer_module, importers[importer])
 
         # Create importer instance and load data
-        emg = importer_class().load(filepath, **kwargs)
+        rec = importer_class().load(filepath, **kwargs)
 
         # Record provenance: which format this recording came from. setdefault so a
         # re-imported serialization file (tabular/zarr) keeps the ORIGINAL
         # source_format restored from its metadata rather than being relabeled.
-        emg.metadata.setdefault("source_format", importer)
+        rec.metadata.setdefault("source_format", importer)
 
         # In a BIDS layout, the sibling _channels.tsv is the authoritative source
         # of per-channel type/units; apply it over the importer's header/label
@@ -260,9 +260,9 @@ class Recording:
 
             channels_tsv = find_channels_tsv(filepath)
             if channels_tsv:
-                apply_channels_tsv(emg, channels_tsv)
+                apply_channels_tsv(rec, channels_tsv)
 
-        return emg
+        return rec
 
     def select_channels(
         self,
@@ -287,13 +287,13 @@ class Recording:
 
         Examples:
             # Select specific channels
-            new_emg = emg.select_channels(['EMG1', 'ACC1'])
+            new_rec = rec.select_channels(['EMG1', 'ACC1'])
 
             # Select all EMG channels
-            emg_only = emg.select_channels(channel_type='EMG')
+            emg_only = rec.select_channels(channel_type='EMG')
 
             # Select specific EMG channels only, this example does not select ACC channels
-            emg_subset = emg.select_channels(['EMG1', 'ACC1'], channel_type='EMG')
+            rec_subset = rec.select_channels(['EMG1', 'ACC1'], channel_type='EMG')
         """
         if self.signals is None:
             raise ValueError("No signals loaded")
@@ -337,21 +337,21 @@ class Recording:
                 raise ValueError(f"None of the selected channels are of modality: {modality}")
 
         # Create new Recording object
-        new_emg = Recording()
+        new_rec = Recording()
 
         # Copy selected signals and channels
-        new_emg.signals = self.signals[channels].copy()
-        new_emg.channels = {ch: self.channels[ch].copy() for ch in channels}
+        new_rec.signals = self.signals[channels].copy()
+        new_rec.channels = {ch: self.channels[ch].copy() for ch in channels}
 
         # Copy metadata
-        new_emg.metadata = self.metadata.copy()
+        new_rec.metadata = self.metadata.copy()
 
         if not inplace:
-            return new_emg
+            return new_rec
         else:
-            self.signals = new_emg.signals
-            self.channels = new_emg.channels
-            self.metadata = new_emg.metadata
+            self.signals = new_rec.signals
+            self.channels = new_rec.channels
+            self.metadata = new_rec.metadata
             return self
 
     def resample(self, target_rate: float) -> "Recording":
@@ -423,18 +423,18 @@ class Recording:
                 "resample() only down-samples (low-res). Up-sampling is out of scope."
             )
 
-        new_emg = Recording()
-        new_emg.channels = {ch: info.copy() for ch, info in self.channels.items()}
-        new_emg.metadata = self.metadata.copy()
+        new_rec = Recording()
+        new_rec.channels = {ch: info.copy() for ch, info in self.channels.items()}
+        new_rec.metadata = self.metadata.copy()
         # Onsets/durations are in SECONDS, so they remain valid after the grid
         # changes; copy them through unchanged.
-        new_emg.events = self.events.copy() if self.events is not None else self.events
+        new_rec.events = self.events.copy() if self.events is not None else self.events
 
         if target_rate == source_rate:
             # No grid change: copy signals through untouched (fresh RangeIndex for
             # consistency with the resampled path).
-            new_emg.signals = self.signals.copy().reset_index(drop=True)
-            return new_emg
+            new_rec.signals = self.signals.copy().reset_index(drop=True)
+            return new_rec
 
         # Rational resampling factors from the integer rates.
         src_i = int(round(source_rate))
@@ -463,12 +463,12 @@ class Recording:
         # shared anti-alias FIR.
         resampled = resample_poly(data, up, down, axis=0)
 
-        new_emg.signals = pd.DataFrame(resampled, columns=columns)
-        new_emg.signals.index = pd.RangeIndex(len(new_emg.signals))
-        for info in new_emg.channels.values():
+        new_rec.signals = pd.DataFrame(resampled, columns=columns)
+        new_rec.signals.index = pd.RangeIndex(len(new_rec.signals))
+        for info in new_rec.channels.values():
             info["sample_frequency"] = actual_rate
 
-        return new_emg
+        return new_rec
 
     def get_channel_types(self) -> list[str]:
         """
@@ -647,12 +647,12 @@ class Recording:
             logging.info(f"Verification requested. Reloading exported file: {filepath}")
             try:
                 # Reload the exported file
-                reloaded_emg = Recording.from_file(filepath, importer="edf")
+                reloaded_rec = Recording.from_file(filepath, importer="edf")
 
                 logging.info("Comparing original signals with reloaded signals...")
                 # Compare signals using the imported function
                 verification_results = compare_signals(
-                    self, reloaded_emg, tolerance=verify_tolerance, channel_map=verify_channel_map
+                    self, reloaded_rec, tolerance=verify_tolerance, channel_map=verify_channel_map
                 )
 
                 # Generate and log report using the imported function
@@ -665,7 +665,7 @@ class Recording:
                 compared_count = sum(1 for k in verification_results if k != "channel_summary")
 
                 if verify_plot and compared_count > 0 and comparison_mode != "failed":
-                    plot_comparison(self, reloaded_emg, channel_map=verify_channel_map)
+                    plot_comparison(self, reloaded_rec, channel_map=verify_channel_map)
                 elif verify_plot:
                     logging.warning(
                         "Skipping verification plot: No channels were successfully compared."

--- a/biosigio/exporters/edf.py
+++ b/biosigio/exporters/edf.py
@@ -274,7 +274,7 @@ class EDFExporter:
 
     @staticmethod
     def export(
-        emg: Recording,
+        rec: Recording,
         filepath: str,
         precision_threshold: float = 0.01,
         method: str = "both",
@@ -293,7 +293,7 @@ class EDFExporter:
         Export EMG data to EDF/BDF format with optional BIDS-compliant channels.tsv file.
 
         Args:
-            emg: Recording object containing the data
+            rec: Recording object containing the data
             filepath: Path to save the EDF/BDF file
             precision_threshold: Maximum acceptable precision loss percentage (default: 0.01%)
             method: Method for signal analysis ('svd', 'fft', or 'both')
@@ -331,7 +331,7 @@ class EDFExporter:
                 (or forced/low-res EDF) trigger clipping.
             **kwargs: Additional arguments for the exporter
         """
-        if emg.signals is None:
+        if rec.signals is None:
             raise ValueError("No signals to export")
 
         print("\nSignal Analysis:")
@@ -373,9 +373,9 @@ class EDFExporter:
         # --- Conditional Signal Analysis ---
         if not bypass_analysis:
             # Analyze signals (needed for summary and potentially for 'auto' format decision)
-            for ch_name in emg.channels:
-                signal = emg.signals[ch_name].values
-                ch_info = emg.channels[ch_name]
+            for ch_name in rec.channels:
+                signal = rec.signals[ch_name].values
+                ch_info = rec.channels[ch_name]
 
                 # Analyze signal characteristics
                 analysis = analyze_signal(
@@ -444,7 +444,7 @@ class EDFExporter:
         # an unreadable file when per-channel record counts differ. Fail loudly instead
         # of writing a corrupt file; mixed-rate sources (e.g. Trigno EMG + ACC) must be
         # resampled to a common rate before export.
-        distinct_rates = {int(emg.channels[ch]["sample_frequency"]) for ch in emg.channels}
+        distinct_rates = {int(rec.channels[ch]["sample_frequency"]) for ch in rec.channels}
         if len(distinct_rates) > 1:
             raise ValueError(
                 "EDF/BDF export requires a single sampling rate across all channels, but "
@@ -459,14 +459,14 @@ class EDFExporter:
             filepath = os.path.splitext(filepath)[0] + ".edf"
             filetype = pyedflib.FILETYPE_EDFPLUS
 
-        writer = pyedflib.EdfWriter(filepath, len(emg.channels), file_type=filetype)
+        writer = pyedflib.EdfWriter(filepath, len(rec.channels), file_type=filetype)
 
         try:
             # MEMORY OPTIMIZATION: Two-pass approach to avoid holding all signals in memory
             # Pass 1: Collect headers only (compute min/max without copying data)
-            for _i, ch_name in enumerate(emg.channels):
-                signal = emg.signals[ch_name].values
-                ch_info = emg.channels[ch_name]
+            for _i, ch_name in enumerate(rec.channels):
+                signal = rec.signals[ch_name].values
+                ch_info = rec.channels[ch_name]
 
                 # Resolve the physical window the bounds will bracket. Handle the
                 # empty/all-NaN edge case, then choose the window (full range, or a
@@ -554,11 +554,11 @@ class EDFExporter:
             # (sample_frequency samples) per call, so calling it once per channel with
             # the full array silently truncated every export to a single record
             # (one second). writeSamples() emits all records for every signal.
-            # IMPORTANT: order must match setSignalHeaders; emg.channels preserves
+            # IMPORTANT: order must match setSignalHeaders; rec.channels preserves
             # insertion order (Python 3.7+) and both passes iterate it.
             signals_to_write = [
-                np.nan_to_num(emg.signals[ch_name].values, nan=0.0).astype(np.float64, copy=False)
-                for ch_name in emg.channels
+                np.nan_to_num(rec.signals[ch_name].values, nan=0.0).astype(np.float64, copy=False)
+                for ch_name in rec.channels
             ]
             writer.writeSamples(signals_to_write)
 
@@ -629,7 +629,7 @@ class EDFExporter:
                         "use_bdf": use_bdf,  # Use the final decision for the whole file
                     }
 
-                summary = summarize_channels(cast(dict, emg.channels), summary_analyses)
+                summary = summarize_channels(cast(dict, rec.channels), summary_analyses)
                 print("\nSummary:")
                 print(summary)
             else:

--- a/biosigio/importers/_mne_common.py
+++ b/biosigio/importers/_mne_common.py
@@ -3,7 +3,7 @@
 MNE is an optional, heavy dependency, so it is imported lazily via
 :func:`require_mne` (with a clear install hint) rather than at module import.
 Both importers turn an MNE ``Raw`` into a :class:`~biosigio.core.emg.Recording` with the
-same channel-type/unit mapping (:func:`raw_to_emg`); they differ only in how the
+same channel-type/unit mapping (:func:`raw_to_recording`); they differ only in how the
 ``Raw`` is read and how events are extracted.
 """
 
@@ -57,7 +57,7 @@ def require_mne():
     return mne
 
 
-def raw_to_emg(raw) -> Recording:
+def raw_to_recording(raw) -> Recording:
     """Build a Recording from an MNE ``Raw``: channels with mapped types and FIFF units.
 
     Does not read events (the two importers extract them differently) and does not
@@ -66,24 +66,24 @@ def raw_to_emg(raw) -> Recording:
     expected pandas warning is suppressed and the frame de-fragmented once after
     (root-cause perf drift tracked in #66).
     """
-    emg = Recording()
+    rec = Recording()
     sfreq = float(raw.info["sfreq"])
     data = raw.get_data()  # (n_channels, n_samples) in SI units
     mne_types = raw.get_channel_types()
-    emg.set_metadata("number_of_signals", len(raw.ch_names))
+    rec.set_metadata("number_of_signals", len(raw.ch_names))
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
         for i, name in enumerate(raw.ch_names):
             channel_type = _MNE_TYPE_TO_biosigIO.get(mne_types[i], "OTHER")
             unit_code = int(raw.info["chs"][i]["unit"])
-            emg.add_channel(
+            rec.add_channel(
                 label=name,
                 data=data[i],
                 sample_frequency=sfreq,
                 physical_dimension=_FIFF_UNIT_TO_DIM.get(unit_code, "n/a"),
                 channel_type=channel_type,
             )
-    if emg.signals is not None:
-        emg.signals = emg.signals.copy()  # de-fragment after many inserts
-    return emg
+    if rec.signals is not None:
+        rec.signals = rec.signals.copy()  # de-fragment after many inserts
+    return rec

--- a/biosigio/importers/brainvision.py
+++ b/biosigio/importers/brainvision.py
@@ -10,7 +10,7 @@ MNE exposes as annotations) are read into ``Recording.events``.
 import pandas as pd
 
 from ..core.emg import Recording
-from ._mne_common import raw_to_emg, require_mne
+from ._mne_common import raw_to_recording, require_mne
 from .base import BaseImporter
 
 
@@ -53,11 +53,11 @@ class BrainVisionImporter(BaseImporter):
         except Exception as e:
             raise ValueError(f"Error reading BrainVision file {filepath}: {e}") from e
 
-        emg = raw_to_emg(raw)
-        emg.set_metadata("source_file", filepath)
+        rec = raw_to_recording(raw)
+        rec.set_metadata("source_file", filepath)
 
         events = self._read_events(raw)
         if not events.empty:
-            emg.events = events
+            rec.events = events
 
-        return emg
+        return rec

--- a/biosigio/importers/csv.py
+++ b/biosigio/importers/csv.py
@@ -204,15 +204,15 @@ class CSVImporter(BaseImporter):
                 )
 
         # Create recording object
-        emg = Recording()
+        rec = Recording()
 
         # Add metadata
-        emg.set_metadata("source_file", filepath)
-        emg.set_metadata("file_format", "CSV")
+        rec.set_metadata("source_file", filepath)
+        rec.set_metadata("file_format", "CSV")
 
         # Add any user-provided metadata
         for key, value in metadata.items():
-            emg.set_metadata(key, value)
+            rec.set_metadata(key, value)
 
         # Default sampling frequency if not specified
         default_sample_frequency = 1000.0  # 1 kHz is a common default for EMG
@@ -246,7 +246,7 @@ class CSVImporter(BaseImporter):
                 phys_dim = self._default_physical_dimension(ch_type)
 
             # Add the channel to the recording
-            emg.add_channel(
+            rec.add_channel(
                 label=column,
                 data=df[column].values,
                 sample_frequency=sample_frequency or default_sample_frequency,
@@ -255,9 +255,9 @@ class CSVImporter(BaseImporter):
             )
 
         # Encourage user to add metadata if missing essential information
-        self._print_metadata_reminder(emg)
+        self._print_metadata_reminder(rec)
 
-        return emg
+        return rec
 
     def _analyze_csv_structure(self, filepath: str) -> dict:
         """
@@ -424,18 +424,18 @@ class CSVImporter(BaseImporter):
         dimensions = {"EMG": "µV", "ACC": "g", "GYRO": "deg/s", "TIME": "s", "OTHER": "a.u."}
         return dimensions.get(channel_type, "a.u.")
 
-    def _print_metadata_reminder(self, emg: Recording) -> None:
+    def _print_metadata_reminder(self, rec: Recording) -> None:
         """
         Print a reminder to add metadata if essential information is missing.
 
         Args:
-            emg: Recording object to check
+            rec: Recording object to check
         """
         essential_metadata = ["subject", "device", "recording_date"]
-        missing = [meta for meta in essential_metadata if meta not in emg.metadata]
+        missing = [meta for meta in essential_metadata if meta not in rec.metadata]
 
         if missing:
             print("[INFO] Reminder: Consider adding essential metadata for better context:")
             for meta in missing:
-                print(f"  emg.set_metadata('{meta}', '<Your {meta.replace('_', ' ').title()}>')")
-            print("Example: emg.set_metadata('subject', 'S001')")
+                print(f"  rec.set_metadata('{meta}', '<Your {meta.replace('_', ' ').title()}>')")
+            print("Example: rec.set_metadata('subject', 'S001')")

--- a/biosigio/importers/edf.py
+++ b/biosigio/importers/edf.py
@@ -158,18 +158,18 @@ class EDFImporter(BaseImporter):
             edf_reader = pyedflib.EdfReader(filepath)
 
             # Create Recording object
-            emg = Recording()
+            rec = Recording()
 
             # Extract and store metadata
             metadata = self._extract_metadata(edf_reader)
             for key, value in metadata["recording_info"].items():
                 if value:  # Only store non-empty values
-                    emg.set_metadata(key, value)
+                    rec.set_metadata(key, value)
             for key, value in metadata["file_info"].items():
-                emg.set_metadata(key, value)
+                rec.set_metadata(key, value)
 
             # Store source file information
-            emg.set_metadata("source_file", filepath)
+            rec.set_metadata("source_file", filepath)
 
             # Read signals
             for i in range(edf_reader.signals_in_file):
@@ -181,7 +181,7 @@ class EDFImporter(BaseImporter):
                 )
 
                 # Add channel to Recording object
-                emg.add_channel(
+                rec.add_channel(
                     label=signal_info["label"],
                     data=signal_data,
                     sample_frequency=signal_info["sample_frequency"],
@@ -198,7 +198,7 @@ class EDFImporter(BaseImporter):
                     "digital_max": signal_info["digital_max"],
                     "transducer": signal_info["transducer"],
                 }
-                emg.channels[signal_info["label"]].update(channel_metadata)
+                rec.channels[signal_info["label"]].update(channel_metadata)
 
             # Read EDF+/BDF+ annotations into events so they survive the
             # import->export->import round-trip (issue #47). Assigned directly
@@ -207,9 +207,9 @@ class EDFImporter(BaseImporter):
             # sorted by onset). Left as the empty __init__ frame when none exist.
             events = self._read_annotations(edf_reader)
             if not events.empty:
-                emg.events = events
+                rec.events = events
 
-            return emg
+            return rec
 
         except Exception as e:
             raise ValueError(f"Error reading EDF file: {str(e)}") from e

--- a/biosigio/importers/meg.py
+++ b/biosigio/importers/meg.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 from ..core.emg import Recording
-from ._mne_common import raw_to_emg, require_mne
+from ._mne_common import raw_to_recording, require_mne
 from .base import BaseImporter
 
 
@@ -63,11 +63,11 @@ class MEGImporter(BaseImporter):
         except Exception as e:
             raise ValueError(f"Error reading MEG file {filepath}: {e}") from e
 
-        emg = raw_to_emg(raw)
-        emg.set_metadata("source_file", filepath)
+        rec = raw_to_recording(raw)
+        rec.set_metadata("source_file", filepath)
 
         events = self._read_events(mne, raw, float(raw.info["sfreq"]))
         if not events.empty:
-            emg.events = events
+            rec.events = events
 
-        return emg
+        return rec

--- a/biosigio/importers/neo.py
+++ b/biosigio/importers/neo.py
@@ -130,7 +130,7 @@ class NeoImporter(BaseImporter):
 
         selected = self._select_streams(seg.analogsignals, stream, filepath)
 
-        emg = Recording()
+        rec = Recording()
         used: set[str] = set()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
@@ -144,28 +144,28 @@ class NeoImporter(BaseImporter):
                 for col, name in enumerate(names):
                     label = _unique_label(name, used)  # keep merged streams distinct
                     used.add(label)
-                    emg.add_channel(
+                    rec.add_channel(
                         label=label,
                         data=data[:, col],
                         sample_frequency=fs,
                         physical_dimension=dimension,
                         channel_type=channel_type,
                     )
-        if emg.signals is not None:
-            emg.signals = emg.signals.copy()  # de-fragment after many inserts (#66)
+        if rec.signals is not None:
+            rec.signals = rec.signals.copy()  # de-fragment after many inserts (#66)
 
         # Align events to the imported signal's time origin (neo times are in the
         # recording's absolute time base, which may not start at zero). The 0-based
         # signal grid discards the absolute origin, so keep it in metadata for
         # downstream (e.g. BIDS) temporal alignment.
         t0 = float(selected[0].t_start.rescale("s").magnitude)
-        self._add_events(emg, seg, t0)
+        self._add_events(rec, seg, t0)
 
-        emg.set_metadata("source_file", filepath)
-        emg.set_metadata("neo_io", type(reader).__name__)
-        emg.set_metadata("t_start_s", t0)
-        emg.set_metadata("number_of_signals", len(emg.channels))
-        return emg
+        rec.set_metadata("source_file", filepath)
+        rec.set_metadata("neo_io", type(reader).__name__)
+        rec.set_metadata("t_start_s", t0)
+        rec.set_metadata("number_of_signals", len(rec.channels))
+        return rec
 
     @staticmethod
     def _select_streams(analogsignals, stream, filepath):
@@ -231,7 +231,7 @@ class NeoImporter(BaseImporter):
         return list(analogsignals)
 
     @staticmethod
-    def _add_events(emg: Recording, seg, t0: float) -> None:
+    def _add_events(rec: Recording, seg, t0: float) -> None:
         """Add neo Events (instantaneous) and Epochs (with duration) as biosigio events."""
 
         def labels_for(obj, times):
@@ -244,9 +244,9 @@ class NeoImporter(BaseImporter):
         for ev in seg.events:
             times = np.asarray(ev.times.rescale("s").magnitude)
             for onset, label in zip(times, labels_for(ev, times), strict=True):
-                emg.add_event(onset=float(onset) - t0, duration=0.0, description=label)
+                rec.add_event(onset=float(onset) - t0, duration=0.0, description=label)
         for ep in seg.epochs:
             times = np.asarray(ep.times.rescale("s").magnitude)
             durations = np.asarray(ep.durations.rescale("s").magnitude)
             for onset, dur, label in zip(times, durations, labels_for(ep, times), strict=True):
-                emg.add_event(onset=float(onset) - t0, duration=float(dur), description=label)
+                rec.add_event(onset=float(onset) - t0, duration=float(dur), description=label)

--- a/biosigio/importers/otb.py
+++ b/biosigio/importers/otb.py
@@ -249,7 +249,7 @@ class OTBImporter(BaseImporter):
             Recording: Recording object containing the loaded data
         """
         # Create Recording object
-        emg = Recording()
+        rec = Recording()
         temp_dir = None
 
         try:
@@ -281,7 +281,7 @@ class OTBImporter(BaseImporter):
             # Add channels to Recording object
             for ch_name, ch_info in metadata["channels"].items():
                 ch_idx = int(ch_name[2:]) - 1  # Extract channel number from 'CHx'
-                emg.add_channel(
+                rec.add_channel(
                     label=ch_name,
                     data=data[ch_idx],
                     sample_frequency=ch_info["sample_frequency"],
@@ -291,9 +291,9 @@ class OTBImporter(BaseImporter):
                 )
 
             # Add metadata
-            emg.set_metadata("source_file", filepath)
-            emg.set_metadata("device", metadata["device"]["name"])
-            emg.set_metadata("signal_resolution", metadata["device"]["ad_bits"])
+            rec.set_metadata("source_file", filepath)
+            rec.set_metadata("device", metadata["device"]["name"])
+            rec.set_metadata("signal_resolution", metadata["device"]["ad_bits"])
 
         finally:
             # Clean up temporary directory
@@ -305,4 +305,4 @@ class OTBImporter(BaseImporter):
                 except Exception as e:
                     print(f"Warning: Failed to clean up temp directory {temp_dir}: {str(e)}")
 
-        return emg
+        return rec

--- a/biosigio/importers/trigno.py
+++ b/biosigio/importers/trigno.py
@@ -81,7 +81,7 @@ class TrignoImporter(BaseImporter):
             Recording: Recording object containing the loaded data
         """
         # Create Recording object
-        emg = Recording()
+        rec = Recording()
 
         # Analyze file structure
         metadata_lines, data_start, header_line = self._analyze_csv_structure(filepath)
@@ -117,7 +117,7 @@ class TrignoImporter(BaseImporter):
                 else:
                     ch_type = "OTHER"
 
-                emg.add_channel(
+                rec.add_channel(
                     label=label,
                     data=df[label].values,
                     sample_frequency=info["sample_frequency"],
@@ -126,7 +126,7 @@ class TrignoImporter(BaseImporter):
                 )
 
         # Add file metadata
-        emg.set_metadata("source_file", filepath)
-        emg.set_metadata("device", "Delsys Trigno")
+        rec.set_metadata("source_file", filepath)
+        rec.set_metadata("device", "Delsys Trigno")
 
-        return emg
+        return rec

--- a/biosigio/importers/wfdb.py
+++ b/biosigio/importers/wfdb.py
@@ -46,21 +46,21 @@ class WFDBImporter(BaseImporter):
             record = wfdb.rdrecord(record_name=record_name, sampfrom=0, sampto=None, physical=True)
 
             # Create Recording object
-            emg = Recording()
+            rec = Recording()
 
             # Store metadata from header
-            emg.set_metadata("source_file", filepath)
-            emg.set_metadata("record_name", record.record_name)
-            emg.set_metadata("sampling_frequency", record.fs)  # Store overall sampling frequency
+            rec.set_metadata("source_file", filepath)
+            rec.set_metadata("record_name", record.record_name)
+            rec.set_metadata("sampling_frequency", record.fs)  # Store overall sampling frequency
             if record.base_date and record.base_time:
-                emg.set_metadata("startdate", record.base_date)
-                emg.set_metadata("starttime", record.base_time)
+                rec.set_metadata("startdate", record.base_date)
+                rec.set_metadata("starttime", record.base_time)
             if record.comments:
-                emg.set_metadata("comments", "\n".join(record.comments))
+                rec.set_metadata("comments", "\n".join(record.comments))
 
             # Add channels
             for i, sig_name in enumerate(record.sig_name):
-                emg.add_channel(
+                rec.add_channel(
                     label=sig_name,
                     data=record.p_signal[:, i],
                     sample_frequency=record.fs,  # Use record's fs, assuming uniform sampling
@@ -93,7 +93,7 @@ class WFDBImporter(BaseImporter):
                 # Filter out None values before updating
                 filtered_metadata = {k: v for k, v in channel_metadata.items() if v is not None}
                 if filtered_metadata:  # Only update if there is metadata to add
-                    emg.channels[sig_name].update(filtered_metadata)
+                    rec.channels[sig_name].update(filtered_metadata)
 
             # Read annotations if available (look for .atr file by default)
             # Note: wfdb-python automatically searches common annotation extensions
@@ -103,9 +103,9 @@ class WFDBImporter(BaseImporter):
                 )
 
                 # Add annotations to the Recording object
-                # Assuming emg object has an `add_event` or `add_annotation` method
+                # Assuming rec object has an `add_event` or `add_annotation` method
                 # The structure (onset, duration, description) is common
-                if hasattr(emg, "add_event") and callable(emg.add_event):
+                if hasattr(rec, "add_event") and callable(rec.add_event):
                     # Map WFDB annotations to events
                     # Use annotation symbols as descriptions, sample indices as onsets
                     for i, symbol in enumerate(annotation.symbol):
@@ -113,13 +113,13 @@ class WFDBImporter(BaseImporter):
                         description = f"WFDB Annotation: {symbol}"
                         # WFDB annotations are typically point events (zero duration)
                         duration_sec = 0
-                        emg.add_event(
+                        rec.add_event(
                             onset=onset_sec, duration=duration_sec, description=description
                         )
 
                 else:
                     # Fallback: Store raw annotation data in metadata if no specific method exists
-                    emg.set_metadata(
+                    rec.set_metadata(
                         "wfdb_annotations",
                         {
                             "sample": annotation.sample.tolist(),
@@ -134,12 +134,12 @@ class WFDBImporter(BaseImporter):
 
             except FileNotFoundError:
                 # This specific FileNotFoundError means the .atr file is missing, which is okay.
-                emg.set_metadata("annotation_status", "Annotation file (.atr) not found.")
+                rec.set_metadata("annotation_status", "Annotation file (.atr) not found.")
             except Exception as ann_e:
                 # Other errors during annotation reading are warnings/metadata entries
-                emg.set_metadata("annotation_error", f"Error reading annotations: {str(ann_e)}")
+                rec.set_metadata("annotation_error", f"Error reading annotations: {str(ann_e)}")
 
-            return emg
+            return rec
 
         except FileNotFoundError as fnf_e:
             # This might occur if rdrecord itself can't find the .dat file

--- a/biosigio/importers/xdf.py
+++ b/biosigio/importers/xdf.py
@@ -428,10 +428,10 @@ class XDFImporter(BaseImporter):
         >>>
         >>> # Import specific streams (only loads selected streams)
         >>> importer = XDFImporter()
-        >>> emg = importer.load("recording.xdf", stream_names=["EMG_stream"])
+        >>> rec = importer.load("recording.xdf", stream_names=["EMG_stream"])
         >>>
         >>> # Or import by type
-        >>> emg = importer.load("recording.xdf", stream_types=["EMG", "EXG"])
+        >>> rec = importer.load("recording.xdf", stream_types=["EMG", "EXG"])
     """
 
     def load(
@@ -537,24 +537,24 @@ class XDFImporter(BaseImporter):
                 )
 
         # Create Recording object
-        emg = Recording()
+        rec = Recording()
 
         # Store metadata
-        emg.set_metadata("source_file", filepath)
-        emg.set_metadata("device", "XDF")
-        emg.set_metadata("stream_count", len(selected_streams))
+        rec.set_metadata("source_file", filepath)
+        rec.set_metadata("device", "XDF")
+        rec.set_metadata("stream_count", len(selected_streams))
 
         if sync_streams and len(selected_streams) > 1:
             self._load_synchronized_streams(
-                emg, selected_streams, default_channel_type, include_timestamps, reference_stream
+                rec, selected_streams, default_channel_type, include_timestamps, reference_stream
             )
         else:
             # Load streams (uses highest sample rate as reference unless specified)
             self._load_streams(
-                emg, selected_streams, default_channel_type, include_timestamps, reference_stream
+                rec, selected_streams, default_channel_type, include_timestamps, reference_stream
             )
 
-        return emg
+        return rec
 
     def _build_select_streams(
         self,
@@ -700,7 +700,7 @@ class XDFImporter(BaseImporter):
 
     def _load_streams(
         self,
-        emg: Recording,
+        rec: Recording,
         streams: list[dict],
         default_channel_type: str,
         include_timestamps: bool = False,
@@ -856,7 +856,7 @@ class XDFImporter(BaseImporter):
                 ch_type = validate_channel_type(ch_info["type"])
             except ValueError:
                 ch_type = "OTHER"
-            emg.channels[label] = {
+            rec.channels[label] = {
                 "sample_frequency": ch_info["srate"] if ch_info["srate"] else base_srate,
                 "physical_dimension": ch_info["unit"],
                 "prefilter": "n/a",
@@ -882,7 +882,7 @@ class XDFImporter(BaseImporter):
 
                 df[ts_label] = resampled_ts
 
-                emg.channels[ts_label] = {
+                rec.channels[ts_label] = {
                     "sample_frequency": ts_info["srate"] if ts_info["srate"] else base_srate,
                     "physical_dimension": "s",  # seconds
                     "prefilter": "n/a",
@@ -890,12 +890,12 @@ class XDFImporter(BaseImporter):
                     "modality": "MISC",
                 }
 
-        emg.signals = df
-        emg.set_metadata("srate", base_srate)
+        rec.signals = df
+        rec.set_metadata("srate", base_srate)
 
     def _load_synchronized_streams(
         self,
-        emg: Recording,
+        rec: Recording,
         streams: list[dict],
         default_channel_type: str,
         include_timestamps: bool = False,
@@ -908,7 +908,7 @@ class XDFImporter(BaseImporter):
         Currently, pyxdf handles clock synchronization during file loading,
         so this delegates to _load_streams without additional processing.
         """
-        self._load_streams(emg, streams, default_channel_type, include_timestamps, reference_stream)
+        self._load_streams(rec, streams, default_channel_type, include_timestamps, reference_stream)
 
     def _extract_channel_info(
         self,

--- a/biosigio/tests/test_bids_channels_tsv.py
+++ b/biosigio/tests/test_bids_channels_tsv.py
@@ -22,17 +22,17 @@ IEEG = (
 
 @pytest.mark.skipif(not IEEG.exists(), reason="iEEG BIDS fixture missing")
 def test_channels_tsv_assigns_seeg_types():
-    emg = Recording.from_file(str(IEEG))
-    assert {info["channel_type"] for info in emg.channels.values()} == {"SEEG"}
-    assert {info["modality"] for info in emg.channels.values()} == {"IEEG"}
+    rec = Recording.from_file(str(IEEG))
+    assert {info["channel_type"] for info in rec.channels.values()} == {"SEEG"}
+    assert {info["modality"] for info in rec.channels.values()} == {"IEEG"}
 
 
 @pytest.mark.skipif(not IEEG.exists(), reason="iEEG BIDS fixture missing")
 def test_bids_channels_off_falls_back_to_header_inference():
-    emg = Recording.from_file(str(IEEG), bids_channels="off")
+    rec = Recording.from_file(str(IEEG), bids_channels="off")
     # Without the sidecar the EDF header cannot supply SEEG; assert the sidecar
     # was not consulted rather than pinning the exact inferred type.
-    assert "SEEG" not in {info["channel_type"] for info in emg.channels.values()}
+    assert "SEEG" not in {info["channel_type"] for info in rec.channels.values()}
 
 
 @pytest.mark.skipif(not IEEG.exists(), reason="iEEG BIDS fixture missing")

--- a/biosigio/tests/test_brainvision_importer.py
+++ b/biosigio/tests/test_brainvision_importer.py
@@ -22,27 +22,27 @@ pytestmark = pytest.mark.skipif(not VHDR.exists(), reason="BrainVision fixture m
 
 
 @pytest.fixture(scope="module")
-def bv_emg():
+def bv_rec():
     return Recording.from_file(str(VHDR))
 
 
-def test_brainvision_channels_and_units(bv_emg):
-    assert list(bv_emg.signals.columns) == ["FP1", "AF7", "FPZ", "FP2", "AF8", "F9", "F7", "F5"]
-    assert {i["channel_type"] for i in bv_emg.channels.values()} == {"EEG"}
-    assert {i["modality"] for i in bv_emg.channels.values()} == {"EEG"}
-    assert {i["physical_dimension"] for i in bv_emg.channels.values()} == {"V"}  # MNE SI units
-    assert {i["sample_frequency"] for i in bv_emg.channels.values()} == {250.0}
-    assert bv_emg.signals.shape == (1250, 8)  # 5 s @ 250 Hz
+def test_brainvision_channels_and_units(bv_rec):
+    assert list(bv_rec.signals.columns) == ["FP1", "AF7", "FPZ", "FP2", "AF8", "F9", "F7", "F5"]
+    assert {i["channel_type"] for i in bv_rec.channels.values()} == {"EEG"}
+    assert {i["modality"] for i in bv_rec.channels.values()} == {"EEG"}
+    assert {i["physical_dimension"] for i in bv_rec.channels.values()} == {"V"}  # MNE SI units
+    assert {i["sample_frequency"] for i in bv_rec.channels.values()} == {250.0}
+    assert bv_rec.signals.shape == (1250, 8)  # 5 s @ 250 Hz
     # No modality creep: an EEG recording must not invent EMG channels.
-    assert "EMG" not in {i["channel_type"] for i in bv_emg.channels.values()}
+    assert "EMG" not in {i["channel_type"] for i in bv_rec.channels.values()}
 
 
-def test_brainvision_markers_become_events(bv_emg):
+def test_brainvision_markers_become_events(bv_rec):
     """.vmrk markers (MNE annotations) are read into events, sorted, in seconds."""
-    assert bv_emg.events is not None and len(bv_emg.events) == 3
-    assert np.allclose(bv_emg.events["onset"].to_numpy(), [1.0, 2.5, 4.0])
-    assert bv_emg.events["onset"].dtype == np.float64
-    assert all(bv_emg.events["description"].str.contains("Stimulus"))
+    assert bv_rec.events is not None and len(bv_rec.events) == 3
+    assert np.allclose(bv_rec.events["onset"].to_numpy(), [1.0, 2.5, 4.0])
+    assert bv_rec.events["onset"].dtype == np.float64
+    assert all(bv_rec.events["description"].str.contains("Stimulus"))
 
 
 def test_brainvision_no_markers_gives_empty_events():
@@ -57,15 +57,15 @@ def test_brainvision_no_markers_gives_empty_events():
     assert events.empty
 
 
-def test_brainvision_roundtrip_through_edf(bv_emg, tmp_path):
+def test_brainvision_roundtrip_through_edf(bv_rec, tmp_path):
     """Channels survive an EDF/BDF export + reimport (r > 0.99)."""
     out = tmp_path / "bv.edf"
-    bv_emg.to_edf(str(out), format="bdf", bypass_analysis=True)
+    bv_rec.to_edf(str(out), format="bdf", bypass_analysis=True)
     written = out if out.exists() else out.with_suffix(".bdf")
     reloaded = Recording.from_file(str(written), bids_channels="off")
-    assert len(reloaded.channels) == len(bv_emg.channels)
-    for ch in bv_emg.signals.columns:
-        original = bv_emg.signals[ch].values.astype(float)
+    assert len(reloaded.channels) == len(bv_rec.channels)
+    for ch in bv_rec.signals.columns:
+        original = bv_rec.signals[ch].values.astype(float)
         roundtripped = reloaded.signals[ch].values[: len(original)].astype(float)
         if np.std(original) == 0:
             continue

--- a/biosigio/tests/test_cli.py
+++ b/biosigio/tests/test_cli.py
@@ -127,12 +127,12 @@ def test_is_unknown_uses_channel_type_not_modality():
 
 def test_apply_modality_fills_only_unknown_channels():
     """--modality fills OTHER-typed channels but leaves detected ones untouched."""
-    emg = Recording()
-    emg.add_channel("X", np.zeros(100), 100, "uV", "OTHER")
-    emg.add_channel("ECG1", np.zeros(100), 100, "uV", "ECG")
-    _apply_modality(emg, "EEG")
-    assert emg.channels["X"]["modality"] == "EEG"  # unknown -> filled
-    assert emg.channels["ECG1"]["modality"] == "MISC"  # detected -> untouched
+    rec = Recording()
+    rec.add_channel("X", np.zeros(100), 100, "uV", "OTHER")
+    rec.add_channel("ECG1", np.zeros(100), 100, "uV", "ECG")
+    _apply_modality(rec, "EEG")
+    assert rec.channels["X"]["modality"] == "EEG"  # unknown -> filled
+    assert rec.channels["ECG1"]["modality"] == "MISC"  # detected -> untouched
 
 
 def test_missing_input_is_input_error():

--- a/biosigio/tests/test_core.py
+++ b/biosigio/tests/test_core.py
@@ -11,157 +11,157 @@ from ..core.emg import Recording
 
 
 @pytest.fixture
-def empty_emg():
+def empty_rec():
     """Create an empty Recording object."""
     return Recording()
 
 
 @pytest.fixture
-def sample_emg():
+def sample_rec():
     """Create a Recording object with sample data."""
-    emg = Recording()
+    rec = Recording()
 
     # Add sample channels
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
     emg_data = np.sin(2 * np.pi * 10 * time)  # 10Hz sine wave
     acc_data = np.cos(2 * np.pi * 5 * time)  # 5Hz cosine wave
 
-    emg.add_channel("EMG1", emg_data, 1000, "mV", channel_type="EMG")
-    emg.add_channel("ACC1", acc_data, 1000, "g", channel_type="ACC")
+    rec.add_channel("EMG1", emg_data, 1000, "mV", channel_type="EMG")
+    rec.add_channel("ACC1", acc_data, 1000, "g", channel_type="ACC")
 
-    return emg
+    return rec
 
 
-def test_emg_initialization(empty_emg):
+def test_emg_initialization(empty_rec):
     """Test Recording object initialization."""
-    assert empty_emg.signals is None
-    assert empty_emg.metadata == {}
-    assert empty_emg.channels == {}
+    assert empty_rec.signals is None
+    assert empty_rec.metadata == {}
+    assert empty_rec.channels == {}
 
 
-def test_add_channel(empty_emg):
+def test_add_channel(empty_rec):
     """Test adding a channel to Recording object."""
     data = np.array([1, 2, 3, 4, 5])
-    empty_emg.add_channel("EMG1", data, 1000, "mV", "EMG")
+    empty_rec.add_channel("EMG1", data, 1000, "mV", "EMG")
 
-    assert "EMG1" in empty_emg.signals.columns
-    assert "EMG1" in empty_emg.channels
-    assert empty_emg.channels["EMG1"]["sample_frequency"] == 1000
-    assert empty_emg.channels["EMG1"]["physical_dimension"] == "mV"
-    assert empty_emg.channels["EMG1"]["channel_type"] == "EMG"
+    assert "EMG1" in empty_rec.signals.columns
+    assert "EMG1" in empty_rec.channels
+    assert empty_rec.channels["EMG1"]["sample_frequency"] == 1000
+    assert empty_rec.channels["EMG1"]["physical_dimension"] == "mV"
+    assert empty_rec.channels["EMG1"]["channel_type"] == "EMG"
 
 
-def test_select_channels(sample_emg):
+def test_select_channels(sample_rec):
     """Test channel selection."""
     # Store original state
-    original_channels = list(sample_emg.signals.columns)
+    original_channels = list(sample_rec.signals.columns)
 
     # Select multiple channels
-    emg_multi = sample_emg.select_channels(["EMG1", "ACC1"])
-    assert list(emg_multi.signals.columns) == ["EMG1", "ACC1"]
-    assert list(emg_multi.channels.keys()) == ["EMG1", "ACC1"]
+    rec_multi = sample_rec.select_channels(["EMG1", "ACC1"])
+    assert list(rec_multi.signals.columns) == ["EMG1", "ACC1"]
+    assert list(rec_multi.channels.keys()) == ["EMG1", "ACC1"]
     # Verify original object is unchanged
-    assert list(sample_emg.signals.columns) == original_channels
+    assert list(sample_rec.signals.columns) == original_channels
 
     # Select single channel
-    emg_single = sample_emg.select_channels("EMG1")
-    assert list(emg_single.signals.columns) == ["EMG1"]
-    assert list(emg_single.channels.keys()) == ["EMG1"]
+    rec_single = sample_rec.select_channels("EMG1")
+    assert list(rec_single.signals.columns) == ["EMG1"]
+    assert list(rec_single.channels.keys()) == ["EMG1"]
     # Verify original object is unchanged
-    assert list(sample_emg.signals.columns) == original_channels
+    assert list(sample_rec.signals.columns) == original_channels
 
 
-def test_metadata(empty_emg):
+def test_metadata(empty_rec):
     """Test metadata handling."""
-    empty_emg.set_metadata("subject", "S001")
-    assert empty_emg.get_metadata("subject") == "S001"
+    empty_rec.set_metadata("subject", "S001")
+    assert empty_rec.get_metadata("subject") == "S001"
 
     # Test non-existent key
-    assert empty_emg.get_metadata("nonexistent") is None
+    assert empty_rec.get_metadata("nonexistent") is None
 
 
-def test_invalid_channel_selection(sample_emg):
+def test_invalid_channel_selection(sample_rec):
     """Test error handling for invalid channel selection."""
     with pytest.raises(ValueError):
-        sample_emg.select_channels("NonexistentChannel")
+        sample_rec.select_channels("NonexistentChannel")
 
 
-def test_plot_signals_validation(empty_emg):
+def test_plot_signals_validation(empty_rec):
     """Test plot_signals input validation."""
     with pytest.raises(ValueError):
-        empty_emg.plot_signals()  # Should raise error when no signals are loaded
+        empty_rec.plot_signals()  # Should raise error when no signals are loaded
 
 
-def test_get_channel_types(sample_emg):
+def test_get_channel_types(sample_rec):
     """Test getting unique channel types."""
-    types = sample_emg.get_channel_types()
+    types = sample_rec.get_channel_types()
     assert set(types) == {"EMG", "ACC"}
 
 
-def test_get_channels_by_type(sample_emg):
+def test_get_channels_by_type(sample_rec):
     """Test getting channels of specific type."""
-    emg_channels = sample_emg.get_channels_by_type("EMG")
-    acc_channels = sample_emg.get_channels_by_type("ACC")
+    emg_channels = sample_rec.get_channels_by_type("EMG")
+    acc_channels = sample_rec.get_channels_by_type("ACC")
 
     assert emg_channels == ["EMG1"]
     assert acc_channels == ["ACC1"]
-    assert sample_emg.get_channels_by_type("NONEXISTENT") == []
+    assert sample_rec.get_channels_by_type("NONEXISTENT") == []
 
 
 # This will be implemented after #3 is resolved
-# def test_select_channels_by_type(sample_emg):
+# def test_select_channels_by_type(sample_rec):
 #     """Test channel selection by type."""
 #     # Select all EMG channels
-#     emg_only = sample_emg.select_channels(channel_type='EMG')
+#     emg_only = sample_rec.select_channels(channel_type='EMG')
 #     assert list(emg_only.signals.columns) == ['EMG1']
 #     assert all(info['channel_type'] == 'EMG' for info in emg_only.channels.values())
 
 #     # Select all ACC channels
-#     acc_only = sample_emg.select_channels(channel_type='ACC')
+#     acc_only = sample_rec.select_channels(channel_type='ACC')
 #     assert list(acc_only.signals.columns) == ['ACC1']
 #     assert all(info['channel_type'] == 'ACC' for info in acc_only.channels.values())
 
 #     # Test with non-existent type
 #     with pytest.raises(ValueError):
-#         sample_emg.select_channels(channel_type='NONEXISTENT')
+#         sample_rec.select_channels(channel_type='NONEXISTENT')
 
 
-def test_select_channels_with_type_filter(sample_emg):
+def test_select_channels_with_type_filter(sample_rec):
     """Test channel selection with type filtering."""
     # Store original state
-    original_channels = list(sample_emg.signals.columns)
+    original_channels = list(sample_rec.signals.columns)
 
     # Select specific channels with type filter
-    result = sample_emg.select_channels(["EMG1", "ACC1"], channel_type="EMG")
+    result = sample_rec.select_channels(["EMG1", "ACC1"], channel_type="EMG")
     assert list(result.signals.columns) == ["EMG1"]
     assert all(info["channel_type"] == "EMG" for info in result.channels.values())
     # Verify original object is unchanged
-    assert list(sample_emg.signals.columns) == original_channels
+    assert list(sample_rec.signals.columns) == original_channels
 
     # Test when no channels match type
     with pytest.raises(ValueError):
-        sample_emg.select_channels(["EMG1", "ACC1"], channel_type="GYRO")
+        sample_rec.select_channels(["EMG1", "ACC1"], channel_type="GYRO")
     # Verify original object is unchanged after error
-    assert list(sample_emg.signals.columns) == original_channels
+    assert list(sample_rec.signals.columns) == original_channels
 
 
-def test_add_channel_validation(empty_emg):
+def test_add_channel_validation(empty_rec):
     """Test add_channel with various data types and validation."""
     # Test with different numpy data types
     data_int = np.array([1, 2, 3], dtype=np.int32)
-    empty_emg.add_channel("INT", data_int, 1000, "count", channel_type="OTHER")
-    assert np.array_equal(empty_emg.signals["INT"].values, data_int)
+    empty_rec.add_channel("INT", data_int, 1000, "count", channel_type="OTHER")
+    assert np.array_equal(empty_rec.signals["INT"].values, data_int)
 
     # Test with float data
     data_float = np.array([1.1, 2.2, 3.3])
-    empty_emg.add_channel("FLOAT", data_float, 1000, "mV", "EMG")
-    assert np.array_equal(empty_emg.signals["FLOAT"].values, data_float)
+    empty_rec.add_channel("FLOAT", data_float, 1000, "mV", "EMG")
+    assert np.array_equal(empty_rec.signals["FLOAT"].values, data_float)
 
     # Test channel info storage
-    assert empty_emg.channels["INT"]["channel_type"] == "OTHER"
-    assert empty_emg.channels["FLOAT"]["channel_type"] == "EMG"  # default type
-    assert empty_emg.channels["INT"]["sample_frequency"] == 1000
-    assert empty_emg.channels["INT"]["physical_dimension"] == "count"
+    assert empty_rec.channels["INT"]["channel_type"] == "OTHER"
+    assert empty_rec.channels["FLOAT"]["channel_type"] == "EMG"  # default type
+    assert empty_rec.channels["INT"]["sample_frequency"] == 1000
+    assert empty_rec.channels["INT"]["physical_dimension"] == "count"
 
 
 @pytest.fixture
@@ -178,19 +178,19 @@ def mock_importers(monkeypatch):
 
     class MockTrignoImporter(MockBaseImporter):
         def _load(self, filepath, **kwargs):
-            emg = Recording()
-            emg.add_channel("TEST", np.array([1, 2, 3]), 1000, "mV", channel_type="EMG")
-            emg.set_metadata("device", "Delsys Trigno")
-            emg.set_metadata("source_file", filepath)
-            return emg
+            rec = Recording()
+            rec.add_channel("TEST", np.array([1, 2, 3]), 1000, "mV", channel_type="EMG")
+            rec.set_metadata("device", "Delsys Trigno")
+            rec.set_metadata("source_file", filepath)
+            return rec
 
     class MockOTBImporter(MockBaseImporter):
         def _load(self, filepath, **kwargs):
-            emg = Recording()
-            emg.add_channel("OTB", np.array([4, 5, 6]), 2000, "mV", channel_type="EMG")
-            emg.set_metadata("device", "OT Bioelettronica")
-            emg.set_metadata("source_file", filepath)
-            return emg
+            rec = Recording()
+            rec.add_channel("OTB", np.array([4, 5, 6]), 2000, "mV", channel_type="EMG")
+            rec.set_metadata("device", "OT Bioelettronica")
+            rec.set_metadata("source_file", filepath)
+            return rec
 
     class MockCSVImporter(MockBaseImporter):
         def _detect_specialized_format(self, filepath):
@@ -210,11 +210,11 @@ def mock_importers(monkeypatch):
                         "If you still want to use the generic CSV importer, set force_generic=True"
                     )
 
-            emg = Recording()
-            emg.add_channel("CSV_CH1", np.array([7, 8, 9]), 1000, "mV", channel_type="EMG")
-            emg.set_metadata("file_format", "CSV")
-            emg.set_metadata("source_file", filepath)
-            return emg
+            rec = Recording()
+            rec.add_channel("CSV_CH1", np.array([7, 8, 9]), 1000, "mV", channel_type="EMG")
+            rec.set_metadata("file_format", "CSV")
+            rec.set_metadata("source_file", filepath)
+            return rec
 
     def mock_import(name, *args):
         # Only intercept our specific importer paths
@@ -256,25 +256,25 @@ def test_from_file(mock_importers, tmp_path):
     trigno_named_file.write_text("")
 
     # Test Trigno importer
-    emg_trigno = Recording.from_file(str(trigno_file), importer="trigno")
-    assert "TEST" in emg_trigno.signals.columns
-    assert emg_trigno.channels["TEST"]["sample_frequency"] == 1000
+    rec_trigno = Recording.from_file(str(trigno_file), importer="trigno")
+    assert "TEST" in rec_trigno.signals.columns
+    assert rec_trigno.channels["TEST"]["sample_frequency"] == 1000
 
     # Test OTB importer (including auto-detection)
     for importer in ["otb", None]:
-        emg_otb = Recording.from_file(str(otb_file), importer=importer)
-        assert "OTB" in emg_otb.signals.columns
-        assert emg_otb.channels["OTB"]["sample_frequency"] == 2000
+        rec_otb = Recording.from_file(str(otb_file), importer=importer)
+        assert "OTB" in rec_otb.signals.columns
+        assert rec_otb.channels["OTB"]["sample_frequency"] == 2000
 
     # Test CSV importer
-    emg_csv = Recording.from_file(str(csv_file), importer="csv")
-    assert "CSV_CH1" in emg_csv.signals.columns
-    assert emg_csv.get_metadata("file_format") == "CSV"
+    rec_csv = Recording.from_file(str(csv_file), importer="csv")
+    assert "CSV_CH1" in rec_csv.signals.columns
+    assert rec_csv.get_metadata("file_format") == "CSV"
 
     # Test CSV importer with auto-detection for .txt files
-    emg_txt = Recording.from_file(str(csv_file), importer=None)
-    assert "CSV_CH1" in emg_txt.signals.columns
-    assert emg_txt.get_metadata("file_format") == "CSV"
+    rec_txt = Recording.from_file(str(csv_file), importer=None)
+    assert "CSV_CH1" in rec_txt.signals.columns
+    assert rec_txt.get_metadata("file_format") == "CSV"
 
     # Test format detection and force_csv
     # First, test that format detection raises an error for trigno file
@@ -282,13 +282,13 @@ def test_from_file(mock_importers, tmp_path):
         Recording.from_file(str(trigno_named_file), importer="csv")
 
     # Now test with force_csv=True to bypass detection
-    emg_forced = Recording.from_file(str(trigno_named_file), importer="csv", force_csv=True)
-    assert "CSV_CH1" in emg_forced.signals.columns
+    rec_forced = Recording.from_file(str(trigno_named_file), importer="csv", force_csv=True)
+    assert "CSV_CH1" in rec_forced.signals.columns
 
     # Test passing parameters to CSV importer
     custom_kwargs = {"channel_types": {"CSV_CH1": "ACC"}}
-    emg_with_params = Recording.from_file(str(csv_file), importer="csv", **custom_kwargs)
-    assert "CSV_CH1" in emg_with_params.signals.columns
+    rec_with_params = Recording.from_file(str(csv_file), importer="csv", **custom_kwargs)
+    assert "CSV_CH1" in rec_with_params.signals.columns
 
     # Test invalid importer
     with pytest.raises(ValueError, match="Unsupported importer"):
@@ -340,9 +340,9 @@ def mock_plt(monkeypatch):
 
 
 @pytest.mark.skip(reason="visualization not critical for core functionality")
-def test_plot_signals_basic(sample_emg, mock_plt):
+def test_plot_signals_basic(sample_rec, mock_plt):
     """Test basic plotting functionality."""
-    sample_emg.plot_signals(show=False, plt_module=mock_plt)
+    sample_rec.plot_signals(show=False, plt_module=mock_plt)
 
     # Verify figure creation
     assert mock_plt.subplots_called
@@ -359,10 +359,10 @@ def test_plot_signals_basic(sample_emg, mock_plt):
 
 
 @pytest.mark.skip(reason="visualization not critical for core functionality")
-def test_plot_signals_style_options(sample_emg, mock_plt):
+def test_plot_signals_style_options(sample_rec, mock_plt):
     """Test different plot styles."""
     # Test dots style
-    sample_emg.plot_signals(show=False, plt_module=mock_plt)
+    sample_rec.plot_signals(show=False, plt_module=mock_plt)
     if isinstance(mock_plt.axes, list):
         for ax in mock_plt.axes:
             ax.scatter.assert_called_once()
@@ -375,7 +375,7 @@ def test_plot_signals_style_options(sample_emg, mock_plt):
     mock_plt.reset()
 
     # Test line style
-    sample_emg.plot_signals(show=False, plt_module=mock_plt)
+    sample_rec.plot_signals(show=False, plt_module=mock_plt)
     if isinstance(mock_plt.axes, list):
         for ax in mock_plt.axes:
             ax.plot.assert_called_once()
@@ -387,10 +387,10 @@ def test_plot_signals_style_options(sample_emg, mock_plt):
 
 
 @pytest.mark.skip(reason="visualization not critical for core functionality")
-def test_plot_signals_customization(sample_emg, mock_plt):
+def test_plot_signals_customization(sample_rec, mock_plt):
     """Test plot customization options."""
     title = "Test Plot"
-    sample_emg.plot_signals(
+    sample_rec.plot_signals(
         channels=["EMG1"], grid=True, title=title, show=False, plt_module=mock_plt
     )
 
@@ -404,24 +404,24 @@ def test_plot_signals_customization(sample_emg, mock_plt):
     assert mock_plt.show_called
 
 
-def test_plot_signals_channel_selection(sample_emg, mock_plt):
+def test_plot_signals_channel_selection(sample_rec, mock_plt):
     """Test plotting with channel selection."""
     # Test single channel
-    sample_emg.plot_signals(channels=["EMG1"], show=False, plt_module=mock_plt)
+    sample_rec.plot_signals(channels=["EMG1"], show=False, plt_module=mock_plt)
     assert not isinstance(mock_plt.axes, list)  # Should be single axis
 
     mock_plt.reset()
 
     # Test invalid channel
     with pytest.raises(ValueError) as exc_info:
-        sample_emg.plot_signals(channels=["NonexistentChannel"])
+        sample_rec.plot_signals(channels=["NonexistentChannel"])
     assert "Channels not found" in str(exc_info.value)
 
 
-def test_plot_signals_time_range(sample_emg, mock_plt):
+def test_plot_signals_time_range(sample_rec, mock_plt):
     """Test plotting with time range selection."""
     time_range = (0.2, 0.8)
-    sample_emg.plot_signals(time_range=time_range, show=False, plt_module=mock_plt)
+    sample_rec.plot_signals(time_range=time_range, show=False, plt_module=mock_plt)
 
     # Verify data selection
     if isinstance(mock_plt.axes, list):
@@ -429,42 +429,42 @@ def test_plot_signals_time_range(sample_emg, mock_plt):
             plot_calls = ax.plot.call_args_list
             assert len(plot_calls) > 0, "No plot calls were made"
             data = plot_calls[-1][0][1]  # Get y-values from last plot call
-            assert len(data) < len(sample_emg.signals)  # Should be subset of data
+            assert len(data) < len(sample_rec.signals)  # Should be subset of data
     else:
         plot_calls = mock_plt.axes.plot.call_args_list
         assert len(plot_calls) > 0, "No plot calls were made"
         data = plot_calls[-1][0][1]  # Get y-values from last plot call
-        assert len(data) < len(sample_emg.signals)  # Should be subset of data
+        assert len(data) < len(sample_rec.signals)  # Should be subset of data
 
 
-def test_emg_add_event(empty_emg):
+def test_emg_add_event(empty_rec):
     """Test adding events to the Recording object."""
-    assert empty_emg.events.empty
+    assert empty_rec.events.empty
 
     # Add first event
-    empty_emg.add_event(onset=1.0, duration=0.5, description="Event A")
-    assert len(empty_emg.events) == 1
+    empty_rec.add_event(onset=1.0, duration=0.5, description="Event A")
+    assert len(empty_rec.events) == 1
     pd.testing.assert_frame_equal(
-        empty_emg.events, pd.DataFrame([{"onset": 1.0, "duration": 0.5, "description": "Event A"}])
+        empty_rec.events, pd.DataFrame([{"onset": 1.0, "duration": 0.5, "description": "Event A"}])
     )
     # onset/duration must be float64 (not object) even from the empty frame
-    assert empty_emg.events["onset"].dtype == np.float64
-    assert empty_emg.events["duration"].dtype == np.float64
+    assert empty_rec.events["onset"].dtype == np.float64
+    assert empty_rec.events["duration"].dtype == np.float64
 
     # Add second event (should be sorted)
-    empty_emg.add_event(onset=0.5, duration=0.1, description="Event B")
-    assert len(empty_emg.events) == 2
+    empty_rec.add_event(onset=0.5, duration=0.1, description="Event B")
+    assert len(empty_rec.events) == 2
     expected_df = pd.DataFrame(
         [
             {"onset": 0.5, "duration": 0.1, "description": "Event B"},
             {"onset": 1.0, "duration": 0.5, "description": "Event A"},
         ]
     )
-    pd.testing.assert_frame_equal(empty_emg.events, expected_df)
+    pd.testing.assert_frame_equal(empty_rec.events, expected_df)
 
     # Add third event
-    empty_emg.add_event(onset=1.5, duration=0.0, description="Event C")
-    assert len(empty_emg.events) == 3
+    empty_rec.add_event(onset=1.5, duration=0.0, description="Event C")
+    assert len(empty_rec.events) == 3
     expected_df = pd.DataFrame(
         [
             {"onset": 0.5, "duration": 0.1, "description": "Event B"},
@@ -472,25 +472,25 @@ def test_emg_add_event(empty_emg):
             {"onset": 1.5, "duration": 0.0, "description": "Event C"},
         ]
     )
-    pd.testing.assert_frame_equal(empty_emg.events, expected_df)
+    pd.testing.assert_frame_equal(empty_rec.events, expected_df)
     # dtype must survive the concat path too
-    assert empty_emg.events["onset"].dtype == np.float64
-    assert empty_emg.events["duration"].dtype == np.float64
+    assert empty_rec.events["onset"].dtype == np.float64
+    assert empty_rec.events["duration"].dtype == np.float64
 
 
-def test_add_event_integer_inputs_coerced_to_float(empty_emg):
+def test_add_event_integer_inputs_coerced_to_float(empty_rec):
     """Integer onset/duration must be stored as float64, not int64 or object."""
-    empty_emg.add_event(onset=2, duration=0, description="Integer onset")
-    assert empty_emg.events["onset"].dtype == np.float64
-    assert empty_emg.events["duration"].dtype == np.float64
-    assert empty_emg.events.loc[0, "onset"] == 2.0
-    assert empty_emg.events.loc[0, "duration"] == 0.0
+    empty_rec.add_event(onset=2, duration=0, description="Integer onset")
+    assert empty_rec.events["onset"].dtype == np.float64
+    assert empty_rec.events["duration"].dtype == np.float64
+    assert empty_rec.events.loc[0, "onset"] == 2.0
+    assert empty_rec.events.loc[0, "duration"] == 0.0
 
 
-def test_to_edf_writes_real_file_and_channels_tsv(sample_emg, tmp_path):
+def test_to_edf_writes_real_file_and_channels_tsv(sample_rec, tmp_path):
     """to_edf writes a real EDF/BDF file plus a BIDS channels.tsv by default."""
     out = tmp_path / "out.edf"
-    sample_emg.to_edf(str(out), format="bdf", bypass_analysis=True)
+    sample_rec.to_edf(str(out), format="bdf", bypass_analysis=True)
     written = out if out.exists() else out.with_suffix(".bdf")
     assert written.exists()
     assert written.with_name(written.stem + "_channels.tsv").exists()
@@ -498,7 +498,7 @@ def test_to_edf_writes_real_file_and_channels_tsv(sample_emg, tmp_path):
     assert set(reloaded.signals.columns) == {"EMG1", "ACC1"}
 
 
-def test_to_edf_bypass_analysis_defaulting(sample_emg, tmp_path, capsys):
+def test_to_edf_bypass_analysis_defaulting(sample_rec, tmp_path, capsys):
     """Forced format skips analysis by default; 'auto' always analyzes.
 
     The decision is observable in the exporter's output ('Summary skipped...' when
@@ -506,39 +506,39 @@ def test_to_edf_bypass_analysis_defaulting(sample_emg, tmp_path, capsys):
     the real to_edf -> EDFExporter behaviour without mocking the exporter.
     """
     # Forced format, bypass=None (default) -> analysis skipped.
-    sample_emg.to_edf(str(tmp_path / "a.edf"), format="edf", bypass_analysis=None)
+    sample_rec.to_edf(str(tmp_path / "a.edf"), format="edf", bypass_analysis=None)
     assert "Summary skipped as signal analysis was bypassed." in capsys.readouterr().out
 
     # Forced format, bypass=False -> analysis runs.
-    sample_emg.to_edf(str(tmp_path / "b.edf"), format="edf", bypass_analysis=False)
+    sample_rec.to_edf(str(tmp_path / "b.edf"), format="edf", bypass_analysis=False)
     out = capsys.readouterr().out
     assert "Recommended Format:" in out and "Summary skipped" not in out
 
     # 'auto' -> analysis runs even when bypass=True is requested (and ignored).
-    sample_emg.to_edf(str(tmp_path / "c.edf"), format="auto", bypass_analysis=True)
+    sample_rec.to_edf(str(tmp_path / "c.edf"), format="auto", bypass_analysis=True)
     assert "Summary skipped" not in capsys.readouterr().out
 
     # Forced BDF mirrors forced EDF: bypass by default, analyze when bypass=False.
-    sample_emg.to_edf(str(tmp_path / "d.bdf"), format="bdf", bypass_analysis=None)
+    sample_rec.to_edf(str(tmp_path / "d.bdf"), format="bdf", bypass_analysis=None)
     assert "Summary skipped as signal analysis was bypassed." in capsys.readouterr().out
-    sample_emg.to_edf(str(tmp_path / "e.bdf"), format="bdf", bypass_analysis=False)
+    sample_rec.to_edf(str(tmp_path / "e.bdf"), format="bdf", bypass_analysis=False)
     assert "Recommended Format:" in capsys.readouterr().out
 
 
-def test_to_edf_external_events_are_written_and_object_untouched(sample_emg, tmp_path):
+def test_to_edf_external_events_are_written_and_object_untouched(sample_rec, tmp_path):
     """The external events_df (not self.events) is what reaches the file, and the
     Recording object's own events are left intact.
 
     Forwarding is verified by reading the EDF+ annotations back with pyedflib
     directly (biosigio's own annotation read-back is pending #47).
     """
-    sample_emg.add_event(onset=0.1, duration=0.0, description="Marker 1")
-    sample_emg.add_event(onset=0.5, duration=0.2, description="Activity")
+    sample_rec.add_event(onset=0.1, duration=0.0, description="Marker 1")
+    sample_rec.add_event(onset=0.5, duration=0.2, description="Activity")
     external = pd.DataFrame([{"onset": 0.3, "duration": 0.1, "description": "External"}])
     out = tmp_path / "ev.edf"
-    sample_emg.to_edf(str(out), format="edf", bypass_analysis=True, events_df=external)
+    sample_rec.to_edf(str(out), format="edf", bypass_analysis=True, events_df=external)
 
-    assert len(sample_emg.events) == 2  # self.events untouched
+    assert len(sample_rec.events) == 2  # self.events untouched
 
     with pyedflib.EdfReader(str(out)) as reader:
         descriptions = list(reader.readAnnotations()[2])
@@ -546,66 +546,66 @@ def test_to_edf_external_events_are_written_and_object_untouched(sample_emg, tmp
     assert "Marker 1" not in descriptions and "Activity" not in descriptions
 
 
-def test_to_edf_empty_raises(empty_emg, tmp_path):
+def test_to_edf_empty_raises(empty_rec, tmp_path):
     """Exporting a Recording object with no signals raises ValueError."""
     with pytest.raises(ValueError):
-        empty_emg.to_edf(str(tmp_path / "test.edf"))
+        empty_rec.to_edf(str(tmp_path / "test.edf"))
 
 
-def test_add_channel_with_prefilter(empty_emg):
+def test_add_channel_with_prefilter(empty_rec):
     """Test adding channel with prefilter specification."""
     data = np.array([1, 2, 3])
     prefilter = "HP 20Hz"
-    empty_emg.add_channel("EMG1", data, 1000, "mV", "EMG", prefilter=prefilter)
+    empty_rec.add_channel("EMG1", data, 1000, "mV", "EMG", prefilter=prefilter)
 
-    assert empty_emg.channels["EMG1"]["prefilter"] == prefilter
+    assert empty_rec.channels["EMG1"]["prefilter"] == prefilter
 
 
-def test_select_channels_none_with_type(sample_emg):
+def test_select_channels_none_with_type(sample_rec):
     """Test selecting all channels of a type when channels=None."""
     # Add another EMG channel for testing
     data = np.linspace(0, 1, 1000)
-    sample_emg.add_channel("EMG2", data, 1000, "mV", channel_type="EMG")
-    original_channels = list(sample_emg.signals.columns)
+    sample_rec.add_channel("EMG2", data, 1000, "mV", channel_type="EMG")
+    original_channels = list(sample_rec.signals.columns)
 
     # Select all EMG channels
-    result = sample_emg.select_channels(channels=None, channel_type="EMG")
+    result = sample_rec.select_channels(channels=None, channel_type="EMG")
     assert set(result.signals.columns) == {"EMG1", "EMG2"}
     assert all(info["channel_type"] == "EMG" for info in result.channels.values())
     # Verify original object is unchanged
-    assert list(sample_emg.signals.columns) == original_channels
+    assert list(sample_rec.signals.columns) == original_channels
 
 
-def test_plot_single_axis(sample_emg, mock_plt):
+def test_plot_single_axis(sample_rec, mock_plt):
     """Test plotting only makes a single axis."""
     # add the same channel data to test multiple channels
-    sample_emg.add_channel("EMG2", sample_emg.signals["EMG1"], 1000, "mV", channel_type="EMG")
-    sample_emg.plot_signals(channels=["EMG1", "EMG2"], show=False, plt_module=mock_plt)
+    sample_rec.add_channel("EMG2", sample_rec.signals["EMG1"], 1000, "mV", channel_type="EMG")
+    sample_rec.plot_signals(channels=["EMG1", "EMG2"], show=False, plt_module=mock_plt)
 
     # Verify axis is one
     assert len(mock_plt.axes) == 1
 
 
-def test_select_channels_empty_result(sample_emg):
+def test_select_channels_empty_result(sample_rec):
     """Test selecting channels with type filter resulting in empty selection."""
     with pytest.raises(ValueError) as exc_info:
-        sample_emg.select_channels(["EMG1"], channel_type="GYRO")
+        sample_rec.select_channels(["EMG1"], channel_type="GYRO")
     assert "None of the selected channels are of type" in str(exc_info.value)
 
 
-def test_add_multiple_channels(empty_emg):
+def test_add_multiple_channels(empty_rec):
     """Test adding multiple channels with different properties."""
     # Add first channel
     data1 = np.array([1, 2, 3])
-    empty_emg.add_channel("CH1", data1, 1000, "mV", channel_type="EMG")
+    empty_rec.add_channel("CH1", data1, 1000, "mV", channel_type="EMG")
 
     # Add second channel with different properties
     data2 = np.array([4, 5, 6])
-    empty_emg.add_channel("CH2", data2, 2000, "g", channel_type="ACC")
+    empty_rec.add_channel("CH2", data2, 2000, "g", channel_type="ACC")
 
     # Verify both channels exist with correct properties
-    assert set(empty_emg.signals.columns) == {"CH1", "CH2"}
-    assert empty_emg.channels["CH1"]["sample_frequency"] == 1000
-    assert empty_emg.channels["CH2"]["sample_frequency"] == 2000
-    assert empty_emg.channels["CH1"]["channel_type"] == "EMG"
-    assert empty_emg.channels["CH2"]["channel_type"] == "ACC"
+    assert set(empty_rec.signals.columns) == {"CH1", "CH2"}
+    assert empty_rec.channels["CH1"]["sample_frequency"] == 1000
+    assert empty_rec.channels["CH2"]["sample_frequency"] == 2000
+    assert empty_rec.channels["CH1"]["channel_type"] == "EMG"
+    assert empty_rec.channels["CH2"]["channel_type"] == "ACC"

--- a/biosigio/tests/test_edf_roundtrip.py
+++ b/biosigio/tests/test_edf_roundtrip.py
@@ -20,15 +20,15 @@ OTB_FIXTURE = os.path.join(EXAMPLE_DIR, "one_sessantaquattro_truncated.otb+")
 @pytest.mark.parametrize("fmt", ["edf", "bdf"])
 def test_export_preserves_full_recording_length(tmp_path, fmt):
     """A multi-second recording must round-trip without losing samples."""
-    emg = Recording.from_file(OTB_FIXTURE, importer="otb")
-    first = emg.signals.columns[0]
-    n_in = len(emg.signals[first])
-    samples_per_record = emg.channels[first]["sample_frequency"]
+    rec = Recording.from_file(OTB_FIXTURE, importer="otb")
+    first = rec.signals.columns[0]
+    n_in = len(rec.signals[first])
+    samples_per_record = rec.channels[first]["sample_frequency"]
     # The fixture must be longer than one data record, or it cannot expose the bug.
     assert n_in > samples_per_record
 
     out = tmp_path / f"roundtrip.{fmt}"
-    emg.to_edf(str(out), format=fmt, bypass_analysis=True)
+    rec.to_edf(str(out), format=fmt, bypass_analysis=True)
 
     reloaded = Recording.from_file(str(out))
     n_out = len(reloaded.signals[reloaded.signals.columns[0]])
@@ -46,10 +46,10 @@ def test_export_preserves_full_recording_length(tmp_path, fmt):
 )
 def test_export_rejects_mixed_sample_rates(tmp_path):
     """Mixed per-channel sample rates must fail loudly, not write a corrupt file."""
-    emg = Recording.from_file(
+    rec = Recording.from_file(
         os.path.join(EXAMPLE_DIR, "truncated_trigno_sample.csv"), importer="trigno"
     )
-    rates = {int(emg.channels[c]["sample_frequency"]) for c in emg.channels}
+    rates = {int(rec.channels[c]["sample_frequency"]) for c in rec.channels}
     assert len(rates) > 1, "fixture must have mixed rates to exercise the guard"
     with pytest.raises(ValueError, match="single sampling rate"):
-        emg.to_edf(str(tmp_path / "mixed.edf"), format="edf", bypass_analysis=True)
+        rec.to_edf(str(tmp_path / "mixed.edf"), format="edf", bypass_analysis=True)

--- a/biosigio/tests/test_edf_scaling.py
+++ b/biosigio/tests/test_edf_scaling.py
@@ -194,9 +194,9 @@ def test_resolve_window_true_is_noop_without_outliers():
 # ----------------------------- end-to-end on files -----------------------------
 
 
-def _export_reload(emg, tmp_path, **kw):
+def _export_reload(rec, tmp_path, **kw):
     out = tmp_path / "case.edf"
-    emg.to_edf(str(out), **kw)
+    rec.to_edf(str(out), **kw)
     written = out if out.exists() else out.with_suffix(".bdf")
     return Recording.from_file(str(written), bids_channels="off"), written
 
@@ -207,9 +207,9 @@ def _export_reload(emg, tmp_path, **kw):
 )
 def test_export_never_clips_within_header_window(tmp_path, amp, off, fmt):
     """Every reloaded sample lies inside the stored physical window (no overflow)."""
-    emg = Recording()
-    emg.add_channel("S", _sine(amp=amp, off=off), 1000, "uV", "EMG")
-    reloaded, written = _export_reload(emg, tmp_path, format=fmt, bypass_analysis=True)
+    rec = Recording()
+    rec.add_channel("S", _sine(amp=amp, off=off), 1000, "uV", "EMG")
+    reloaded, written = _export_reload(rec, tmp_path, format=fmt, bypass_analysis=True)
     with pyedflib.EdfReader(str(written)) as r:
         h = r.getSignalHeaders()[0]
     vals = reloaded.signals["S"].values
@@ -220,9 +220,9 @@ def test_export_never_clips_within_header_window(tmp_path, amp, off, fmt):
 
 @pytest.mark.parametrize("constant", [0.0, 1.0, -3.5])
 def test_export_constant_and_zero_channels(tmp_path, constant):
-    emg = Recording()
-    emg.add_channel("C", np.full(2000, constant), 1000, "uV", "EMG")
-    reloaded, _ = _export_reload(emg, tmp_path, format="bdf", bypass_analysis=True)
+    rec = Recording()
+    rec.add_channel("C", np.full(2000, constant), 1000, "uV", "EMG")
+    reloaded, _ = _export_reload(rec, tmp_path, format="bdf", bypass_analysis=True)
     assert np.allclose(reloaded.signals["C"].values, constant, atol=1e-3)
 
 
@@ -235,17 +235,17 @@ def test_singularity_protection_recovers_bulk(tmp_path):
     range and the bulk loses resolution. Auto must do at least as well, and meet
     the >0.99 bar that clipping is meant to protect.
     """
-    emg = Recording.from_file(str(EMG_FIXTURE))
-    ch = list(emg.channels)[0]
-    base = emg.signals[ch].values.astype(float).copy()
+    rec = Recording.from_file(str(EMG_FIXTURE))
+    ch = list(rec.channels)[0]
+    base = rec.signals[ch].values.astype(float).copy()
     spike_idx = len(base) // 2
-    emg.signals.iloc[spike_idx, emg.signals.columns.get_loc(ch)] = base.max() * 500.0
+    rec.signals.iloc[spike_idx, rec.signals.columns.get_loc(ch)] = base.max() * 500.0
     bulk = np.ones(len(base), bool)
     bulk[spike_idx] = False
 
     def bulk_r(clip):
         reloaded, _ = _export_reload(
-            emg, tmp_path, format="edf", bypass_analysis=True, clip_outliers=clip
+            rec, tmp_path, format="edf", bypass_analysis=True, clip_outliers=clip
         )
         rel = reloaded.signals[ch].values.astype(float)[: len(base)]
         return float(np.corrcoef(base[bulk], rel[bulk])[0, 1])
@@ -278,17 +278,17 @@ def test_export_rejects_unrepresentable_magnitude(tmp_path, fmt):
     that re-creates the #61 corruption), so the exporter must reject it loudly
     before writing, for BOTH formats (the physical field is 8 chars in each).
     """
-    emg = Recording()
-    emg.add_channel("BIG", _sine(amp=2e7), 1000, "uV", "EMG")
+    rec = Recording()
+    rec.add_channel("BIG", _sine(amp=2e7), 1000, "uV", "EMG")
     with pytest.raises(ValueError, match="cannot be stored in the EDF/BDF header"):
-        emg.to_edf(str(tmp_path / "big.edf"), format=fmt, bypass_analysis=True, clip_outliers=False)
+        rec.to_edf(str(tmp_path / "big.edf"), format=fmt, bypass_analysis=True, clip_outliers=False)
 
 
 def test_export_rejects_huge_positive_offset(tmp_path):
     """A large positive DC offset (~1.2e8) also overflows the 8-char field."""
-    emg = Recording()
-    emg.add_channel("OFF", _sine(amp=1000.0) + 1.2e8, 1000, "uV", "EMG")
+    rec = Recording()
+    rec.add_channel("OFF", _sine(amp=1000.0) + 1.2e8, 1000, "uV", "EMG")
     with pytest.raises(ValueError, match="cannot be stored"):
-        emg.to_edf(
+        rec.to_edf(
             str(tmp_path / "off.bdf"), format="bdf", bypass_analysis=True, clip_outliers=False
         )

--- a/biosigio/tests/test_eeglab_bids_fixture.py
+++ b/biosigio/tests/test_eeglab_bids_fixture.py
@@ -25,22 +25,22 @@ EEG_SET = (
 
 @pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
 def test_eeglab_bids_eeg_fixture_imports():
-    emg = Recording.from_file(str(EEG_SET), importer="eeglab")
+    rec = Recording.from_file(str(EEG_SET), importer="eeglab")
 
     # All 64 channels imported with their real 10-10 montage labels.
-    assert len(emg.channels) == 64
-    assert "FP1" in emg.signals.columns
+    assert len(rec.channels) == 64
+    assert "FP1" in rec.signals.columns
 
-    col = emg.signals.columns[0]
-    assert emg.channels[col]["sample_frequency"] == 250
+    col = rec.signals.columns[0]
+    assert rec.channels[col]["sample_frequency"] == 250
 
     # 60 s at 250 Hz.
-    n = len(emg.signals[col])
+    n = len(rec.signals[col])
     assert n == 15000
 
     # Time index is seconds derived from the sample count, not the old
     # milliseconds/srate mis-scaling (which gave ~240 s for a 60 s recording).
-    assert emg.signals.index[-1] == pytest.approx((n - 1) / 250, rel=1e-6)
+    assert rec.signals.index[-1] == pytest.approx((n - 1) / 250, rel=1e-6)
 
     # Events were parsed from the .set event struct into the events table.
-    assert not emg.events.empty and len(emg.events) == 3
+    assert not rec.events.empty and len(rec.events) == 3

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -125,34 +125,34 @@ def sample_eeglab_set():
 def test_eeglab_importer(sample_eeglab_set):
     """Test EEGLAB importer with sample data."""
     importer = EEGLABImporter()
-    emg = importer.load(sample_eeglab_set)
+    rec = importer.load(sample_eeglab_set)
 
     # Check if metadata was loaded
-    assert emg.get_metadata("subject") == "test_subject"
-    assert emg.get_metadata("srate") == 1000
-    assert emg.get_metadata("device") == "EEGLAB"
+    assert rec.get_metadata("subject") == "test_subject"
+    assert rec.get_metadata("srate") == 1000
+    assert rec.get_metadata("device") == "EEGLAB"
 
     # Check if signals were loaded
-    assert emg.signals is not None
-    assert emg.signals.shape[0] == 1000  # 1000 samples
-    assert emg.signals.shape[1] == 32  # 32 channels
+    assert rec.signals is not None
+    assert rec.signals.shape[0] == 1000  # 1000 samples
+    assert rec.signals.shape[1] == 32  # 32 channels
 
     # Check if channel info was loaded
-    assert len(emg.channels) == 32
-    for _ch_name, ch_info in emg.channels.items():
+    assert len(rec.channels) == 32
+    for _ch_name, ch_info in rec.channels.items():
         assert ch_info["channel_type"] == "EMG"
         assert ch_info["sample_frequency"] == 1000
         assert ch_info["physical_dimension"] == "uV"
 
     # Events are loaded into the events table (onset/duration in seconds), not metadata.
-    assert "events" not in emg.metadata
-    assert not emg.events.empty
-    assert len(emg.events) == 5
-    assert list(emg.events["description"]) == [f"{i + 1}" for i in range(5)]
+    assert "events" not in rec.metadata
+    assert not rec.events.empty
+    assert len(rec.events) == 5
+    assert list(rec.events["description"]) == [f"{i + 1}" for i in range(5)]
     # EEGLAB latency is 1-based samples -> seconds at 1000 Hz: (i*200+100 - 1) / 1000.
     expected_onsets = [(i * 200 + 100 - 1) / 1000 for i in range(5)]
-    assert emg.events["onset"].tolist() == pytest.approx(expected_onsets)
-    assert (emg.events["duration"] == 0.0).all()
+    assert rec.events["onset"].tolist() == pytest.approx(expected_onsets)
+    assert (rec.events["duration"] == 0.0).all()
 
 
 def test_eeglab_file_not_found():
@@ -165,68 +165,68 @@ def test_eeglab_file_not_found():
 def test_eeglab_metadata_extraction(sample_eeglab_set):
     """Test metadata extraction from EEGLAB file."""
     importer = EEGLABImporter()
-    emg = importer.load(sample_eeglab_set)
+    rec = importer.load(sample_eeglab_set)
 
     # Test basic metadata
-    assert emg.get_metadata("setname") == "test_emg"
-    assert emg.get_metadata("subject") == "test_subject"
-    assert emg.get_metadata("group") == "test_group"
-    assert emg.get_metadata("condition") == "test_condition"
-    assert emg.get_metadata("session") == "001"
-    assert emg.get_metadata("comments") == "Test EMG data"
+    assert rec.get_metadata("setname") == "test_emg"
+    assert rec.get_metadata("subject") == "test_subject"
+    assert rec.get_metadata("group") == "test_group"
+    assert rec.get_metadata("condition") == "test_condition"
+    assert rec.get_metadata("session") == "001"
+    assert rec.get_metadata("comments") == "Test EMG data"
 
     # Test recording parameters
-    assert emg.get_metadata("srate") == 1000
-    assert emg.get_metadata("nbchan") == 32
-    assert emg.get_metadata("trials") == 1
-    assert emg.get_metadata("pnts") == 1000
-    assert emg.get_metadata("xmin") == 0.0
-    assert emg.get_metadata("xmax") == 1.0
+    assert rec.get_metadata("srate") == 1000
+    assert rec.get_metadata("nbchan") == 32
+    assert rec.get_metadata("trials") == 1
+    assert rec.get_metadata("pnts") == 1000
+    assert rec.get_metadata("xmin") == 0.0
+    assert rec.get_metadata("xmax") == 1.0
 
 
 def test_eeglab_channel_type_detection(sample_eeglab_set):
     """Test channel type detection from EEGLAB file."""
     importer = EEGLABImporter()
-    emg = importer.load(sample_eeglab_set)
+    rec = importer.load(sample_eeglab_set)
 
     # All channels should be EMG type
-    for _ch_name, ch_info in emg.channels.items():
+    for _ch_name, ch_info in rec.channels.items():
         assert ch_info["channel_type"] == "EMG"
 
     # Test channel naming
     for i in range(16):
-        assert f"emg{i}_left" in emg.channels
+        assert f"emg{i}_left" in rec.channels
     for i in range(16):
-        assert f"emg{i}_right" in emg.channels
+        assert f"emg{i}_right" in rec.channels
 
 
 def test_eeglab_event_processing(sample_eeglab_set):
     """Test event processing from EEGLAB file."""
     importer = EEGLABImporter()
-    emg = importer.load(sample_eeglab_set)
+    rec = importer.load(sample_eeglab_set)
 
     # Events are loaded into the events table (onset/duration in seconds), not metadata.
-    assert "events" not in emg.metadata
-    assert not emg.events.empty
-    assert len(emg.events) == 5
+    assert "events" not in rec.metadata
+    assert not rec.events.empty
+    assert len(rec.events) == 5
     # The EEGLAB event `type` becomes the description.
-    assert list(emg.events["description"]) == [f"{i + 1}" for i in range(5)]
+    assert list(rec.events["description"]) == [f"{i + 1}" for i in range(5)]
     # latency (1-based samples) -> seconds at 1000 Hz: (i*200+100 - 1) / 1000.
     expected_onsets = [(i * 200 + 100 - 1) / 1000 for i in range(5)]
-    assert emg.events["onset"].tolist() == pytest.approx(expected_onsets)
+    assert rec.events["onset"].tolist() == pytest.approx(expected_onsets)
 
 
 def test_eeglab_to_edf_export(sample_eeglab_set):
     """Test exporting EEGLAB data to EDF format."""
     importer = EEGLABImporter()
-    emg = importer.load(sample_eeglab_set)
+    rec = importer.load(sample_eeglab_set)
 
     # Export to EDF
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         edf_path = f.name
 
     try:
-        emg.to_edf(edf_path)
+        rec.to_edf(edf_path)
 
         # Check if EDF file was created
         assert os.path.exists(edf_path) or os.path.exists(os.path.splitext(edf_path)[0] + ".bdf")

--- a/biosigio/tests/test_exporters.py
+++ b/biosigio/tests/test_exporters.py
@@ -17,9 +17,9 @@ from ..exporters.edf import EDFExporter, _determine_scaling_factors
 
 
 @pytest.fixture
-def sample_emg():
+def sample_rec():
     """Create a Recording object with sample data."""
-    emg = Recording()
+    rec = Recording()
 
     # Create sample data
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
@@ -27,10 +27,10 @@ def sample_emg():
     acc_data = np.cos(2 * np.pi * 5 * time) * 1.5  # Use a non-unity amplitude
 
     # Add channels
-    emg.add_channel("EMG1", emg_data, 1000, "mV", "EMG")
-    emg.add_channel("ACC1", acc_data, 1000, "g", "ACC")
+    rec.add_channel("EMG1", emg_data, 1000, "mV", "EMG")
+    rec.add_channel("ACC1", acc_data, 1000, "g", "ACC")
 
-    return emg
+    return rec
 
 
 def _reconstruct_physical_signal(reader: pyedflib.EdfReader, signal_index: int) -> np.ndarray:
@@ -166,7 +166,7 @@ def test_determine_scaling_factors():
     assert phys_max == 1.0e-6
 
 
-def test_edf_export(sample_emg):
+def test_edf_export(sample_rec):
     """Test EDF export functionality."""
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         edf_path = f.name
@@ -177,7 +177,7 @@ def test_edf_export(sample_emg):
 
     try:
         # Export using default ('auto') format - our test signals have high DR so expect BDF
-        EDFExporter.export(sample_emg, edf_path, precision_threshold=1)
+        EDFExporter.export(sample_rec, edf_path, precision_threshold=1)
 
         # Check if either EDF or BDF file was created (expect BDF here due to high dynamic range)
         actual_path = bdf_path if os.path.exists(bdf_path) else edf_path
@@ -206,7 +206,7 @@ def test_edf_export(sample_emg):
             assert headers[0]["digital_max"] == 8388607
             assert headers[0]["physical_min"] < headers[0]["physical_max"]
 
-            original_emg_data = sample_emg.signals["EMG1"].values
+            original_emg_data = sample_rec.signals["EMG1"].values
             reconstructed_emg_data = _reconstruct_physical_signal(reader, 0)
             assert np.allclose(original_emg_data, reconstructed_emg_data, atol=1e-3), (
                 f"EMG1 scaling incorrect. Max diff: {np.max(np.abs(original_emg_data - reconstructed_emg_data)):.2e}"
@@ -221,7 +221,7 @@ def test_edf_export(sample_emg):
             assert headers[1]["digital_max"] == 8388607
             assert headers[1]["physical_min"] < headers[1]["physical_max"]
 
-            original_acc_data = sample_emg.signals["ACC1"].values
+            original_acc_data = sample_rec.signals["ACC1"].values
             reconstructed_acc_data = _reconstruct_physical_signal(reader, 1)
             assert np.allclose(original_acc_data, reconstructed_acc_data, atol=1e-3), (
                 f"ACC1 scaling incorrect. Max diff: {np.max(np.abs(original_acc_data - reconstructed_acc_data)):.2e}"
@@ -245,7 +245,7 @@ def test_edf_export(sample_emg):
             os.unlink(channels_tsv_path)
 
 
-def test_edf_export_no_channels_tsv(sample_emg):
+def test_edf_export_no_channels_tsv(sample_rec):
     """Test that channels.tsv is not created when create_channels_tsv=False."""
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         edf_path = f.name
@@ -253,7 +253,7 @@ def test_edf_export_no_channels_tsv(sample_emg):
 
     try:
         # Export with create_channels_tsv=False
-        EDFExporter.export(sample_emg, edf_path, create_channels_tsv=False, precision_threshold=1)
+        EDFExporter.export(sample_rec, edf_path, create_channels_tsv=False, precision_threshold=1)
 
         # Check if either EDF or BDF file was created
         actual_path = bdf_path if os.path.exists(bdf_path) else edf_path
@@ -275,13 +275,13 @@ def test_edf_export_no_channels_tsv(sample_emg):
 
 def test_edf_export_no_signals():
     """Test error handling when exporting empty Recording object."""
-    empty_emg = Recording()
+    empty_rec = Recording()
     with pytest.raises(ValueError):
         with tempfile.NamedTemporaryFile(suffix=".edf") as f:
-            EDFExporter.export(empty_emg, f.name)
+            EDFExporter.export(empty_rec, f.name)
 
 
-def test_edf_export_file_permissions(sample_emg):
+def test_edf_export_file_permissions(sample_rec):
     """Test error handling for file permission issues."""
     # Attempt to write to a directory that likely doesn't exist or isn't writable
     invalid_path = "/dev/null/some_dir/test.edf"
@@ -291,7 +291,7 @@ def test_edf_export_file_permissions(sample_emg):
 
     # Expecting an OSError or similar depending on OS and filesystem
     with pytest.raises(Exception) as excinfo:
-        EDFExporter.export(sample_emg, invalid_path)
+        EDFExporter.export(sample_rec, invalid_path)
     print(f"Caught expected exception: {excinfo.type}")  # For debugging
 
 
@@ -373,20 +373,20 @@ def test_format_selection():
 
     # Test case 1: High quality signal with small amplitude (should still use BDF due to dynamic range)
     clean_signal = np.sin(2 * np.pi * 10 * time) * 1  # Clean 10 Hz sine with amplitude 1
-    emg_clean = Recording()
-    emg_clean.add_channel("Clean", clean_signal, 1000, "uV", "EMG")
+    rec_clean = Recording()
+    rec_clean.add_channel("Clean", clean_signal, 1000, "uV", "EMG")
 
     # Test case 2: Moderate dynamic range signal that will trigger EDF
     # Update test to reflect signals under ~80dB typically use EDF
     hdr_signal, actual_dr = generate_high_dynamic_range_signal(dynamic_range_db=85)
     print(f"HDR signal generated with {actual_dr:.1f} dB dynamic range")
-    emg_hdr = Recording()
-    emg_hdr.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
+    rec_hdr = Recording()
+    rec_hdr.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
 
     # Test case 3: Mixed signals (should result in BDF due to high DR clean signal)
-    emg_mixed = Recording()
-    emg_mixed.add_channel("Clean", clean_signal, 1000, "uV", "EMG")
-    emg_mixed.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
+    rec_mixed = Recording()
+    rec_mixed.add_channel("Clean", clean_signal, 1000, "uV", "EMG")
+    rec_mixed.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         base_path = f.name
@@ -411,13 +411,13 @@ def test_format_selection():
 
     try:
         # Test clean signal -> BDF (due to high DR in our analysis)
-        EDFExporter.export(emg_clean, edf_path_clean, format="auto")
+        EDFExporter.export(rec_clean, edf_path_clean, format="auto")
         assert os.path.exists(bdf_path_clean), "BDF file not created for clean signal in auto mode"
         assert not os.path.exists(edf_path_clean), "EDF file created unexpectedly"
 
         # Test HDR signal -> EDF (since actual dynamic range is below BDF threshold)
         with warnings.catch_warnings(record=True) as w:
-            EDFExporter.export(emg_hdr, edf_path_hdr, format="auto")
+            EDFExporter.export(rec_hdr, edf_path_hdr, format="auto")
             # Since our signal's dynamic range is ~78dB, expect EDF file
             assert os.path.exists(edf_path_hdr), (
                 "EDF file not created for moderate (~78dB) DR signal in auto mode"
@@ -428,7 +428,7 @@ def test_format_selection():
 
         # Test mixed signal -> BDF (because the clean signal has a high DR)
         with warnings.catch_warnings(record=True) as w:
-            EDFExporter.export(emg_mixed, edf_path_mixed, format="auto")
+            EDFExporter.export(rec_mixed, edf_path_mixed, format="auto")
             assert os.path.exists(bdf_path_mixed), (
                 "BDF file not created for mixed signal in auto mode"
             )
@@ -454,13 +454,13 @@ def test_format_reproducibility():
 
     # BDF test signal (large amplitude, requires BDF ideally)
     bdf_signal = np.sin(2 * np.pi * 10 * time) * 1e6
-    emg_bdf = Recording()
-    emg_bdf.add_channel("LargeAmp", bdf_signal, 1000, "uV", "EMG")
+    rec_bdf = Recording()
+    rec_bdf.add_channel("LargeAmp", bdf_signal, 1000, "uV", "EMG")
 
     # EDF test signal (smaller amplitude, suitable for EDF)
     edf_signal = np.sin(2 * np.pi * 10 * time) * 1000
-    emg_edf = Recording()
-    emg_edf.add_channel("SmallAmp", edf_signal, 1000, "uV", "EMG")
+    rec_edf = Recording()
+    rec_edf.add_channel("SmallAmp", edf_signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         base_path = f.name
@@ -472,7 +472,7 @@ def test_format_reproducibility():
 
     try:
         # Test BDF reproducibility (using format='bdf')
-        EDFExporter.export(emg_bdf, bdf_test_path, format="bdf")
+        EDFExporter.export(rec_bdf, bdf_test_path, format="bdf")
         assert os.path.exists(bdf_test_path)
         with pyedflib.EdfReader(bdf_test_path) as reader:
             reconstructed_bdf = _reconstruct_physical_signal(reader, 0)
@@ -482,7 +482,7 @@ def test_format_reproducibility():
             )
 
         # Test EDF reproducibility (using format='edf')
-        EDFExporter.export(emg_edf, edf_test_path, format="edf")
+        EDFExporter.export(rec_edf, edf_test_path, format="edf")
         assert os.path.exists(edf_test_path)
         with pyedflib.EdfReader(edf_test_path) as reader:
             reconstructed_edf = _reconstruct_physical_signal(reader, 0)
@@ -502,11 +502,11 @@ def test_format_reproducibility():
 
 def test_bdf_format_selection():
     """Test automatic BDF format selection with scaling verification."""
-    emg = Recording()
+    rec = Recording()
     time = np.linspace(0, 1, 1000)
     # Create signal that should trigger BDF in 'auto' mode
     signal = np.sin(2 * np.pi * 10 * time) * 1e6  # Large amplitude
-    emg.add_channel("HighPrec", signal, 1000, "uV", "EMG")
+    rec.add_channel("HighPrec", signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         edf_path = f.name
@@ -518,7 +518,7 @@ def test_bdf_format_selection():
     try:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            EDFExporter.export(emg, edf_path, format="auto")
+            EDFExporter.export(rec, edf_path, format="auto")
             # Both files might exist since we create one then rename, just check BDF was created
             assert os.path.exists(bdf_path), (
                 "BDF file was not created in auto mode for high precision signal"
@@ -558,16 +558,16 @@ def test_user_format_selection():
     hdr_signal, _ = generate_high_dynamic_range_signal(
         dynamic_range_db=85
     )  # Lower threshold for reliability
-    emg_hdr = Recording()
-    emg_hdr.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
+    rec_hdr = Recording()
+    rec_hdr.add_channel("HDR", hdr_signal, 1000, "uV", "EMG")
 
     # Signal that would normally trigger EDF (Lower Dynamic Range)
     np.random.seed(42)
     noisy_signal = np.sin(2 * np.pi * 10 * time) * 100
     noise = np.random.normal(0, 5.0, 1000)
     noisy_signal += noise
-    emg_lowdr = Recording()
-    emg_lowdr.add_channel("LowDR", noisy_signal, 1000, "uV", "EMG")
+    rec_lowdr = Recording()
+    rec_lowdr.add_channel("LowDR", noisy_signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         base_path = f.name
@@ -583,7 +583,7 @@ def test_user_format_selection():
         # 1. Force EDF for HDR signal (no warning expected as format is explicit)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            EDFExporter.export(emg_hdr, edf_path_hdr, format="edf")
+            EDFExporter.export(rec_hdr, edf_path_hdr, format="edf")
             assert os.path.exists(edf_path_hdr), (
                 "EDF file not created when format='edf' specified for HDR signal"
             )
@@ -604,7 +604,7 @@ def test_user_format_selection():
         # 2. Force BDF for LowDR signal (no warning expected as format is explicit)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            EDFExporter.export(emg_lowdr, bdf_path_lowdr, format="bdf")
+            EDFExporter.export(rec_lowdr, bdf_path_lowdr, format="bdf")
             assert os.path.exists(bdf_path_lowdr), (
                 "BDF file not created when format='bdf' specified for LowDR signal"
             )
@@ -636,18 +636,18 @@ def test_user_format_selection():
 def test_high_dynamic_range():
     """Test export of signals with high dynamic range using auto format."""
     # Create Recording object
-    emg = Recording()
+    rec = Recording()
 
     # Generate a high dynamic range signal (lowered threshold for test reliability)
     hdr_signal, actual_dr = generate_high_dynamic_range_signal(dynamic_range_db=85)
     assert actual_dr > 75, f"Generated signal has {actual_dr:.1f} dB DR, expected >75 dB"
     print(f"Successfully generated test signal with {actual_dr:.1f} dB dynamic range")
-    emg.add_channel("HDR_EMG", hdr_signal, 1000, "uV", "EMG")
+    rec.add_channel("HDR_EMG", hdr_signal, 1000, "uV", "EMG")
 
     # Add a regular channel for comparison - this has high dynamic range
     time = np.linspace(0, 1, 1000)
     regular_signal = np.sin(2 * np.pi * 10 * time) * 1000
-    emg.add_channel("REG_EMG", regular_signal, 1000, "uV", "EMG")
+    rec.add_channel("REG_EMG", regular_signal, 1000, "uV", "EMG")
 
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         edf_path = f.name
@@ -660,7 +660,7 @@ def test_high_dynamic_range():
         # Export the EMG data using format='auto'
         # When we mix a moderate DR signal with a high DR signal,
         # the exporter should use BDF
-        EDFExporter.export(emg, edf_path, format="auto")
+        EDFExporter.export(rec, edf_path, format="auto")
 
         # The regular signal has high DR so we expect BDF output
         assert os.path.exists(bdf_path), "BDF file not created even though REG_EMG has high DR"
@@ -731,7 +731,7 @@ def test_dynamic_range_calculation():
 @patch("biosigio.exporters.edf.analyze_signal")
 @patch("biosigio.exporters.edf.determine_format_suitability")
 def test_edf_export_bypass_analysis(
-    mock_determine_suitability, mock_analyze_signal, sample_emg, capsys
+    mock_determine_suitability, mock_analyze_signal, sample_rec, capsys
 ):
     """Test EDF/BDF export with bypass_analysis=True."""
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
@@ -744,7 +744,7 @@ def test_edf_export_bypass_analysis(
 
     try:
         # --- Test bypassing with format='edf' ---
-        EDFExporter.export(sample_emg, edf_path, format="edf", bypass_analysis=True)
+        EDFExporter.export(sample_rec, edf_path, format="edf", bypass_analysis=True)
 
         # Verify analysis functions were NOT called
         mock_analyze_signal.assert_not_called()
@@ -766,7 +766,7 @@ def test_edf_export_bypass_analysis(
             assert headers[0]["digital_min"] == -32768  # EDF range
             assert headers[0]["digital_max"] == 32767
             reconstructed_emg = _reconstruct_physical_signal(reader, 0)
-            assert np.allclose(sample_emg.signals["EMG1"].values, reconstructed_emg, atol=0.2)
+            assert np.allclose(sample_rec.signals["EMG1"].values, reconstructed_emg, atol=0.2)
 
         # Verify summary was skipped
         captured = capsys.readouterr()
@@ -783,7 +783,7 @@ def test_edf_export_bypass_analysis(
             os.unlink(edf_channels_tsv_path)
 
         # --- Test bypassing with format='bdf' ---
-        EDFExporter.export(sample_emg, bdf_path, format="bdf", bypass_analysis=True)
+        EDFExporter.export(sample_rec, bdf_path, format="bdf", bypass_analysis=True)
 
         # Verify analysis functions were NOT called
         mock_analyze_signal.assert_not_called()
@@ -805,7 +805,7 @@ def test_edf_export_bypass_analysis(
             assert headers[0]["digital_min"] == -8388608  # BDF range
             assert headers[0]["digital_max"] == 8388607
             reconstructed_emg = _reconstruct_physical_signal(reader, 0)
-            assert np.allclose(sample_emg.signals["EMG1"].values, reconstructed_emg, atol=0.2)
+            assert np.allclose(sample_rec.signals["EMG1"].values, reconstructed_emg, atol=0.2)
 
         # Verify summary was skipped
         captured = capsys.readouterr()
@@ -819,7 +819,7 @@ def test_edf_export_bypass_analysis(
 
         # --- Test error when bypassing with format='auto' ---
         with pytest.raises(ValueError, match="Cannot bypass analysis when format is set to 'auto'"):
-            EDFExporter.export(sample_emg, edf_path, format="auto", bypass_analysis=True)
+            EDFExporter.export(sample_rec, edf_path, format="auto", bypass_analysis=True)
 
         mock_analyze_signal.assert_not_called()  # Should raise error before analysis
 
@@ -836,7 +836,7 @@ def test_edf_export_bypass_analysis(
 @patch("biosigio.exporters.edf.analyze_signal")
 @patch("biosigio.exporters.edf.determine_format_suitability")
 def test_edf_export_force_analysis(
-    mock_determine_suitability, mock_analyze_signal, sample_emg, capsys
+    mock_determine_suitability, mock_analyze_signal, sample_rec, capsys
 ):
     """Test EDF/BDF export with bypass_analysis=False when format is specified."""
     # Mock return values for analysis functions
@@ -857,11 +857,11 @@ def test_edf_export_force_analysis(
 
     try:
         # --- Test forcing analysis with format='edf' ---
-        EDFExporter.export(sample_emg, edf_path, format="edf", bypass_analysis=False)
+        EDFExporter.export(sample_rec, edf_path, format="edf", bypass_analysis=False)
 
         # Verify analysis functions WERE called (once per channel)
-        assert mock_analyze_signal.call_count == len(sample_emg.channels)
-        assert mock_determine_suitability.call_count == len(sample_emg.channels)
+        assert mock_analyze_signal.call_count == len(sample_rec.channels)
+        assert mock_determine_suitability.call_count == len(sample_rec.channels)
 
         # Verify file was created
         assert os.path.exists(edf_path), (

--- a/biosigio/tests/test_importer_wfdb.py
+++ b/biosigio/tests/test_importer_wfdb.py
@@ -60,44 +60,44 @@ def wfdb_importer():
 
 def test_wfdb_load_basic(wfdb_importer, wfdb_data):
     """Test basic loading of a WFDB record (.hea file)."""
-    emg = wfdb_importer.load(str(wfdb_data["hea"]))
+    rec = wfdb_importer.load(str(wfdb_data["hea"]))
 
-    assert isinstance(emg, Recording)
-    assert emg.signals is not None
-    assert isinstance(emg.signals, pd.DataFrame)
+    assert isinstance(rec, Recording)
+    assert rec.signals is not None
+    assert isinstance(rec.signals, pd.DataFrame)
     # Record 100 has 2 signals
-    assert emg.signals.shape[1] == 2
+    assert rec.signals.shape[1] == 2
     # Check if time index is created
-    assert isinstance(emg.signals.index, pd.Index)
+    assert isinstance(rec.signals.index, pd.Index)
 
     # Check metadata
-    assert emg.get_metadata("record_name") == WFDB_RECORD_NAME
-    assert emg.get_metadata("sampling_frequency") == 360.0  # Known frequency for record 100
-    assert emg.get_metadata("source_file") == str(wfdb_data["hea"])
+    assert rec.get_metadata("record_name") == WFDB_RECORD_NAME
+    assert rec.get_metadata("sampling_frequency") == 360.0  # Known frequency for record 100
+    assert rec.get_metadata("source_file") == str(wfdb_data["hea"])
 
     # Check channels
-    assert len(emg.channels) == 2
-    assert "MLII" in emg.channels
-    assert "V5" in emg.channels
-    assert emg.channels["MLII"]["physical_dimension"] == "mV"
-    assert emg.channels["V5"]["physical_dimension"] == "mV"
-    assert emg.channels["MLII"]["sample_frequency"] == 360.0
-    assert emg.channels["V5"]["sample_frequency"] == 360.0
+    assert len(rec.channels) == 2
+    assert "MLII" in rec.channels
+    assert "V5" in rec.channels
+    assert rec.channels["MLII"]["physical_dimension"] == "mV"
+    assert rec.channels["V5"]["physical_dimension"] == "mV"
+    assert rec.channels["MLII"]["sample_frequency"] == 360.0
+    assert rec.channels["V5"]["sample_frequency"] == 360.0
 
 
 def test_wfdb_load_annotations(wfdb_importer, wfdb_data):
     """Test loading WFDB record with annotations (.atr file present)."""
-    emg = wfdb_importer.load(str(wfdb_data["hea"]))
+    rec = wfdb_importer.load(str(wfdb_data["hea"]))
 
-    assert emg.events is not None
-    assert isinstance(emg.events, pd.DataFrame)
-    assert not emg.events.empty
-    assert list(emg.events.columns) == ["onset", "duration", "description"]
+    assert rec.events is not None
+    assert isinstance(rec.events, pd.DataFrame)
+    assert not rec.events.empty
+    assert list(rec.events.columns) == ["onset", "duration", "description"]
     # Check specific values for record 100 annotations
-    assert len(emg.events) == 2274  # Known number of annotations for record 100.atr
-    assert emg.events.iloc[0]["onset"] == pytest.approx(18 / 360.0)
-    assert emg.events.iloc[0]["duration"] == 0
-    assert emg.events.iloc[0]["description"] == "WFDB Annotation: +"
+    assert len(rec.events) == 2274  # Known number of annotations for record 100.atr
+    assert rec.events.iloc[0]["onset"] == pytest.approx(18 / 360.0)
+    assert rec.events.iloc[0]["duration"] == 0
+    assert rec.events.iloc[0]["description"] == "WFDB Annotation: +"
 
 
 def test_wfdb_load_no_annotations_file(wfdb_importer, wfdb_data):
@@ -105,16 +105,16 @@ def test_wfdb_load_no_annotations_file(wfdb_importer, wfdb_data):
     # Remove the .atr file
     os.remove(wfdb_data["atr"])
 
-    emg = wfdb_importer.load(str(wfdb_data["hea"]))
+    rec = wfdb_importer.load(str(wfdb_data["hea"]))
 
     # Events DataFrame should be empty
-    assert emg.events is not None
-    assert isinstance(emg.events, pd.DataFrame)
-    assert emg.events.empty
+    assert rec.events is not None
+    assert isinstance(rec.events, pd.DataFrame)
+    assert rec.events.empty
 
     # Check metadata status
-    assert emg.get_metadata("annotation_status") == "Annotation file (.atr) not found."
-    assert emg.get_metadata("annotation_error") is None
+    assert rec.get_metadata("annotation_status") == "Annotation file (.atr) not found."
+    assert rec.get_metadata("annotation_error") is None
 
 
 def test_wfdb_load_file_not_found(wfdb_importer, tmp_path):
@@ -142,8 +142,8 @@ def test_wfdb_importer_handles_record_name_input(wfdb_importer, wfdb_data):
     """Test that the importer can load using just the record name within the directory."""
     # Provide the path to the directory and the base record name
     record_base_path = os.path.join(wfdb_data["dir"], WFDB_RECORD_NAME)
-    emg = wfdb_importer.load(record_base_path)
+    rec = wfdb_importer.load(record_base_path)
 
-    assert isinstance(emg, Recording)
-    assert emg.get_metadata("record_name") == WFDB_RECORD_NAME
-    assert not emg.events.empty  # Check annotations loaded correctly too
+    assert isinstance(rec, Recording)
+    assert rec.get_metadata("record_name") == WFDB_RECORD_NAME
+    assert not rec.events.empty  # Check annotations loaded correctly too

--- a/biosigio/tests/test_importers.py
+++ b/biosigio/tests/test_importers.py
@@ -59,28 +59,28 @@ def sample_generic_csv():
 def test_trigno_importer(sample_trigno_csv):
     """Test Trigno importer with sample data."""
     importer = TrignoImporter()
-    emg = importer.load(sample_trigno_csv)
+    rec = importer.load(sample_trigno_csv)
 
     # Check if all channels were loaded
-    assert "EMG1" in emg.channels
-    assert "EMG2" in emg.channels
-    assert "ACC1" in emg.channels
+    assert "EMG1" in rec.channels
+    assert "EMG2" in rec.channels
+    assert "ACC1" in rec.channels
 
     # Check channel properties
-    assert emg.channels["EMG1"]["sample_frequency"] == 1000
-    assert emg.channels["EMG1"]["physical_dimension"] == "mV"
-    assert emg.channels["EMG1"]["channel_type"] == "EMG"
+    assert rec.channels["EMG1"]["sample_frequency"] == 1000
+    assert rec.channels["EMG1"]["physical_dimension"] == "mV"
+    assert rec.channels["EMG1"]["channel_type"] == "EMG"
 
-    assert emg.channels["ACC1"]["physical_dimension"] == "g"
-    assert emg.channels["ACC1"]["channel_type"] == "ACC"
+    assert rec.channels["ACC1"]["physical_dimension"] == "g"
+    assert rec.channels["ACC1"]["channel_type"] == "ACC"
 
     # Check data shape
-    assert len(emg.signals) == 5  # 5 samples
-    assert len(emg.signals.columns) == 3  # 3 channels
+    assert len(rec.signals) == 5  # 5 samples
+    assert len(rec.signals.columns) == 3  # 3 channels
 
     # Check metadata
-    assert emg.get_metadata("device") == "Delsys Trigno"
-    assert emg.get_metadata("source_file") == sample_trigno_csv
+    assert rec.get_metadata("device") == "Delsys Trigno"
+    assert rec.get_metadata("source_file") == sample_trigno_csv
 
 
 def test_trigno_file_not_found():
@@ -116,25 +116,25 @@ def test_csv_importer_basic(sample_generic_csv):
     importer = CSVImporter()
 
     # Test with default parameters
-    emg = importer.load(
+    rec = importer.load(
         sample_generic_csv,
         sample_frequency=1000,  # Required since no time column
         has_header=False,
     )
 
     # Check if channels were created
-    assert len(emg.channels) == 3  # 3 columns in our test data
-    assert "Channel_0" in emg.channels
-    assert "Channel_1" in emg.channels
-    assert "Channel_2" in emg.channels
+    assert len(rec.channels) == 3  # 3 columns in our test data
+    assert "Channel_0" in rec.channels
+    assert "Channel_1" in rec.channels
+    assert "Channel_2" in rec.channels
 
     # Check data shape
-    assert len(emg.signals) == 5  # 5 samples
-    assert len(emg.signals.columns) == 3  # 3 channels
+    assert len(rec.signals) == 5  # 5 samples
+    assert len(rec.signals.columns) == 3  # 3 channels
 
     # Check metadata
-    assert emg.get_metadata("source_file") == sample_generic_csv
-    assert emg.get_metadata("file_format") == "CSV"
+    assert rec.get_metadata("source_file") == sample_generic_csv
+    assert rec.get_metadata("file_format") == "CSV"
 
 
 def test_csv_importer_channel_params(sample_generic_csv):
@@ -147,7 +147,7 @@ def test_csv_importer_channel_params(sample_generic_csv):
     physical_dimensions = {"Channel_0": "mV", "Channel_1": "mV", "Channel_2": "g"}
 
     # Test with custom channel parameters
-    emg = importer.load(
+    rec = importer.load(
         sample_generic_csv,
         sample_frequency=1000,
         has_header=False,
@@ -156,11 +156,11 @@ def test_csv_importer_channel_params(sample_generic_csv):
     )
 
     # Check channel properties
-    assert emg.channels["Channel_0"]["channel_type"] == "EMG"
-    assert emg.channels["Channel_0"]["physical_dimension"] == "mV"
+    assert rec.channels["Channel_0"]["channel_type"] == "EMG"
+    assert rec.channels["Channel_0"]["physical_dimension"] == "mV"
 
-    assert emg.channels["Channel_2"]["channel_type"] == "ACC"
-    assert emg.channels["Channel_2"]["physical_dimension"] == "g"
+    assert rec.channels["Channel_2"]["channel_type"] == "ACC"
+    assert rec.channels["Channel_2"]["physical_dimension"] == "g"
 
 
 def test_csv_importer_selection(sample_generic_csv):
@@ -168,18 +168,18 @@ def test_csv_importer_selection(sample_generic_csv):
     importer = CSVImporter()
 
     # Test with column selection
-    emg = importer.load(
+    rec = importer.load(
         sample_generic_csv, sample_frequency=1000, has_header=False, columns=[0, 2]
     )  # Select only first and third columns
 
     # Check if only selected channels were loaded
-    assert len(emg.channels) == 2
-    assert "Channel_0" in emg.channels
-    assert "Channel_1" in emg.channels
-    assert "Channel_2" not in emg.channels  # This should not exist
+    assert len(rec.channels) == 2
+    assert "Channel_0" in rec.channels
+    assert "Channel_1" in rec.channels
+    assert "Channel_2" not in rec.channels  # This should not exist
 
     # Check data shape
-    assert len(emg.signals.columns) == 2
+    assert len(rec.signals.columns) == 2
 
 
 def test_csv_importer_custom_names(sample_generic_csv):
@@ -189,17 +189,17 @@ def test_csv_importer_custom_names(sample_generic_csv):
     channel_names = ["EMG_L", "EMG_R", "ACC_X"]
 
     # Test with custom channel names
-    emg = importer.load(
+    rec = importer.load(
         sample_generic_csv, sample_frequency=1000, has_header=False, channel_names=channel_names
     )
 
     # Check if channels have correct names
-    assert "EMG_L" in emg.channels
-    assert "EMG_R" in emg.channels
-    assert "ACC_X" in emg.channels
+    assert "EMG_L" in rec.channels
+    assert "EMG_R" in rec.channels
+    assert "ACC_X" in rec.channels
 
     # Check data shape
-    assert len(emg.signals.columns) == 3
+    assert len(rec.signals.columns) == 3
 
 
 def test_csv_format_detection(sample_trigno_csv):
@@ -217,11 +217,11 @@ def test_csv_format_detection(sample_trigno_csv):
     assert "force_generic=True" in error_msg
 
     # Test with force_generic=True
-    emg = importer.load(sample_trigno_csv, force_generic=True)
+    rec = importer.load(sample_trigno_csv, force_generic=True)
 
     # Basic checks to make sure it loaded something
-    assert emg.signals is not None
-    assert len(emg.channels) > 0
+    assert rec.signals is not None
+    assert len(rec.channels) > 0
 
 
 def test_csv_file_not_found():
@@ -250,13 +250,13 @@ def test_csv_delimiter_detection(sample_generic_csv):
         assert analyzed_params["delimiter"] == "\t"
 
         # Test loading with auto-detection
-        emg = importer.load(tab_file, sample_frequency=1000, has_header=False)
+        rec = importer.load(tab_file, sample_frequency=1000, has_header=False)
 
         # Debug print
-        print("EMG channels:", list(emg.channels.keys()))
-        print("EMG signals columns:", list(emg.signals.columns))
+        print("EMG channels:", list(rec.channels.keys()))
+        print("EMG signals columns:", list(rec.signals.columns))
 
-        assert len(emg.channels) == 4
+        assert len(rec.channels) == 4
 
         # Clean up
         os.unlink(tab_file)
@@ -269,26 +269,26 @@ def test_csv_delimiter_detection(sample_generic_csv):
 def test_otb_importer():
     """Test OTB importer with sample data."""
     importer = OTBImporter()
-    emg = importer.load("examples/one_sessantaquattro_truncated.otb+")
+    rec = importer.load("examples/one_sessantaquattro_truncated.otb+")
 
     # Check if channels were loaded
-    assert len(emg.channels) > 0
+    assert len(rec.channels) > 0
 
     # Check channel properties for first channel
-    first_channel = next(iter(emg.channels.values()))
+    first_channel = next(iter(rec.channels.values()))
     assert first_channel["sample_frequency"] > 0
     assert first_channel["physical_dimension"] in ["mV", "g", "rad", "a.u."]
     assert first_channel["channel_type"] in ["EMG", "ACC", "GYRO", "QUAT", "CTRL", "OTHER"]
 
     # Check metadata
-    assert emg.get_metadata("device") is not None
-    assert emg.get_metadata("signal_resolution") is not None
-    assert emg.get_metadata("source_file") == "examples/one_sessantaquattro_truncated.otb+"
+    assert rec.get_metadata("device") is not None
+    assert rec.get_metadata("signal_resolution") is not None
+    assert rec.get_metadata("source_file") == "examples/one_sessantaquattro_truncated.otb+"
 
     # Check data structure
-    assert emg.signals is not None
-    assert len(emg.signals) > 0  # Has samples
-    assert len(emg.signals.columns) == len(emg.channels)  # Columns match channels
+    assert rec.signals is not None
+    assert len(rec.signals) > 0  # Has samples
+    assert len(rec.signals.columns) == len(rec.channels)  # Columns match channels
 
 
 def test_otb_file_not_found():
@@ -301,14 +301,14 @@ def test_otb_file_not_found():
 def test_otb_metadata_parsing():
     """Test metadata parsing from OTB file."""
     importer = OTBImporter()
-    emg = importer.load("examples/one_sessantaquattro_truncated.otb+")
+    rec = importer.load("examples/one_sessantaquattro_truncated.otb+")
 
     # Test device metadata
-    assert emg.get_metadata("device") is not None
-    assert emg.get_metadata("signal_resolution") is not None
+    assert rec.get_metadata("device") is not None
+    assert rec.get_metadata("signal_resolution") is not None
 
     # Test channel metadata
-    for _channel_name, channel_info in emg.channels.items():
+    for _channel_name, channel_info in rec.channels.items():
         assert "sample_frequency" in channel_info
         assert "physical_dimension" in channel_info
         assert "channel_type" in channel_info
@@ -414,28 +414,28 @@ def sample_edf_file():
 def test_edf_importer(sample_edf_file):
     """Test EDF importer with sample data."""
     importer = EDFImporter()
-    emg = importer.load(sample_edf_file)
+    rec = importer.load(sample_edf_file)
 
     # Check if channels were loaded
-    assert "EMG1" in emg.channels
-    assert "ACC1" in emg.channels
+    assert "EMG1" in rec.channels
+    assert "ACC1" in rec.channels
 
     # Check channel properties
-    assert emg.channels["EMG1"]["sample_frequency"] == 1000
-    assert emg.channels["EMG1"]["physical_dimension"] == "mV"
-    assert emg.channels["EMG1"]["channel_type"] == "EMG"
-    assert "HP:20Hz LP:500Hz" in emg.channels["EMG1"]["prefilter"]
+    assert rec.channels["EMG1"]["sample_frequency"] == 1000
+    assert rec.channels["EMG1"]["physical_dimension"] == "mV"
+    assert rec.channels["EMG1"]["channel_type"] == "EMG"
+    assert "HP:20Hz LP:500Hz" in rec.channels["EMG1"]["prefilter"]
 
-    assert emg.channels["ACC1"]["physical_dimension"] == "g"
-    assert emg.channels["ACC1"]["channel_type"] == "ACC"
+    assert rec.channels["ACC1"]["physical_dimension"] == "g"
+    assert rec.channels["ACC1"]["channel_type"] == "ACC"
 
     # Check data shape
-    assert len(emg.signals) == 1000  # 1000 samples
-    assert len(emg.signals.columns) == 2  # 2 channels
+    assert len(rec.signals) == 1000  # 1000 samples
+    assert len(rec.signals.columns) == 2  # 2 channels
 
     # Check metadata
-    assert emg.get_metadata("source_file") == sample_edf_file
-    assert emg.get_metadata("filetype") in [0, 1, 2]  # EDF, EDF+, or BDF+
+    assert rec.get_metadata("source_file") == sample_edf_file
+    assert rec.get_metadata("filetype") in [0, 1, 2]  # EDF, EDF+, or BDF+
 
 
 def test_edf_file_not_found():
@@ -448,28 +448,28 @@ def test_edf_file_not_found():
 def test_edf_channel_type_detection(sample_edf_file):
     """Test channel type detection from labels and transducers."""
     importer = EDFImporter()
-    emg = importer.load(sample_edf_file)
+    rec = importer.load(sample_edf_file)
 
     # Test EMG channel detection
-    assert emg.channels["EMG1"]["channel_type"] == "EMG"
+    assert rec.channels["EMG1"]["channel_type"] == "EMG"
 
     # Test ACC channel detection
-    assert emg.channels["ACC1"]["channel_type"] == "ACC"
+    assert rec.channels["ACC1"]["channel_type"] == "ACC"
 
 
 def test_edf_metadata_extraction(sample_edf_file):
     """Test metadata extraction from EDF file."""
     importer = EDFImporter()
-    emg = importer.load(sample_edf_file)
+    rec = importer.load(sample_edf_file)
 
     # Check file metadata
-    assert "filetype" in emg.metadata
-    assert "number_of_signals" in emg.metadata
-    assert emg.metadata["number_of_signals"] == 2
+    assert "filetype" in rec.metadata
+    assert "number_of_signals" in rec.metadata
+    assert rec.metadata["number_of_signals"] == 2
 
     # Check recording info
     assert any(
-        key in emg.metadata
+        key in rec.metadata
         for key in ["startdate", "equipment", "technician", "recording_additional"]
     )
 
@@ -479,9 +479,9 @@ def test_edf_no_annotations_yields_empty_events(sample_edf_file):
 
     (``sample_edf_file`` is EDF+: pyedflib's EdfWriter defaults to FILETYPE_EDFPLUS.)
     """
-    emg = EDFImporter().load(sample_edf_file)
-    assert emg.events is not None
-    assert emg.events.empty
+    rec = EDFImporter().load(sample_edf_file)
+    assert rec.events is not None
+    assert rec.events.empty
 
 
 def test_edf_plain_format_has_no_events(tmp_path):
@@ -506,8 +506,8 @@ def test_edf_plain_format_has_no_events(tmp_path):
     writer.writeSamples([np.sin(2 * np.pi * 5 * np.arange(500) / 100)])
     writer.close()
 
-    emg = EDFImporter().load(path)
-    assert emg.events.empty
+    rec = EDFImporter().load(path)
+    assert rec.events.empty
 
 
 def test_edf_annotation_readback(tmp_path):
@@ -535,8 +535,8 @@ def test_edf_annotation_readback(tmp_path):
     writer.writeAnnotation(0.5, 0.0, "stim_onset")
     writer.close()
 
-    emg = EDFImporter().load(path)
-    assert list(emg.events["description"]) == ["stim_onset", "stim_offset"]
-    assert np.allclose(emg.events["onset"].to_numpy(), [0.5, 2.0], atol=1e-3)
-    assert np.allclose(emg.events["duration"].to_numpy(), [0.0, 0.5], atol=1e-3)
-    assert emg.events["onset"].dtype == np.float64
+    rec = EDFImporter().load(path)
+    assert list(rec.events["description"]) == ["stim_onset", "stim_offset"]
+    assert np.allclose(rec.events["onset"].to_numpy(), [0.5, 2.0], atol=1e-3)
+    assert np.allclose(rec.events["duration"].to_numpy(), [0.0, 0.5], atol=1e-3)
+    assert rec.events["onset"].dtype == np.float64

--- a/biosigio/tests/test_lowres.py
+++ b/biosigio/tests/test_lowres.py
@@ -25,41 +25,41 @@ requires_emg = pytest.mark.skipif(not EMG_EDF.exists(), reason="EMG fixture miss
 _CONST_PTP = 1e-9  # below this peak-to-peak a channel has no defined correlation
 
 
-def _rates(emg: Recording) -> set:
-    return {info["sample_frequency"] for info in emg.channels.values()}
+def _rates(rec: Recording) -> set:
+    return {info["sample_frequency"] for info in rec.channels.values()}
 
 
 @requires_eeg
 def test_resample_eeg_250_to_100_structure():
     """250 -> 100 Hz: new rate on all channels, expected sample count, channels/events kept."""
-    emg = Recording.from_file(str(EEG), importer="eeglab")
-    n_old = emg.signals.shape[0]
-    n_channels = len(emg.channels)
-    n_events = len(emg.events)
+    rec = Recording.from_file(str(EEG), importer="eeglab")
+    n_old = rec.signals.shape[0]
+    n_channels = len(rec.channels)
+    n_events = len(rec.events)
 
-    rs = emg.resample(100)
+    rs = rec.resample(100)
 
     assert _rates(rs) == {100}, "every channel must report the new rate"
     # resample_poly output length is ceil(n * up / down), not round(n * ratio).
     g = gcd(250, 100)
     assert rs.signals.shape[0] == ceil(n_old * (100 // g) / (250 // g))
     assert len(rs.channels) == n_channels, "channel count preserved"
-    assert set(rs.signals.columns) == set(emg.signals.columns), "channel names preserved"
+    assert set(rs.signals.columns) == set(rec.signals.columns), "channel names preserved"
     assert len(rs.events) == n_events, "events preserved"
 
     # Non-destructive: the source is untouched.
-    assert emg.signals.shape[0] == n_old
-    assert _rates(emg) == {250}
+    assert rec.signals.shape[0] == n_old
+    assert _rates(rec) == {250}
 
 
 @requires_eeg
 def test_resample_preserves_channel_and_recording_metadata():
     """Channel type/modality/units/prefilter and recording metadata survive."""
-    emg = Recording.from_file(str(EEG), importer="eeglab")
-    emg.set_metadata("subject", "sub-01")
-    rs = emg.resample(100)
+    rec = Recording.from_file(str(EEG), importer="eeglab")
+    rec.set_metadata("subject", "sub-01")
+    rs = rec.resample(100)
 
-    for ch, info in emg.channels.items():
+    for ch, info in rec.channels.items():
         new = rs.channels[ch]
         assert new["channel_type"] == info["channel_type"]
         assert new["modality"] == info["modality"]
@@ -80,9 +80,9 @@ def test_resample_anti_aliasing_removes_above_nyquist():
     t = np.arange(int(fs * 10)) / fs
     signal = np.sin(2 * np.pi * 5 * t) + np.sin(2 * np.pi * 80 * t)
 
-    emg = Recording()
-    emg.add_channel("S", signal, fs, "uV", "EEG")
-    rs = emg.resample(100)
+    rec = Recording()
+    rec.add_channel("S", signal, fs, "uV", "EEG")
+    rs = rec.resample(100)
 
     y = rs.signals["S"].to_numpy()
     assert _rates(rs) == {100}
@@ -102,8 +102,8 @@ def test_resample_anti_aliasing_removes_above_nyquist():
 @requires_eeg
 def test_resample_roundtrip_through_edf():
     """resample(100) -> EDF export -> reload: 100 Hz, per-channel r > 0.99 on 10 s."""
-    emg = Recording.from_file(str(EEG), importer="eeglab")
-    rs = emg.resample(100)
+    rec = Recording.from_file(str(EEG), importer="eeglab")
+    rs = rec.resample(100)
 
     import tempfile
 
@@ -166,8 +166,8 @@ def test_cli_lowres_default_is_double_lowres(tmp_path):
 @requires_emg
 def test_cli_lowres_skips_when_already_low(tmp_path, capsys):
     """Source already <= target rate: export without resampling, with a stderr note."""
-    emg = Recording.from_file(str(EMG_EDF))
-    source_rate = max(_rates(emg))
+    rec = Recording.from_file(str(EMG_EDF))
+    source_rate = max(_rates(rec))
     target = source_rate + 100.0  # guarantee source <= target
 
     out = tmp_path / "skip.edf"
@@ -176,26 +176,26 @@ def test_cli_lowres_skips_when_already_low(tmp_path, capsys):
     assert "without resampling" in capsys.readouterr().err
 
     reloaded = Recording.from_file(str(out), bids_channels="off")
-    assert _rates(reloaded) == _rates(emg), "rate unchanged when no resampling occurred"
+    assert _rates(reloaded) == _rates(rec), "rate unchanged when no resampling occurred"
 
 
 @requires_eeg
 def test_resample_equal_rate_returns_unchanged_copy():
     """target == source: a copy with the same rate and sample count, but a new object."""
-    emg = Recording.from_file(str(EEG), importer="eeglab")
-    rs = emg.resample(250)
-    assert rs is not emg
+    rec = Recording.from_file(str(EEG), importer="eeglab")
+    rs = rec.resample(250)
+    assert rs is not rec
     assert _rates(rs) == {250}
-    assert rs.signals.shape == emg.signals.shape
-    assert np.allclose(rs.signals.to_numpy(), emg.signals.to_numpy())
+    assert rs.signals.shape == rec.signals.shape
+    assert np.allclose(rs.signals.to_numpy(), rec.signals.to_numpy())
 
 
 @requires_eeg
 def test_resample_above_source_raises():
     """Up-sampling is refused (low-res only)."""
-    emg = Recording.from_file(str(EEG), importer="eeglab")
+    rec = Recording.from_file(str(EEG), importer="eeglab")
     with pytest.raises(ValueError, match="exceeds source rate"):
-        emg.resample(500)
+        rec.resample(500)
 
 
 def test_resample_non_integer_target_stores_actual_rate():
@@ -205,10 +205,10 @@ def test_resample_non_integer_target_stores_actual_rate():
     integer factors up=25/down=64 -> achieves exactly 100.0 Hz, which must be what
     is written to the channels (not the requested 100.4).
     """
-    emg = Recording()
+    rec = Recording()
     rng = np.random.default_rng(0)
-    emg.add_channel("X", rng.standard_normal(2560), 256, "uV", "EEG")
-    rs = emg.resample(100.4)
+    rec.add_channel("X", rng.standard_normal(2560), 256, "uV", "EEG")
+    rs = rec.resample(100.4)
     assert _rates(rs) == {100.0}  # the ACHIEVED rate, never the requested 100.4
     assert 100.4 not in _rates(rs)
 
@@ -219,11 +219,11 @@ def test_resample_mixed_rate_raises():
     biosigio stores one uniform-length grid, so the two channels share a length;
     only their declared sample_frequency differs, which the guard must reject.
     """
-    emg = Recording()
-    emg.add_channel("A", np.zeros(1000), 500.0, "uV", "EEG")
-    emg.add_channel("B", np.zeros(1000), 250.0, "uV", "EEG")
+    rec = Recording()
+    rec.add_channel("A", np.zeros(1000), 500.0, "uV", "EEG")
+    rec.add_channel("B", np.zeros(1000), 250.0, "uV", "EEG")
     with pytest.raises(ValueError, match="single sampling rate"):
-        emg.resample(100)
+        rec.resample(100)
 
 
 def test_resample_no_signals_raises():

--- a/biosigio/tests/test_meg_importer.py
+++ b/biosigio/tests/test_meg_importer.py
@@ -25,13 +25,13 @@ pytestmark = pytest.mark.skipif(not MEG.exists(), reason="MEG fixture missing")
 
 
 @pytest.fixture(scope="module")
-def meg_emg():
+def meg_rec():
     return Recording.from_file(str(MEG))
 
 
-def test_meg_channel_types_preserved(meg_emg):
+def test_meg_channel_types_preserved(meg_rec):
     """Sensor types stay distinct (mag vs reference vs stim), not collapsed."""
-    types = Counter(i["channel_type"] for i in meg_emg.channels.values())
+    types = Counter(i["channel_type"] for i in meg_rec.channels.values())
     assert types["MEGMAG"] == 274
     assert types["MEGREFMAG"] == 29
     assert types["TRIG"] == 2
@@ -40,8 +40,8 @@ def test_meg_channel_types_preserved(meg_emg):
     assert "EMG" not in types
 
 
-def test_meg_units_and_modalities(meg_emg):
-    by_type = {i["channel_type"]: i for i in meg_emg.channels.values()}
+def test_meg_units_and_modalities(meg_rec):
+    by_type = {i["channel_type"]: i for i in meg_rec.channels.values()}
     assert by_type["MEGMAG"]["physical_dimension"] == "T"  # Tesla magnetometers
     assert by_type["MEGREFMAG"]["physical_dimension"] == "T"
     assert by_type["TRIG"]["physical_dimension"] == "V"
@@ -49,40 +49,40 @@ def test_meg_units_and_modalities(meg_emg):
     assert by_type["TRIG"]["modality"] == "MISC"
 
 
-def test_meg_sampling_and_shape(meg_emg):
-    rates = {i["sample_frequency"] for i in meg_emg.channels.values()}
+def test_meg_sampling_and_shape(meg_rec):
+    rates = {i["sample_frequency"] for i in meg_rec.channels.values()}
     assert rates == {100.0}
-    assert meg_emg.signals.shape == (3000, 305)  # 30 s @ 100 Hz, 305 channels
+    assert meg_rec.signals.shape == (3000, 305)  # 30 s @ 100 Hz, 305 channels
 
 
-def test_meg_stim_events(meg_emg):
+def test_meg_stim_events(meg_rec):
     """Stim-channel triggers are read into events (onsets in seconds, sorted)."""
-    assert meg_emg.events is not None and len(meg_emg.events) == 58
-    onsets = meg_emg.events["onset"].to_numpy()
+    assert meg_rec.events is not None and len(meg_rec.events) == 58
+    onsets = meg_rec.events["onset"].to_numpy()
     assert (onsets[:-1] <= onsets[1:]).all()  # sorted
     assert onsets.min() >= 0.0 and onsets.max() <= 30.0  # within the recording
-    assert meg_emg.events["onset"].dtype == np.float64
+    assert meg_rec.events["onset"].dtype == np.float64
     # Descriptions are the stringified trigger codes.
-    assert all(d.isdigit() for d in meg_emg.events["description"])
+    assert all(d.isdigit() for d in meg_rec.events["description"])
 
 
-def test_meg_roundtrip_preserves_tesla_signals(meg_emg, tmp_path):
+def test_meg_roundtrip_preserves_tesla_signals(meg_rec, tmp_path):
     """Tesla-magnitude MEG channels survive EDF/BDF export+reimport (r > 0.99).
 
     Magnetometer values are ~1e-12 T, exercising the exporter's small-magnitude
     physical-bound path; BDF (auto-selected for the dynamic range) must keep them.
     """
     out = tmp_path / "meg.edf"
-    meg_emg.to_edf(str(out), format="bdf", bypass_analysis=True)
+    meg_rec.to_edf(str(out), format="bdf", bypass_analysis=True)
     written = out if out.exists() else out.with_suffix(".bdf")
     reloaded = Recording.from_file(str(written), bids_channels="off")
-    assert len(reloaded.channels) == len(meg_emg.channels)
+    assert len(reloaded.channels) == len(meg_rec.channels)
 
     # Check a handful of magnetometer channels on a 10 s window.
-    mag = [c for c, i in meg_emg.channels.items() if i["channel_type"] == "MEGMAG"][:5]
+    mag = [c for c, i in meg_rec.channels.items() if i["channel_type"] == "MEGMAG"][:5]
     window = slice(0, 1000)  # 10 s @ 100 Hz
     for ch in mag:
-        original = meg_emg.signals[ch].values[window].astype(float)
+        original = meg_rec.signals[ch].values[window].astype(float)
         roundtripped = reloaded.signals[ch].values[window].astype(float)
         if np.std(original) == 0:
             continue

--- a/biosigio/tests/test_modality_integration.py
+++ b/biosigio/tests/test_modality_integration.py
@@ -20,36 +20,36 @@ XDF_FILE = _REPO / "examples/multi_stream_test.xdf"
 
 
 def test_add_channel_requires_channel_type():
-    emg = Recording()
+    rec = Recording()
     with pytest.raises(TypeError):
-        emg.add_channel("C", np.zeros(10), 100, "uV")  # channel_type omitted
+        rec.add_channel("C", np.zeros(10), 100, "uV")  # channel_type omitted
 
 
 def test_add_channel_validates_and_infers_modality():
-    emg = Recording()
-    emg.add_channel("E1", np.zeros(10), 100, "uV", "eeg")  # case-insensitive
-    assert emg.channels["E1"]["channel_type"] == "EEG"
-    assert emg.channels["E1"]["modality"] == "EEG"
+    rec = Recording()
+    rec.add_channel("E1", np.zeros(10), 100, "uV", "eeg")  # case-insensitive
+    assert rec.channels["E1"]["channel_type"] == "EEG"
+    assert rec.channels["E1"]["modality"] == "EEG"
 
-    emg.add_channel("S1", np.zeros(10), 100, "uV", "ECOG")
-    assert emg.channels["S1"]["modality"] == "IEEG"
+    rec.add_channel("S1", np.zeros(10), 100, "uV", "ECOG")
+    assert rec.channels["S1"]["modality"] == "IEEG"
 
     with pytest.raises(ValueError):
-        emg.add_channel("X", np.zeros(10), 100, "uV", "BOGUS")
+        rec.add_channel("X", np.zeros(10), 100, "uV", "BOGUS")
 
 
 def test_set_channel_and_modality_selectors():
-    emg = Recording()
-    emg.add_channel("a", np.zeros(10), 100, "uV", "EEG")
-    emg.add_channel("b", np.zeros(10), 100, "mV", "EMG")
+    rec = Recording()
+    rec.add_channel("a", np.zeros(10), 100, "uV", "EEG")
+    rec.add_channel("b", np.zeros(10), 100, "mV", "EMG")
 
-    assert set(emg.get_modalities()) == {"EEG", "EMG"}
-    assert emg.get_channels_by_modality("EEG") == ["a"]
-    assert emg.select_channels(modality="EMG").signals.columns.tolist() == ["b"]
+    assert set(rec.get_modalities()) == {"EEG", "EMG"}
+    assert rec.get_channels_by_modality("EEG") == ["a"]
+    assert rec.select_channels(modality="EMG").signals.columns.tolist() == ["b"]
 
-    emg.set_channel("b", channel_type="ECG")
-    assert emg.channels["b"]["channel_type"] == "ECG"
-    assert emg.channels["b"]["modality"] == "MISC"  # re-derived from new type
+    rec.set_channel("b", channel_type="ECG")
+    assert rec.channels["b"]["channel_type"] == "ECG"
+    assert rec.channels["b"]["modality"] == "MISC"  # re-derived from new type
 
 
 def test_csv_time_column_is_not_an_invalid_type():
@@ -60,9 +60,9 @@ def test_csv_time_column_is_not_an_invalid_type():
 
 @pytest.mark.skipif(not XDF_FILE.exists(), reason="XDF fixture missing")
 def test_xdf_channels_carry_valid_type_and_modality():
-    emg = Recording.from_file(str(XDF_FILE))
-    assert len(emg.channels) > 0
-    for info in emg.channels.values():
+    rec = Recording.from_file(str(XDF_FILE))
+    assert len(rec.channels) > 0
+    for info in rec.channels.values():
         # No raw/unvalidated LSL type strings leak through, and every channel
         # carries a modality (so the modality selectors work for XDF data).
         assert info["channel_type"] in VALID_CHANNEL_TYPES
@@ -71,9 +71,9 @@ def test_xdf_channels_carry_valid_type_and_modality():
 
 @pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
 def test_real_eeg_does_not_creep_to_emg():
-    emg = Recording.from_file(str(EEG_SET), importer="eeglab")
-    types = {info["channel_type"] for info in emg.channels.values()}
+    rec = Recording.from_file(str(EEG_SET), importer="eeglab")
+    types = {info["channel_type"] for info in rec.channels.values()}
     # The headline bug: EEG data must not be silently relabelled EMG.
     assert "EMG" not in types
     # Every channel carries a modality after the explicit-modality migration.
-    assert all("modality" in info for info in emg.channels.values())
+    assert all("modality" in info for info in rec.channels.values())

--- a/biosigio/tests/test_roundtrip.py
+++ b/biosigio/tests/test_roundtrip.py
@@ -88,13 +88,13 @@ MIXED_RATE_CASES = [
 def _roundtrip(case):
     """Import -> export (auto) -> reimport once per fixture (cached)."""
     if case.name not in _RT_CACHE:
-        emg = Recording.from_file(str(case.path), importer=case.importer)
+        rec = Recording.from_file(str(case.path), importer=case.importer)
         out = os.path.join(_RT_DIR, f"{case.name}.edf")
         # format="auto" exercises the real EDF/BDF selection (and ignores
         # bypass_analysis by design), which is what a round-trip harness wants.
-        emg.to_edf(out, format="auto")
+        rec.to_edf(out, format="auto")
         written = out if os.path.exists(out) else os.path.splitext(out)[0] + ".bdf"
-        _RT_CACHE[case.name] = (emg, Recording.from_file(written))
+        _RT_CACHE[case.name] = (rec, Recording.from_file(written))
     return _RT_CACHE[case.name]
 
 
@@ -103,12 +103,12 @@ def test_roundtrip_preserves_structure(case):
     """No sample loss, channel count preserved, no modality creep (all fixtures)."""
     if not case.path.exists():
         pytest.skip(f"fixture missing: {case.path}")
-    emg, reloaded = _roundtrip(case)
+    rec, reloaded = _roundtrip(case)
 
     # No samples lost (modulo one EDF data-record of zero padding).
-    rate = max(int(c["sample_frequency"]) for c in emg.channels.values())
-    assert emg.signals.shape[0] <= reloaded.signals.shape[0] <= emg.signals.shape[0] + rate
-    assert len(reloaded.channels) == len(emg.channels)
+    rate = max(int(c["sample_frequency"]) for c in rec.channels.values())
+    assert rec.signals.shape[0] <= reloaded.signals.shape[0] <= rec.signals.shape[0] + rate
+    assert len(reloaded.channels) == len(rec.channels)
 
     # No modality creep: a fixture with no EMG must not gain EMG channels.
     if not case.has_emg:
@@ -128,19 +128,19 @@ def test_roundtrip_preserves_signal_values(case):
     """
     if not case.path.exists():
         pytest.skip(f"fixture missing: {case.path}")
-    emg, reloaded = _roundtrip(case)
+    rec, reloaded = _roundtrip(case)
 
-    rate = max(int(c["sample_frequency"]) for c in emg.channels.values())
-    n = emg.signals.shape[0]
+    rate = max(int(c["sample_frequency"]) for c in rec.channels.values())
+    n = rec.signals.shape[0]
     width = min(int(_WINDOW_S * rate), n)
     start = int(_RNG.integers(0, n - width + 1)) if n > width else 0
     window = slice(start, start + width)
 
     compared = 0
     low_corr = []
-    for ch in emg.channels:
+    for ch in rec.channels:
         assert ch in reloaded.signals.columns, f"{case.name}: channel '{ch}' lost on reload"
-        original = emg.signals[ch].values[window].astype(float)
+        original = rec.signals[ch].values[window].astype(float)
         roundtripped = reloaded.signals[ch].values[window].astype(float)
         compared += 1
         ptp = float(np.ptp(original))
@@ -162,12 +162,12 @@ def test_roundtrip_preserves_signal_values(case):
 def test_mixed_rate_export_raises(case, tmp_path):
     if not case.path.exists():
         pytest.skip(f"fixture missing: {case.path}")
-    emg = Recording.from_file(str(case.path), importer=case.importer)
-    rates = {int(c["sample_frequency"]) for c in emg.channels.values()}
+    rec = Recording.from_file(str(case.path), importer=case.importer)
+    rates = {int(c["sample_frequency"]) for c in rec.channels.values()}
     if len(rates) <= 1:
         pytest.skip(f"{case.name}: fixture is single-rate, guard not exercised")
     with pytest.raises(ValueError, match="single sampling rate"):
-        emg.to_edf(str(tmp_path / f"{case.name}.edf"), format="edf", bypass_analysis=True)
+        rec.to_edf(str(tmp_path / f"{case.name}.edf"), format="edf", bypass_analysis=True)
 
 
 def test_meg_fif_imports_via_mne():
@@ -176,10 +176,10 @@ def test_meg_fif_imports_via_mne():
     if not meg.exists():
         pytest.skip("MEG fixture missing")
     pytest.importorskip("mne", reason="MEG import requires the optional 'meg' extra (mne)")
-    emg = Recording.from_file(str(meg))
-    assert len(emg.channels) > 0
+    rec = Recording.from_file(str(meg))
+    assert len(rec.channels) > 0
     # No modality creep: a MEG file must not invent EMG channels.
-    assert not [c for c, i in emg.channels.items() if i["channel_type"] == "EMG"]
+    assert not [c for c, i in rec.channels.items() if i["channel_type"] == "EMG"]
 
 
 def test_event_roundtrip_through_edf(tmp_path):
@@ -192,11 +192,11 @@ def test_event_roundtrip_through_edf(tmp_path):
     fixture = BIDS / "emg/sub-01/emg/sub-01_task-isometric10percentmvc_run-01_emg.edf"
     if not fixture.exists():
         pytest.skip("EMG fixture missing")
-    emg = Recording.from_file(str(fixture))
-    emg.add_event(onset=0.5, duration=0.0, description="m1")
-    emg.add_event(onset=1.0, duration=0.2, description="m2")
+    rec = Recording.from_file(str(fixture))
+    rec.add_event(onset=0.5, duration=0.0, description="m1")
+    rec.add_event(onset=1.0, duration=0.2, description="m2")
     out = tmp_path / "ev.edf"
-    emg.to_edf(str(out), format="edf", bypass_analysis=True)
+    rec.to_edf(str(out), format="edf", bypass_analysis=True)
 
     reloaded = Recording.from_file(str(out), bids_channels="off")
     assert len(reloaded.events) == 2

--- a/biosigio/tests/test_verification.py
+++ b/biosigio/tests/test_verification.py
@@ -8,30 +8,30 @@ from ..core.emg import Recording
 
 
 @pytest.fixture
-def sample_emg_pair():
+def sample_rec_pair():
     """Create a pair of Recording objects with identical data for testing."""
-    emg_original = Recording()
-    emg_reloaded = Recording()
+    rec_original = Recording()
+    rec_reloaded = Recording()
 
     # Add identical channels
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
     signal1 = np.sin(2 * np.pi * 10 * time)  # 10Hz sine wave
     signal2 = np.cos(2 * np.pi * 5 * time)  # 5Hz cosine wave
 
-    emg_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
-    emg_original.add_channel("ACC1", signal2, 1000, "g", channel_type="ACC")
+    rec_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
+    rec_original.add_channel("ACC1", signal2, 1000, "g", channel_type="ACC")
 
-    emg_reloaded.add_channel("EMG1", signal1.copy(), 1000, "mV", channel_type="EMG")
-    emg_reloaded.add_channel("ACC1", signal2.copy(), 1000, "g", channel_type="ACC")
+    rec_reloaded.add_channel("EMG1", signal1.copy(), 1000, "mV", channel_type="EMG")
+    rec_reloaded.add_channel("ACC1", signal2.copy(), 1000, "g", channel_type="ACC")
 
-    return emg_original, emg_reloaded
+    return rec_original, rec_reloaded
 
 
 @pytest.fixture
-def sample_emg_pair_different():
+def sample_rec_pair_different():
     """Create a pair of Recording objects with slightly different data."""
-    emg_original = Recording()
-    emg_reloaded = Recording()
+    rec_original = Recording()
+    rec_reloaded = Recording()
 
     # Add slightly different channels
     time = np.linspace(0, 1, 1000)
@@ -42,40 +42,40 @@ def sample_emg_pair_different():
     signal1_modified = signal1 + 0.05 * np.random.randn(len(signal1))
     signal2_modified = signal2 + 0.05 * np.random.randn(len(signal2))
 
-    emg_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
-    emg_original.add_channel("ACC1", signal2, 1000, "g", channel_type="ACC")
+    rec_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
+    rec_original.add_channel("ACC1", signal2, 1000, "g", channel_type="ACC")
 
-    emg_reloaded.add_channel("EMG1", signal1_modified, 1000, "mV", channel_type="EMG")
-    emg_reloaded.add_channel("ACC1", signal2_modified, 1000, "g", channel_type="ACC")
+    rec_reloaded.add_channel("EMG1", signal1_modified, 1000, "mV", channel_type="EMG")
+    rec_reloaded.add_channel("ACC1", signal2_modified, 1000, "g", channel_type="ACC")
 
-    return emg_original, emg_reloaded
+    return rec_original, rec_reloaded
 
 
 @pytest.fixture
-def sample_emg_pair_renamed():
+def sample_rec_pair_renamed():
     """Create a pair of Recording objects with same data but different channel names."""
-    emg_original = Recording()
-    emg_reloaded = Recording()
+    rec_original = Recording()
+    rec_reloaded = Recording()
 
     # Add channels with different names but identical data
     time = np.linspace(0, 1, 1000)
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
 
-    emg_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
-    emg_original.add_channel("ACC1", signal2, 1000, "g", channel_type="ACC")
+    rec_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
+    rec_original.add_channel("ACC1", signal2, 1000, "g", channel_type="ACC")
 
-    emg_reloaded.add_channel("EMG_CH1", signal1.copy(), 1000, "mV", channel_type="EMG")
-    emg_reloaded.add_channel("ACC_CH1", signal2.copy(), 1000, "g", channel_type="ACC")
+    rec_reloaded.add_channel("EMG_CH1", signal1.copy(), 1000, "mV", channel_type="EMG")
+    rec_reloaded.add_channel("ACC_CH1", signal2.copy(), 1000, "g", channel_type="ACC")
 
-    return emg_original, emg_reloaded
+    return rec_original, rec_reloaded
 
 
 @pytest.fixture
-def sample_emg_pair_different_lengths():
+def sample_rec_pair_different_lengths():
     """Create a pair of Recording objects with different signal lengths."""
-    emg_original = Recording()
-    emg_reloaded = Recording()
+    rec_original = Recording()
+    rec_reloaded = Recording()
 
     # Add channels with different lengths
     time1 = np.linspace(0, 1, 1000)
@@ -84,17 +84,17 @@ def sample_emg_pair_different_lengths():
     signal1 = np.sin(2 * np.pi * 10 * time1)
     signal2 = np.sin(2 * np.pi * 10 * time2)  # Shorter version
 
-    emg_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
-    emg_reloaded.add_channel("EMG1", signal2, 1000, "mV", channel_type="EMG")
+    rec_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
+    rec_reloaded.add_channel("EMG1", signal2, 1000, "mV", channel_type="EMG")
 
-    return emg_original, emg_reloaded
+    return rec_original, rec_reloaded
 
 
-def test_compare_signals_identical(sample_emg_pair):
+def test_compare_signals_identical(sample_rec_pair):
     """Test compare_signals with identical signals."""
-    emg_original, emg_reloaded = sample_emg_pair
+    rec_original, rec_reloaded = sample_rec_pair
 
-    result = compare_signals(emg_original, emg_reloaded)
+    result = compare_signals(rec_original, rec_reloaded)
 
     # Check channel summary
     assert result["channel_summary"]["comparison_mode"] == "exact_name"
@@ -110,15 +110,15 @@ def test_compare_signals_identical(sample_emg_pair):
         assert result[channel]["is_identical"]  # Check boolean value without "is True"
 
 
-def test_compare_signals_different(sample_emg_pair_different):
+def test_compare_signals_different(sample_rec_pair_different):
     """Test compare_signals with slightly different signals."""
-    emg_original, emg_reloaded = sample_emg_pair_different
+    rec_original, rec_reloaded = sample_rec_pair_different
 
     # Use a higher tolerance to still consider them identical
-    result_high_tolerance = compare_signals(emg_original, emg_reloaded, tolerance=0.1)
+    result_high_tolerance = compare_signals(rec_original, rec_reloaded, tolerance=0.1)
 
     # Use a lower tolerance to consider them different
-    result_low_tolerance = compare_signals(emg_original, emg_reloaded, tolerance=0.01)
+    result_low_tolerance = compare_signals(rec_original, rec_reloaded, tolerance=0.01)
 
     # With high tolerance, they should be considered identical
     assert all(result_high_tolerance[ch]["is_identical"] for ch in ["EMG1", "ACC1"])
@@ -127,14 +127,14 @@ def test_compare_signals_different(sample_emg_pair_different):
     assert not all(result_low_tolerance[ch]["is_identical"] for ch in ["EMG1", "ACC1"])
 
 
-def test_compare_signals_with_channel_map(sample_emg_pair_renamed):
+def test_compare_signals_with_channel_map(sample_rec_pair_renamed):
     """Test compare_signals with channel mapping."""
-    emg_original, emg_reloaded = sample_emg_pair_renamed
+    rec_original, rec_reloaded = sample_rec_pair_renamed
 
     # Define channel mapping
     channel_map = {"EMG1": "EMG_CH1", "ACC1": "ACC_CH1"}
 
-    result = compare_signals(emg_original, emg_reloaded, channel_map=channel_map)
+    result = compare_signals(rec_original, rec_reloaded, channel_map=channel_map)
 
     # Check comparison mode
     assert result["channel_summary"]["comparison_mode"] == "mapped"
@@ -149,11 +149,11 @@ def test_compare_signals_with_channel_map(sample_emg_pair_renamed):
     assert result["ACC1"]["is_identical"]  # Check boolean value without "is True"
 
 
-def test_compare_signals_different_lengths(sample_emg_pair_different_lengths):
+def test_compare_signals_different_lengths(sample_rec_pair_different_lengths):
     """Test compare_signals with different signal lengths."""
-    emg_original, emg_reloaded = sample_emg_pair_different_lengths
+    rec_original, rec_reloaded = sample_rec_pair_different_lengths
 
-    result = compare_signals(emg_original, emg_reloaded)
+    result = compare_signals(rec_original, rec_reloaded)
 
     # Check that comparison was made (truncating to shorter length)
     assert "EMG1" in result
@@ -163,17 +163,17 @@ def test_compare_signals_different_lengths(sample_emg_pair_different_lengths):
 
 def test_compare_signals_empty_intersection():
     """Test compare_signals with no common channels."""
-    emg1 = Recording()
-    emg2 = Recording()
+    rec1 = Recording()
+    rec2 = Recording()
 
     # Add completely different channels
     time = np.linspace(0, 1, 1000)
     signal = np.sin(2 * np.pi * 10 * time)
 
-    emg1.add_channel("CH1", signal, 1000, "mV", "EMG")
-    emg2.add_channel("CH2", signal, 1000, "mV", "EMG")
+    rec1.add_channel("CH1", signal, 1000, "mV", "EMG")
+    rec2.add_channel("CH2", signal, 1000, "mV", "EMG")
 
-    result = compare_signals(emg1, emg2)
+    result = compare_signals(rec1, rec2)
 
     # Should be order-based comparison with no actual comparisons
     assert result["channel_summary"]["comparison_mode"] == "order_based"
@@ -184,33 +184,33 @@ def test_compare_signals_empty_intersection():
 
 def test_compare_signals_invalid_channel_map():
     """Test compare_signals with invalid channel map."""
-    emg1 = Recording()
-    emg2 = Recording()
+    rec1 = Recording()
+    rec2 = Recording()
 
     time = np.linspace(0, 1, 1000)
     signal = np.sin(2 * np.pi * 10 * time)
 
-    emg1.add_channel("CH1", signal, 1000, "mV", "EMG")
-    emg2.add_channel("CH2", signal, 1000, "mV", "EMG")
+    rec1.add_channel("CH1", signal, 1000, "mV", "EMG")
+    rec2.add_channel("CH2", signal, 1000, "mV", "EMG")
 
     # Channel map with non-existent original channel
     channel_map = {"NONEXISTENT": "CH2"}
 
     with pytest.raises(ValueError):
-        compare_signals(emg1, emg2, channel_map=channel_map)
+        compare_signals(rec1, rec2, channel_map=channel_map)
 
 
 def test_compare_signals_with_constant_signal():
     """Test compare_signals with constant signals (zero range)."""
-    emg1 = Recording()
-    emg2 = Recording()
+    rec1 = Recording()
+    rec2 = Recording()
 
     # Add constant signals to both
     const_signal = np.ones(1000)
-    emg1.add_channel("CONST", const_signal, 1000, "mV", "EMG")
-    emg2.add_channel("CONST", const_signal + 1e-6, 1000, "mV", "EMG")  # Tiny difference
+    rec1.add_channel("CONST", const_signal, 1000, "mV", "EMG")
+    rec2.add_channel("CONST", const_signal + 1e-6, 1000, "mV", "EMG")  # Tiny difference
 
-    result = compare_signals(emg1, emg2)
+    result = compare_signals(rec1, rec2)
 
     # Should handle constant signals properly (no division by zero)
     assert "CONST" in result

--- a/biosigio/tests/test_visualization.py
+++ b/biosigio/tests/test_visualization.py
@@ -8,9 +8,9 @@ from biosigio.visualization.static import plot_comparison, plot_signals
 
 
 @pytest.fixture
-def sample_emg():
+def sample_rec():
     """Create a sample Recording object for visualization testing."""
-    emg = Recording()
+    rec = Recording()
 
     # Create sample data
     time = np.linspace(0, 1, 1000)  # 1 second at 1000Hz
@@ -19,18 +19,18 @@ def sample_emg():
     signal3 = 0.5 * np.sin(2 * np.pi * 15 * time)  # 15Hz sine wave
 
     # Add channels
-    emg.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
-    emg.add_channel("EMG2", signal2, 1000, "mV", channel_type="EMG")
-    emg.add_channel("ACC1", signal3, 1000, "g", channel_type="ACC")
+    rec.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
+    rec.add_channel("EMG2", signal2, 1000, "mV", channel_type="EMG")
+    rec.add_channel("ACC1", signal3, 1000, "g", channel_type="ACC")
 
-    return emg
+    return rec
 
 
 @pytest.fixture
-def emg_pair():
+def rec_pair():
     """Create a pair of Recording objects for comparison testing."""
-    emg_original = Recording()
-    emg_reloaded = Recording()
+    rec_original = Recording()
+    rec_reloaded = Recording()
 
     # Create sample data
     time = np.linspace(0, 1, 1000)
@@ -38,15 +38,15 @@ def emg_pair():
     signal2 = np.cos(2 * np.pi * 5 * time)
 
     # Add channels to original
-    emg_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
-    emg_original.add_channel("EMG2", signal2, 1000, "mV", channel_type="EMG")
+    rec_original.add_channel("EMG1", signal1, 1000, "mV", channel_type="EMG")
+    rec_original.add_channel("EMG2", signal2, 1000, "mV", channel_type="EMG")
 
     # Add slightly modified channels to reloaded
     signal1_modified = signal1 + 0.01 * np.random.randn(len(signal1))
-    emg_reloaded.add_channel("EMG1", signal1_modified, 1000, "mV", channel_type="EMG")
-    emg_reloaded.add_channel("EMG2", signal2.copy(), 1000, "mV", channel_type="EMG")
+    rec_reloaded.add_channel("EMG1", signal1_modified, 1000, "mV", channel_type="EMG")
+    rec_reloaded.add_channel("EMG2", signal2.copy(), 1000, "mV", channel_type="EMG")
 
-    return emg_original, emg_reloaded
+    return rec_original, rec_reloaded
 
 
 class MockPlt:
@@ -106,122 +106,122 @@ class MockPlt:
         self.tight_layout_called = True
 
 
-def test_plot_signals_basic(sample_emg):
+def test_plot_signals_basic(sample_rec):
     """Test basic functionality of plot_signals."""
     mock_plt = MockPlt()
-    plot_signals(sample_emg, show=True, plt_module=mock_plt)
+    plot_signals(sample_rec, show=True, plt_module=mock_plt)
     assert mock_plt.show_called
 
 
 @patch("matplotlib.pyplot.subplots")
 @patch("matplotlib.pyplot.show")
-def test_plot_signals_parameters(mock_show, mock_subplots, sample_emg):
+def test_plot_signals_parameters(mock_show, mock_subplots, sample_rec):
     """Test plot_signals with various parameters."""
     fig_mock = MagicMock()
     ax_mock = MagicMock()
     mock_subplots.return_value = (fig_mock, ax_mock)
 
     # Test with specific channels
-    plot_signals(sample_emg, channels=["EMG1", "EMG2"], show=True)
+    plot_signals(sample_rec, channels=["EMG1", "EMG2"], show=True)
 
     # Verify the plot was created with the correct channels
     assert ax_mock.plot.call_count == 2  # Two channels should be plotted
 
     # Test with time range
-    plot_signals(sample_emg, time_range=(0.1, 0.5), show=True)
+    plot_signals(sample_rec, time_range=(0.1, 0.5), show=True)
     ax_mock.set_xlabel.assert_called_with("Time (s)")
 
 
-def test_plot_signals_errors(sample_emg):
+def test_plot_signals_errors(sample_rec):
     """Test error handling in plot_signals."""
     # Test with invalid channel
     with pytest.raises(ValueError):
-        plot_signals(sample_emg, channels=["NonExistentChannel"])
+        plot_signals(sample_rec, channels=["NonExistentChannel"])
 
     # Test with empty Recording object
-    empty_emg = Recording()
+    empty_rec = Recording()
     with pytest.raises(ValueError):
-        plot_signals(empty_emg)
+        plot_signals(empty_rec)
 
 
-def test_plot_signals_options(sample_emg):
+def test_plot_signals_options(sample_rec):
     """Test various options of plot_signals."""
     mock_plt = MockPlt()
 
     # Test with grid=False
-    plot_signals(sample_emg, grid=False, show=False, plt_module=mock_plt)
+    plot_signals(sample_rec, grid=False, show=False, plt_module=mock_plt)
 
     # Test with detrend=True
-    plot_signals(sample_emg, detrend=True, show=False, plt_module=mock_plt)
+    plot_signals(sample_rec, detrend=True, show=False, plt_module=mock_plt)
 
     # Test with uniform_scale=False
-    plot_signals(sample_emg, uniform_scale=False, show=False, plt_module=mock_plt)
+    plot_signals(sample_rec, uniform_scale=False, show=False, plt_module=mock_plt)
 
     # Test with title
-    plot_signals(sample_emg, title="Test Plot", show=False, plt_module=mock_plt)
+    plot_signals(sample_rec, title="Test Plot", show=False, plt_module=mock_plt)
 
     assert not mock_plt.show_called, "show() should not be called when show=False"
     assert mock_plt.tight_layout_called, "tight_layout() should be called"
 
 
-def test_plot_signals_with_constant(sample_emg):
+def test_plot_signals_with_constant(sample_rec):
     """Test plot_signals with constant signals (zero range)."""
     # Add a constant signal
-    sample_emg.add_channel("CONST", np.ones(1000), 1000, "mV", "EMG")
+    sample_rec.add_channel("CONST", np.ones(1000), 1000, "mV", "EMG")
 
     mock_plt = MockPlt()
     # This should not raise any errors despite the constant signal
-    plot_signals(sample_emg, channels=["CONST"], show=False, plt_module=mock_plt)
+    plot_signals(sample_rec, channels=["CONST"], show=False, plt_module=mock_plt)
 
 
-def test_plot_comparison_basic(emg_pair):
+def test_plot_comparison_basic(rec_pair):
     """Test basic functionality of plot_comparison."""
-    emg_original, emg_reloaded = emg_pair
+    rec_original, rec_reloaded = rec_pair
     mock_plt = MockPlt()
-    plot_comparison(emg_original, emg_reloaded, show=True, plt_module=mock_plt)
+    plot_comparison(rec_original, rec_reloaded, show=True, plt_module=mock_plt)
     assert mock_plt.show_called
 
 
-def test_plot_comparison_parameters(emg_pair):
+def test_plot_comparison_parameters(rec_pair):
     """Test plot_comparison with various parameters."""
-    emg_original, emg_reloaded = emg_pair
+    rec_original, rec_reloaded = rec_pair
     mock_plt = MockPlt()
 
     # Test with specific channels
-    plot_comparison(emg_original, emg_reloaded, channels=["EMG1"], show=False, plt_module=mock_plt)
+    plot_comparison(rec_original, rec_reloaded, channels=["EMG1"], show=False, plt_module=mock_plt)
 
     # Test with time range
     plot_comparison(
-        emg_original, emg_reloaded, time_range=(0.1, 0.5), show=False, plt_module=mock_plt
+        rec_original, rec_reloaded, time_range=(0.1, 0.5), show=False, plt_module=mock_plt
     )
 
     # Test with detrend=True
-    plot_comparison(emg_original, emg_reloaded, detrend=True, show=False, plt_module=mock_plt)
+    plot_comparison(rec_original, rec_reloaded, detrend=True, show=False, plt_module=mock_plt)
 
     # Test with grid=False
-    plot_comparison(emg_original, emg_reloaded, grid=False, show=False, plt_module=mock_plt)
+    plot_comparison(rec_original, rec_reloaded, grid=False, show=False, plt_module=mock_plt)
 
     # Test with custom suptitle
     plot_comparison(
-        emg_original, emg_reloaded, suptitle="Custom Title", show=False, plt_module=mock_plt
+        rec_original, rec_reloaded, suptitle="Custom Title", show=False, plt_module=mock_plt
     )
 
     # Ensure show was not called
     assert not mock_plt.show_called
 
 
-def test_plot_comparison_with_channel_map(emg_pair):
+def test_plot_comparison_with_channel_map(rec_pair):
     """Test plot_comparison with channel mapping."""
-    emg_original, emg_reloaded = emg_pair
+    rec_original, rec_reloaded = rec_pair
 
     # Create a reloaded Recording with different channel names
-    emg_renamed = Recording()
+    rec_renamed = Recording()
     time = np.linspace(0, 1, 1000)
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
 
-    emg_renamed.add_channel("Channel1", signal1, 1000, "mV", "EMG")
-    emg_renamed.add_channel("Channel2", signal2, 1000, "mV", "EMG")
+    rec_renamed.add_channel("Channel1", signal1, 1000, "mV", "EMG")
+    rec_renamed.add_channel("Channel2", signal2, 1000, "mV", "EMG")
 
     # Define channel mapping
     channel_map = {"EMG1": "Channel1", "EMG2": "Channel2"}
@@ -229,35 +229,35 @@ def test_plot_comparison_with_channel_map(emg_pair):
     mock_plt = MockPlt()
     # This should not raise any errors
     plot_comparison(
-        emg_original, emg_renamed, channel_map=channel_map, show=False, plt_module=mock_plt
+        rec_original, rec_renamed, channel_map=channel_map, show=False, plt_module=mock_plt
     )
 
 
 def test_plot_comparison_no_common_channels():
     """Test plot_comparison with no common channels."""
     # Create two Recording objects with completely different channels
-    emg1 = Recording()
-    emg2 = Recording()
+    rec1 = Recording()
+    rec2 = Recording()
 
     time = np.linspace(0, 1, 1000)
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
 
-    emg1.add_channel("CH1", signal1, 1000, "mV", "EMG")
-    emg2.add_channel("CH2", signal2, 1000, "mV", "EMG")
+    rec1.add_channel("CH1", signal1, 1000, "mV", "EMG")
+    rec2.add_channel("CH2", signal2, 1000, "mV", "EMG")
 
     # This should not raise errors, but will print a warning
     with patch("builtins.print") as mock_print:
         mock_plt = MockPlt()
-        plot_comparison(emg1, emg2, show=False, plt_module=mock_plt)
+        plot_comparison(rec1, rec2, show=False, plt_module=mock_plt)
         # Verify warning was printed
         mock_print.assert_called()
 
 
 def test_plot_comparison_different_lengths():
     """Test plot_comparison with signals of different lengths."""
-    emg1 = Recording()
-    emg2 = Recording()
+    rec1 = Recording()
+    rec2 = Recording()
 
     # Create signals with different lengths
     time1 = np.linspace(0, 1, 1000)
@@ -266,34 +266,34 @@ def test_plot_comparison_different_lengths():
     signal1 = np.sin(2 * np.pi * 10 * time1)
     signal2 = np.sin(2 * np.pi * 10 * time2)
 
-    emg1.add_channel("CH1", signal1, 1000, "mV", "EMG")
-    emg2.add_channel("CH1", signal2, 1000, "mV", "EMG")
+    rec1.add_channel("CH1", signal1, 1000, "mV", "EMG")
+    rec2.add_channel("CH1", signal2, 1000, "mV", "EMG")
 
     mock_plt = MockPlt()
     # This should handle different length signals
-    plot_comparison(emg1, emg2, show=False, plt_module=mock_plt)
+    plot_comparison(rec1, rec2, show=False, plt_module=mock_plt)
 
 
 def test_plot_comparison_order_based():
     """Test plot_comparison with order-based matching."""
     # Create two Recording objects with different channel names
-    emg1 = Recording()
-    emg2 = Recording()
+    rec1 = Recording()
+    rec2 = Recording()
 
     time = np.linspace(0, 1, 1000)
     signal1 = np.sin(2 * np.pi * 10 * time)
     signal2 = np.cos(2 * np.pi * 5 * time)
 
-    emg1.add_channel("CH1", signal1, 1000, "mV", "EMG")
-    emg1.add_channel("CH2", signal2, 1000, "mV", "EMG")
+    rec1.add_channel("CH1", signal1, 1000, "mV", "EMG")
+    rec1.add_channel("CH2", signal2, 1000, "mV", "EMG")
 
-    emg2.add_channel("Channel1", signal1, 1000, "mV", "EMG")
-    emg2.add_channel("Channel2", signal2, 1000, "mV", "EMG")
+    rec2.add_channel("Channel1", signal1, 1000, "mV", "EMG")
+    rec2.add_channel("Channel2", signal2, 1000, "mV", "EMG")
 
     # No common names, should fall back to order-based
     with patch("builtins.print") as mock_print:
         mock_plt = MockPlt()
-        plot_comparison(emg1, emg2, show=False, plt_module=mock_plt)
+        plot_comparison(rec1, rec2, show=False, plt_module=mock_plt)
 
         # Verify that print was called and check if any call contains 'order_based'
         assert mock_print.called

--- a/biosigio/tests/test_xdf_importer.py
+++ b/biosigio/tests/test_xdf_importer.py
@@ -83,32 +83,32 @@ def test_summarize_xdf_stream_lookup():
 def test_xdf_importer_basic():
     """Test XDF importer with sample data."""
     importer = XDFImporter()
-    emg = importer.load(SAMPLE_XDF_PATH)
+    rec = importer.load(SAMPLE_XDF_PATH)
 
     # Check if channels were loaded
-    assert len(emg.channels) == 8
+    assert len(rec.channels) == 8
 
     # Check channel properties
-    first_channel = list(emg.channels.keys())[0]
-    assert emg.channels[first_channel]["sample_frequency"] == 1000.0
+    first_channel = list(rec.channels.keys())[0]
+    assert rec.channels[first_channel]["sample_frequency"] == 1000.0
 
     # Check data shape
-    assert emg.signals.shape == (9520, 8)
+    assert rec.signals.shape == (9520, 8)
 
     # Check metadata
-    assert emg.get_metadata("device") == "XDF"
-    assert emg.get_metadata("source_file") == SAMPLE_XDF_PATH
-    assert emg.get_metadata("stream_count") == 1
+    assert rec.get_metadata("device") == "XDF"
+    assert rec.get_metadata("source_file") == SAMPLE_XDF_PATH
+    assert rec.get_metadata("stream_count") == 1
 
 
 def test_xdf_importer_from_emg_class():
     """Test XDF import through Recording.from_file."""
-    emg = Recording.from_file(SAMPLE_XDF_PATH)
+    rec = Recording.from_file(SAMPLE_XDF_PATH)
 
     # Check basic loading
-    assert emg.signals is not None
-    assert len(emg.channels) == 8
-    assert emg.signals.shape[0] == 9520
+    assert rec.signals is not None
+    assert len(rec.channels) == 8
+    assert rec.signals.shape[0] == 9520
 
 
 def test_xdf_importer_stream_selection_by_type():
@@ -116,8 +116,8 @@ def test_xdf_importer_stream_selection_by_type():
     importer = XDFImporter()
 
     # Select by type - should match the stream
-    emg = importer.load(SAMPLE_XDF_PATH, stream_types=["EEG"])
-    assert len(emg.channels) == 8
+    rec = importer.load(SAMPLE_XDF_PATH, stream_types=["EEG"])
+    assert len(rec.channels) == 8
 
     # Select by non-matching type - should raise error
     with pytest.raises(ValueError, match="No matching streams"):
@@ -129,8 +129,8 @@ def test_xdf_importer_stream_selection_by_name():
     importer = XDFImporter()
 
     # Select by name (case-insensitive)
-    emg = importer.load(SAMPLE_XDF_PATH, stream_names=["obci_neeg1"])
-    assert len(emg.channels) == 8
+    rec = importer.load(SAMPLE_XDF_PATH, stream_names=["obci_neeg1"])
+    assert len(rec.channels) == 8
 
     # Select by non-matching name
     with pytest.raises(ValueError, match="No matching streams"):
@@ -140,50 +140,50 @@ def test_xdf_importer_stream_selection_by_name():
 def test_xdf_importer_channel_labels():
     """Test channel labeling in XDF importer."""
     importer = XDFImporter()
-    emg = importer.load(SAMPLE_XDF_PATH)
+    rec = importer.load(SAMPLE_XDF_PATH)
 
     # Check channel names contain stream name prefix
-    channel_names = list(emg.channels.keys())
+    channel_names = list(rec.channels.keys())
     assert all("obci_neeg1" in name for name in channel_names)
 
 
 def test_xdf_importer_timestamps():
     """Test timestamp handling in XDF importer."""
     importer = XDFImporter()
-    emg = importer.load(SAMPLE_XDF_PATH)
+    rec = importer.load(SAMPLE_XDF_PATH)
 
     # Check time index starts at 0
-    assert emg.signals.index[0] == pytest.approx(0.0, abs=1e-6)
+    assert rec.signals.index[0] == pytest.approx(0.0, abs=1e-6)
 
     # Check duration matches expected
-    duration = emg.signals.index[-1]
+    duration = rec.signals.index[-1]
     assert duration > 9.0  # Should be about 9.5 seconds
 
 
 def test_xdf_export_roundtrip():
     """Test XDF import and EDF export roundtrip."""
     # Load XDF file
-    emg = Recording.from_file(SAMPLE_XDF_PATH)
+    rec = Recording.from_file(SAMPLE_XDF_PATH)
 
     # Export to EDF
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         temp_path = f.name
 
     try:
-        emg.to_edf(temp_path, format="edf")
+        rec.to_edf(temp_path, format="edf")
 
         # Reload from EDF
-        emg_reloaded = Recording.from_file(temp_path)
+        rec_reloaded = Recording.from_file(temp_path)
 
         # Check basic structure preserved
-        assert len(emg_reloaded.channels) == len(emg.channels)
+        assert len(rec_reloaded.channels) == len(rec.channels)
 
         # Check data is similar (allowing for EDF precision loss)
         for orig_ch, reload_ch in zip(
-            emg.channels.keys(), emg_reloaded.channels.keys(), strict=False
+            rec.channels.keys(), rec_reloaded.channels.keys(), strict=False
         ):
-            orig_data = emg.signals[orig_ch].values
-            reload_data = emg_reloaded.signals[reload_ch].values
+            orig_data = rec.signals[orig_ch].values
+            reload_data = rec_reloaded.signals[reload_ch].values
 
             # Trim to same length (EDF may have different sample count)
             min_len = min(len(orig_data), len(reload_data))
@@ -213,11 +213,11 @@ def test_xdf_file_not_found():
 def test_xdf_default_channel_type():
     """Test default channel type assignment."""
     importer = XDFImporter()
-    emg = importer.load(SAMPLE_XDF_PATH, default_channel_type="EEG")
+    rec = importer.load(SAMPLE_XDF_PATH, default_channel_type="EEG")
 
     # Since the stream has no explicit channel types in desc,
     # channels should get the default type
-    for channel_info in emg.channels.values():
+    for channel_info in rec.channels.values():
         assert channel_info["channel_type"] == "EEG"
 
 
@@ -245,19 +245,19 @@ def test_multistream_summarize():
 
 def test_multistream_import_all():
     """Test importing all numeric streams from multi-stream file."""
-    emg = Recording.from_file(MULTI_STREAM_XDF_PATH)
+    rec = Recording.from_file(MULTI_STREAM_XDF_PATH)
 
     # Should have channels from EEG, EMG, and Mocap (not Markers - string stream)
     # EEG: 8, EMG: 2, Mocap: 6 = 16 total
-    assert len(emg.channels) == 16
+    assert len(rec.channels) == 16
 
 
 def test_multistream_import_by_type():
     """Test importing specific stream types from multi-stream file."""
     # Import only EMG
-    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"])
-    assert len(emg.channels) == 2
-    channel_names = list(emg.channels.keys())
+    rec = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"])
+    assert len(rec.channels) == 2
+    channel_names = list(rec.channels.keys())
     assert "EMG_L" in channel_names
     assert "EMG_R" in channel_names
 
@@ -274,16 +274,16 @@ def test_multistream_import_by_type():
 
 def test_multistream_import_by_name():
     """Test importing specific streams by name from multi-stream file."""
-    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_names=["TestEMG"])
-    assert len(emg.channels) == 2
+    rec = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_names=["TestEMG"])
+    assert len(rec.channels) == 2
 
 
 def test_multistream_import_multiple_types():
     """Test importing multiple stream types from multi-stream file."""
-    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG", "EMG"])
+    rec = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EEG", "EMG"])
 
     # Should have EEG (8) + EMG (2) = 10 channels
-    assert len(emg.channels) == 10
+    assert len(rec.channels) == 10
 
 
 def test_multistream_sampling_rates():
@@ -398,10 +398,10 @@ def test_multistream_reference_stream_not_found():
 def test_include_timestamps_single_stream():
     """Test include_timestamps option with single stream."""
     importer = XDFImporter()
-    emg = importer.load(SAMPLE_XDF_PATH, include_timestamps=True)
+    rec = importer.load(SAMPLE_XDF_PATH, include_timestamps=True)
 
     # Should have original channels plus one timestamp channel
-    channel_names = list(emg.channels.keys())
+    channel_names = list(rec.channels.keys())
 
     # Find the timestamp channel
     ts_channels = [ch for ch in channel_names if "_LSL_timestamps" in ch]
@@ -409,19 +409,19 @@ def test_include_timestamps_single_stream():
 
     # Check timestamp channel properties
     ts_channel = ts_channels[0]
-    assert emg.channels[ts_channel]["physical_dimension"] == "s"
-    assert emg.channels[ts_channel]["channel_type"] == "MISC"
+    assert rec.channels[ts_channel]["physical_dimension"] == "s"
+    assert rec.channels[ts_channel]["channel_type"] == "MISC"
 
     # Verify timestamp values are reasonable (should be monotonically increasing)
-    ts_values = emg.signals[ts_channel].values
+    ts_values = rec.signals[ts_channel].values
     assert np.all(np.diff(ts_values) >= 0), "Timestamps should be monotonically increasing"
 
 
 def test_include_timestamps_multistream():
     """Test include_timestamps option with multi-stream file."""
-    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, include_timestamps=True)
+    rec = Recording.from_file(MULTI_STREAM_XDF_PATH, include_timestamps=True)
 
-    channel_names = list(emg.channels.keys())
+    channel_names = list(rec.channels.keys())
 
     # Should have timestamp channels for each numeric stream (EEG, EMG, Mocap)
     ts_channels = [ch for ch in channel_names if "_LSL_timestamps" in ch]
@@ -429,15 +429,15 @@ def test_include_timestamps_multistream():
 
     # Verify each timestamp channel
     for ts_ch in ts_channels:
-        assert emg.channels[ts_ch]["physical_dimension"] == "s"
-        assert emg.channels[ts_ch]["channel_type"] == "MISC"
+        assert rec.channels[ts_ch]["physical_dimension"] == "s"
+        assert rec.channels[ts_ch]["channel_type"] == "MISC"
 
 
 def test_include_timestamps_by_type():
     """Test include_timestamps with stream type selection."""
-    emg = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"], include_timestamps=True)
+    rec = Recording.from_file(MULTI_STREAM_XDF_PATH, stream_types=["EMG"], include_timestamps=True)
 
-    channel_names = list(emg.channels.keys())
+    channel_names = list(rec.channels.keys())
 
     # Should have EMG channels plus one timestamp channel
     ts_channels = [ch for ch in channel_names if "_LSL_timestamps" in ch]
@@ -447,9 +447,9 @@ def test_include_timestamps_by_type():
 
 def test_include_timestamps_default_false():
     """Test that timestamps are not included by default."""
-    emg = Recording.from_file(SAMPLE_XDF_PATH)
+    rec = Recording.from_file(SAMPLE_XDF_PATH)
 
-    channel_names = list(emg.channels.keys())
+    channel_names = list(rec.channels.keys())
     ts_channels = [ch for ch in channel_names if "_LSL_timestamps" in ch]
 
     assert len(ts_channels) == 0, "Timestamp channels should not be included by default"
@@ -461,32 +461,32 @@ def test_include_timestamps_export_roundtrip():
     import tempfile
 
     # Load with timestamps
-    emg = Recording.from_file(SAMPLE_XDF_PATH, include_timestamps=True)
+    rec = Recording.from_file(SAMPLE_XDF_PATH, include_timestamps=True)
 
     # Find timestamp channel
-    ts_channels = [ch for ch in emg.channels.keys() if "_LSL_timestamps" in ch]
+    ts_channels = [ch for ch in rec.channels.keys() if "_LSL_timestamps" in ch]
     assert len(ts_channels) == 1
     ts_channel = ts_channels[0]
-    original_ts = emg.signals[ts_channel].values.copy()
+    original_ts = rec.signals[ts_channel].values.copy()
 
     # Export to EDF
     with tempfile.NamedTemporaryFile(suffix=".edf", delete=False) as f:
         temp_path = f.name
 
     try:
-        emg.to_edf(temp_path, format="edf")
+        rec.to_edf(temp_path, format="edf")
 
         # Reload from EDF
-        emg_reloaded = Recording.from_file(temp_path)
+        rec_reloaded = Recording.from_file(temp_path)
 
         # Check timestamp channel exists in reloaded data
         # Note: EDF has 16-char limit, so "_LSL_timestamps" may be truncated to "_LSL_t"
-        reloaded_channels = list(emg_reloaded.channels.keys())
+        reloaded_channels = list(rec_reloaded.channels.keys())
         reloaded_ts_channels = [ch for ch in reloaded_channels if "_LSL_t" in ch]
         assert len(reloaded_ts_channels) == 1
 
         # Check values are preserved (with some tolerance for EDF precision)
-        reloaded_ts = emg_reloaded.signals[reloaded_ts_channels[0]].values
+        reloaded_ts = rec_reloaded.signals[reloaded_ts_channels[0]].values
         min_len = min(len(original_ts), len(reloaded_ts))
         correlation = np.corrcoef(original_ts[:min_len], reloaded_ts[:min_len])[0, 1]
         assert correlation > 0.99, f"Timestamp correlation is {correlation}"

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
-__version__ = "1.0.2"
-__version_info__ = (1, 0, 2)
+__version__ = "1.0.3"
+__version_info__ = (1, 0, 3)
 
 
 def get_version() -> str:

--- a/biosigio/visualization/static.py
+++ b/biosigio/visualization/static.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def plot_signals(
-    emg_object: "Recording",  # Changed first arg to accept Recording object
+    rec_object: "Recording",  # Changed first arg to accept Recording object
     channels: list[str] | None = None,
     time_range: tuple[float, float] | None = None,
     offset_scale: float = 0.8,
@@ -28,7 +28,7 @@ def plot_signals(
     Plot EMG signals in a single plot with vertical offsets.
 
     Args:
-        emg_object: The Recording object containing the signals and metadata.
+        rec_object: The Recording object containing the signals and metadata.
         channels: List of channels to plot. If None, plot all channels.
         time_range: Tuple of (start_time, end_time) to plot. If None, plot all data.
         offset_scale: Portion of allocated space each signal can use (0.0 to 1.0).
@@ -39,10 +39,10 @@ def plot_signals(
         show: Whether to display the plot.
         plt_module: Matplotlib pyplot module to use.
     """
-    if emg_object.signals is None:
+    if rec_object.signals is None:
         raise ValueError("Recording object has no signals loaded.")
 
-    signals_df = emg_object.signals
+    signals_df = rec_object.signals
 
     if channels is None:
         channels = list(signals_df.columns)
@@ -147,8 +147,8 @@ def plot_signals(
 
 
 def plot_comparison(
-    emg_original: "Recording",
-    emg_reloaded: "Recording",
+    rec_original: "Recording",
+    rec_reloaded: "Recording",
     channels: list[str] | None = None,
     time_range: tuple[float, float] | None = None,
     detrend: bool = False,
@@ -164,8 +164,8 @@ def plot_comparison(
     Creates subplots for each channel pair.
 
     Args:
-        emg_original: The original Recording object.
-        emg_reloaded: The reloaded Recording object.
+        rec_original: The original Recording object.
+        rec_reloaded: The reloaded Recording object.
         channels: List of original channels to plot. If None, plot common/mapped channels.
         time_range: Tuple of (start_time, end_time) to plot. If None, plot all data.
         detrend: Whether to remove mean from signals before plotting.
@@ -179,11 +179,11 @@ def plot_comparison(
     """
     # Removed local import: from biosigio.core.emg import Recording
 
-    if emg_original.signals is None or emg_reloaded.signals is None:
+    if rec_original.signals is None or rec_reloaded.signals is None:
         raise ValueError("Both Recording objects must have signals loaded to plot a comparison")
 
-    original_channel_names = set(emg_original.signals.columns)
-    reloaded_channel_names = set(emg_reloaded.signals.columns)
+    original_channel_names = set(rec_original.signals.columns)
+    reloaded_channel_names = set(rec_reloaded.signals.columns)
 
     # --- Channel Matching Logic (adapted from compare_signals) ---
     comparison_mode = "unknown"
@@ -274,8 +274,8 @@ def plot_comparison(
 
     for i, (orig_ch, reloaded_ch) in enumerate(channel_pairs):
         ax = axes[i]
-        sig_orig = emg_original.signals[orig_ch]
-        sig_reloaded = emg_reloaded.signals[reloaded_ch]
+        sig_orig = rec_original.signals[orig_ch]
+        sig_reloaded = rec_reloaded.signals[reloaded_ch]
 
         # Apply time range
         if time_range:

--- a/docs/api/analysis/verification.md
+++ b/docs/api/analysis/verification.md
@@ -24,16 +24,16 @@ from biosigio import Recording
 from biosigio.analysis.verification import compare_signals, report_verification_results
 
 # Load original recording
-emg_original = Recording.from_file("data.csv", importer="trigno")
+rec_original = Recording.from_file("data.csv", importer="trigno")
 
 # Export to EDF/BDF and reload. With the default format='auto', to_edf may pick
 # either .edf or .bdf, so reload the path it actually wrote.
 written_path = "exported_data.edf"  # or "exported_data.bdf" if BDF was selected
-emg_original.to_edf("exported_data")
-emg_reloaded = Recording.from_file(written_path)
+rec_original.to_edf("exported_data")
+rec_reloaded = Recording.from_file(written_path)
 
 # Compare signals
-results = compare_signals(emg_original, emg_reloaded)
+results = compare_signals(rec_original, rec_reloaded)
 
 # Generate report
 is_identical = report_verification_results(results, verify_tolerance=0.01)
@@ -58,6 +58,6 @@ channel_map = {
 }
 
 # Compare with mapping
-results = compare_signals(emg_original, emg_reloaded, channel_map=channel_map)
+results = compare_signals(rec_original, rec_reloaded, channel_map=channel_map)
 is_identical = report_verification_results(results, verify_tolerance=0.01)
 ``` 

--- a/docs/api/emg.md
+++ b/docs/api/emg.md
@@ -87,14 +87,14 @@ Details about the main attributes:
 from biosigio import Recording
 
 # Load from file with automatic importer selection
-emg = Recording.from_file("data.otb+")
+rec = Recording.from_file("data.otb+")
 
 # Load with explicit importer
-emg = Recording.from_file("data.otb+", importer="otb")
+rec = Recording.from_file("data.otb+", importer="otb")
 
 # Generic CSV/TXT supports automatic importer selection, but a Delsys Trigno
 # export is best loaded with its dedicated importer
-emg = Recording.from_file("data.csv", importer='trigno')
+rec = Recording.from_file("data.csv", importer='trigno')
 ```
 
 ### Building a Recording Programmatically
@@ -104,15 +104,15 @@ import numpy as np
 from biosigio import Recording
 
 # Start from an empty Recording and add channels
-emg = Recording()
-emg.add_channel(
+rec = Recording()
+rec.add_channel(
     label='EMG1',
     data=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
     sample_frequency=1000,
     physical_dimension='µV',
     channel_type='EMG',
 )
-emg.add_channel(
+rec.add_channel(
     label='EMG2',
     data=np.array([5.0, 4.0, 3.0, 2.0, 1.0]),
     sample_frequency=1000,
@@ -125,37 +125,37 @@ emg.add_channel(
 
 ```python
 # Select by channel names
-subset = emg.select_channels(['EMG1', 'EMG2'])
+subset = rec.select_channels(['EMG1', 'EMG2'])
 
 # Select by channel type
-emg_only = emg.select_channels(channel_type='EMG')
+emg_only = rec.select_channels(channel_type='EMG')
 ```
 
 ### Metadata Handling
 
 ```python
 # Set metadata
-emg.set_metadata('subject', 'S001')
+rec.set_metadata('subject', 'S001')
 
 # Get metadata
-subject = emg.get_metadata('subject')
+subject = rec.get_metadata('subject')
 
 # Check if metadata exists
-if emg.has_metadata('condition'):
-    condition = emg.get_metadata('condition')
+if rec.has_metadata('condition'):
+    condition = rec.get_metadata('condition')
 ```
 
 ### Plotting
 
 ```python
 # Plot all channels
-emg.plot_signals()
+rec.plot_signals()
 
 # Plot specific channels with time range
-emg.plot_signals(['EMG1', 'EMG2'], time_range=(0, 5))
+rec.plot_signals(['EMG1', 'EMG2'], time_range=(0, 5))
 
 # Customize plot
-emg.plot_signals(
+rec.plot_signals(
     channels=['EMG1', 'EMG2'],
     time_range=(0, 5),
     title='EMG Signals',
@@ -173,26 +173,26 @@ from biosigio.visualization.static import plot_comparison
 import matplotlib.pyplot as plt
 
 # Export with built-in verification
-emg_original.to_edf('output', verify=True, verify_tolerance=0.001)
+rec_original.to_edf('output', verify=True, verify_tolerance=0.001)
 
 # Export and verify with custom channel mapping
 channel_map = {'EMG1': 'CH1', 'EMG2': 'CH2'}
-emg_original.to_edf('output', verify=True, verify_channel_map=channel_map)
+rec_original.to_edf('output', verify=True, verify_channel_map=channel_map)
 
 # Export, verify, and generate verification plot
-emg_original.to_edf('output', verify=True, verify_plot=True)
+rec_original.to_edf('output', verify=True, verify_plot=True)
 
 # Manual verification (alternative approach). With the default format='auto',
 # to_edf may write either output.edf or output.bdf; reload the path it wrote.
-emg_original.to_edf('output')
-emg_reloaded = Recording.from_file('output.edf')  # or 'output.bdf' if BDF was selected
+rec_original.to_edf('output')
+rec_reloaded = Recording.from_file('output.edf')  # or 'output.bdf' if BDF was selected
 
 # Compare signals
-results = compare_signals(emg_original, emg_reloaded, tolerance=0.001)
+results = compare_signals(rec_original, rec_reloaded, tolerance=0.001)
 is_identical = report_verification_results(results, verify_tolerance=0.001)
 
 # Plot comparison for visual verification
-plot_comparison(emg_original, emg_reloaded, channels=['EMG1', 'EMG2'])
+plot_comparison(rec_original, rec_reloaded, channels=['EMG1', 'EMG2'])
 plt.show()
 ```
 
@@ -200,11 +200,11 @@ plt.show()
 
 ```python
 # Export with automatic format selection
-emg.to_edf('output')
+rec.to_edf('output')
 
 # Force EDF format
-emg.to_edf('output', format='edf')
+rec.to_edf('output', format='edf')
 
 # Control format selection method
-emg.to_edf('output', method='svd')
+rec.to_edf('output', method='svd')
 ```

--- a/docs/api/exporters/edf.md
+++ b/docs/api/exporters/edf.md
@@ -16,14 +16,14 @@ The EDF/BDF exporter module in biosigIO provides functionality to export biosign
 from biosigio import Recording
 
 # Load data
-emg = Recording.from_file('data.csv', importer='trigno')
+rec = Recording.from_file('data.csv', importer='trigno')
 
 # Export to EDF/BDF with automatic format selection
-emg.to_edf('output')  # Will generate output.edf or output.bdf
+rec.to_edf('output')  # Will generate output.edf or output.bdf
 
 # Force specific format
-emg.to_edf('output_edf', format='edf')  # Forces 16-bit EDF
-emg.to_edf('output_bdf', format='bdf')  # Forces 24-bit BDF
+rec.to_edf('output_edf', format='edf')  # Forces 16-bit EDF
+rec.to_edf('output_bdf', format='bdf')  # Forces 24-bit BDF
 ```
 
 ## Automatic Format Selection
@@ -32,15 +32,15 @@ A key feature of biosigIO's exporter is its ability to automatically determine w
 
 ```python
 # Control the analysis method for format selection
-emg.to_edf('output', method='svd')  # Use SVD analysis only
-emg.to_edf('output', method='fft')  # Use FFT analysis only 
-emg.to_edf('output', method='both')  # Use both methods (default)
+rec.to_edf('output', method='svd')  # Use SVD analysis only
+rec.to_edf('output', method='fft')  # Use FFT analysis only 
+rec.to_edf('output', method='both')  # Use both methods (default)
 
 # Customize SVD parameters
-emg.to_edf('output', method='svd', svd_rank=5)  # Manual rank cutoff
+rec.to_edf('output', method='svd', svd_rank=5)  # Manual rank cutoff
 
 # Customize FFT parameters
-emg.to_edf('output', 
+rec.to_edf('output', 
            method='fft', 
            fft_noise_range=(0.1, 10))  # Manual frequency range for noise floor estimation
 ```

--- a/docs/api/importers/csv.md
+++ b/docs/api/importers/csv.md
@@ -17,10 +17,10 @@ from biosigio import Recording
 from biosigio.importers.csv import CSVImporter
 
 # Method 1: Using Recording.from_file (recommended)
-emg = Recording.from_file('data.csv', importer='csv')
+rec = Recording.from_file('data.csv', importer='csv')
 
 # Method 2: Using the importer directly
-emg = CSVImporter().load('data.csv', has_header=True, delimiter=',')
+rec = CSVImporter().load('data.csv', has_header=True, delimiter=',')
 ```
 
 ## Auto-Detection Features
@@ -81,14 +81,14 @@ The CSV importer uses pandas to:
 
 ```python
 # Load CSV with automatic format detection
-emg = Recording.from_file('data.csv', importer='csv')
+rec = Recording.from_file('data.csv', importer='csv')
 ```
 
 ### Headerless CSV with Custom Names
 
 ```python
 # Load headerless CSV with custom channel names
-emg = Recording.from_file('data.csv', importer='csv',
+rec = Recording.from_file('data.csv', importer='csv',
                    has_header=False,
                    sample_frequency=1000,  # Required since no time column
                    channel_names=['EMG_L', 'EMG_R', 'ACC_X'])
@@ -98,7 +98,7 @@ emg = Recording.from_file('data.csv', importer='csv',
 
 ```python
 # Specify channel types and physical dimensions
-emg = Recording.from_file('data.csv', importer='csv',
+rec = Recording.from_file('data.csv', importer='csv',
                    channel_types={
                        'EMG1': 'EMG',
                        'EMG2': 'EMG',

--- a/docs/api/importers/edf.md
+++ b/docs/api/importers/edf.md
@@ -17,10 +17,10 @@ from biosigio import Recording
 from biosigio.importers.edf import EDFImporter
 
 # Method 1: Using Recording.from_file (recommended)
-emg = Recording.from_file('data.edf', importer='edf')  # Works for both .edf and .bdf
+rec = Recording.from_file('data.edf', importer='edf')  # Works for both .edf and .bdf
 
 # Method 2: Using the importer directly
-emg = EDFImporter().load('data.edf')
+rec = EDFImporter().load('data.edf')
 ```
 
 ## File Format Support
@@ -86,10 +86,10 @@ EDF/BDF, these events are written out again as EDF+ annotations.
 
 ```python
 # Load an EDF+ file with annotations
-emg = Recording.from_file('data.edf', importer='edf')
+rec = Recording.from_file('data.edf', importer='edf')
 
 # Access annotations via the events DataFrame
-for _, event in emg.events.iterrows():
+for _, event in rec.events.iterrows():
     print(f"Event: {event['description']} at {event['onset']}s, "
           f"duration: {event['duration']}s")
 ```

--- a/docs/api/importers/eeglab.md
+++ b/docs/api/importers/eeglab.md
@@ -17,10 +17,10 @@ from biosigio import Recording
 from biosigio.importers.eeglab import EEGLABImporter
 
 # Method 1: Using Recording.from_file (recommended)
-emg = Recording.from_file('data.set', importer='eeglab')
+rec = Recording.from_file('data.set', importer='eeglab')
 
 # Method 2: Using the importer directly
-emg = EEGLABImporter().load('data.set')
+rec = EEGLABImporter().load('data.set')
 ```
 
 ## File Format Support

--- a/docs/api/importers/otb.md
+++ b/docs/api/importers/otb.md
@@ -17,10 +17,10 @@ from biosigio import Recording
 from biosigio.importers.otb import OTBImporter
 
 # Method 1: Using Recording.from_file (recommended)
-emg = Recording.from_file('data.otb+', importer='otb')
+rec = Recording.from_file('data.otb+', importer='otb')
 
 # Method 2: Using the importer directly
-emg = OTBImporter().load('data.otb+')
+rec = OTBImporter().load('data.otb+')
 ```
 
 ## File Format Support

--- a/docs/api/importers/trigno.md
+++ b/docs/api/importers/trigno.md
@@ -17,10 +17,10 @@ from biosigio import Recording
 from biosigio.importers.trigno import TrignoImporter
 
 # Method 1: Using Recording.from_file (recommended)
-emg = Recording.from_file('data.csv', importer='trigno')
+rec = Recording.from_file('data.csv', importer='trigno')
 
 # Method 2: Using the importer directly
-emg = TrignoImporter().load('data.csv')
+rec = TrignoImporter().load('data.csv')
 ```
 
 ## File Format Requirements

--- a/docs/api/importers/xdf.md
+++ b/docs/api/importers/xdf.md
@@ -19,11 +19,11 @@ from biosigio import Recording
 from biosigio.importers.xdf import XDFImporter
 
 # Method 1: Using Recording.from_file (recommended)
-emg = Recording.from_file('recording.xdf')
+rec = Recording.from_file('recording.xdf')
 
 # Method 2: Using the importer directly
 importer = XDFImporter()
-emg = importer.load('recording.xdf')
+rec = importer.load('recording.xdf')
 ```
 
 ### Exploring File Contents
@@ -54,30 +54,30 @@ print(summary)
 
 ```python
 # Load only specific stream types
-emg = Recording.from_file('recording.xdf', stream_types=['EMG'])
+rec = Recording.from_file('recording.xdf', stream_types=['EMG'])
 
 # Load multiple types
-emg = Recording.from_file('recording.xdf', stream_types=['EMG', 'EEG'])
+rec = Recording.from_file('recording.xdf', stream_types=['EMG', 'EEG'])
 
 # Load by stream name
-emg = Recording.from_file('recording.xdf', stream_names=['MyEMGDevice'])
+rec = Recording.from_file('recording.xdf', stream_names=['MyEMGDevice'])
 
 # Load by stream ID
-emg = Recording.from_file('recording.xdf', stream_ids=[2])
+rec = Recording.from_file('recording.xdf', stream_ids=[2])
 ```
 
 ### Setting Default Channel Type
 
 ```python
 # For streams without explicit channel type metadata
-emg = Recording.from_file('recording.xdf', default_channel_type='EMG')
+rec = Recording.from_file('recording.xdf', default_channel_type='EMG')
 ```
 
 ### Preserving LSL Timestamps
 
 ```python
 # Include original LSL timestamps as additional channels
-emg = Recording.from_file('recording.xdf', include_timestamps=True)
+rec = Recording.from_file('recording.xdf', include_timestamps=True)
 
 # Each stream gets a "{stream_name}_LSL_timestamps" channel
 # Useful for synchronization with other LSL-recorded data

--- a/docs/api/visualization/static.md
+++ b/docs/api/visualization/static.md
@@ -26,11 +26,11 @@ from biosigio import Recording
 from biosigio.visualization.static import plot_signals
 
 # Load EMG data
-emg = Recording.from_file("data.csv", importer="trigno")
+rec = Recording.from_file("data.csv", importer="trigno")
 
 # Plot signals directly with custom parameters
 plot_signals(
-    emg_object=emg,
+    rec_object=rec,
     channels=['EMG1', 'EMG2'],
     time_range=(0, 5),
     offset_scale=0.7,
@@ -49,8 +49,8 @@ from biosigio import Recording
 from biosigio.visualization.static import plot_comparison
 
 # Load original and reloaded EMG data
-emg_original = Recording.from_file("original.csv", importer="trigno")
-emg_reloaded = Recording.from_file("reloaded.edf")
+rec_original = Recording.from_file("original.csv", importer="trigno")
+rec_reloaded = Recording.from_file("reloaded.edf")
 
 # Create channel mapping
 channel_map = {
@@ -60,8 +60,8 @@ channel_map = {
 
 # Plot comparison directly
 plot_comparison(
-    emg_original=emg_original,
-    emg_reloaded=emg_reloaded,
+    rec_original=rec_original,
+    rec_reloaded=rec_reloaded,
     channels=['EMG1', 'EMG2'],
     time_range=(1, 3),
     detrend=True,

--- a/docs/examples/eeglab.md
+++ b/docs/examples/eeglab.md
@@ -11,34 +11,34 @@ import matplotlib.pyplot as plt
 
 # Load data from an EEGLAB .set file
 data_path = 'path_to_your_eeglab_file.set'
-emg = Recording.from_file(data_path, importer='eeglab')
+rec = Recording.from_file(data_path, importer='eeglab')
 
 # Print metadata
 print("\nMetadata:")
 print("-" * 50)
 for key in ['subject', 'session', 'condition', 'srate', 'nbchan', 'pnts']:
-    if key in emg.metadata:
-        print(f"{key}: {emg.get_metadata(key)}")
+    if key in rec.metadata:
+        print(f"{key}: {rec.get_metadata(key)}")
 
 # Print available channels
 print("\nAvailable channels:")
 print("-" * 50)
-channel_types = emg.get_channel_types()
+channel_types = rec.get_channel_types()
 for ch_type in channel_types:
-    channels = emg.get_channels_by_type(ch_type)
+    channels = rec.get_channels_by_type(ch_type)
     print(f"{ch_type} channels ({len(channels)}):")
     for i, ch_name in enumerate(channels[:5]):  # Print first 5 channels of each type
-        ch_info = emg.channels[ch_name]
+        ch_info = rec.channels[ch_name]
         print(f"  - {ch_name} (Sampling rate: {ch_info['sample_frequency']} Hz, "
               f"Unit: {ch_info['physical_dimension']})")
     if len(channels) > 5:
         print(f"  ... and {len(channels) - 5} more {ch_type} channels")
 
 # Plot EMG channels
-emg_channels = emg.get_channels_by_type('EMG')
+emg_channels = rec.get_channels_by_type('EMG')
 if emg_channels:
     # Select EMG channels only
-    emg_only = emg.select_channels(emg_channels)
+    emg_only = rec.select_channels(emg_channels)
     
     # Plot the first 5 seconds
     plt.figure(figsize=(12, 8))
@@ -57,19 +57,19 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # Load EEGLAB data with events
-emg = Recording.from_file('data_with_events.set', importer='eeglab')
+rec = Recording.from_file('data_with_events.set', importer='eeglab')
 
-# EEGLAB events are loaded into emg.events (a DataFrame: onset/duration in
+# EEGLAB events are loaded into rec.events (a DataFrame: onset/duration in
 # seconds, description = the EEGLAB event 'type'). The latency (samples) is
 # converted to an onset in seconds on import.
-if not emg.events.empty:
-    print(f"Found {len(emg.events)} events")
+if not rec.events.empty:
+    print(f"Found {len(rec.events)} events")
 
     # Print the first 5 events
-    print(emg.events.head(5).to_string(index=False))
+    print(rec.events.head(5).to_string(index=False))
 
     # Extract specific event types by description
-    movement_events = emg.events[emg.events['description'] == 'movement']
+    movement_events = rec.events[rec.events['description'] == 'movement']
     print(f"Found {len(movement_events)} movement events")
 
     # Plot signals around the first movement event
@@ -80,7 +80,7 @@ if not emg.events.empty:
         # Plot 2 seconds before and after the event. Pass show=False so the
         # event marker can be overlaid before displaying.
         window = 2  # seconds
-        emg.plot_signals(
+        rec.plot_signals(
             time_range=(event_time - window, event_time + window),
             title=f"EMG around movement event at {event_time:.2f}s",
             show=False
@@ -104,24 +104,24 @@ from biosigio import Recording
 import matplotlib.pyplot as plt
 
 # Load EEGLAB data
-emg = Recording.from_file('epoched_data.set', importer='eeglab')
+rec = Recording.from_file('epoched_data.set', importer='eeglab')
 
 # trials > 1 indicates epoched data; get_metadata returns None if absent
-trials = emg.get_metadata('trials')
+trials = rec.get_metadata('trials')
 is_epoched = trials is not None and trials > 1
 print(f"Data is {'epoched' if is_epoched else 'continuous'}")
 
 if is_epoched:
-    n_epochs = emg.get_metadata('trials')
-    epoch_length = emg.get_metadata('pnts')
-    fs = emg.get_sampling_frequency()
+    n_epochs = rec.get_metadata('trials')
+    epoch_length = rec.get_metadata('pnts')
+    fs = rec.get_sampling_frequency()
     epoch_duration = epoch_length / fs
 
     print(f"Number of epochs: {n_epochs}")
     print(f"Epoch length: {epoch_length} samples ({epoch_duration:.2f} seconds)")
 
 # Plot the first few seconds (plot_signals manages its own figure)
-emg.plot_signals(time_range=(0, 5), title="EEGLAB Signals")
+rec.plot_signals(time_range=(0, 5), title="EEGLAB Signals")
 ```
 
 ## Exporting EEGLAB Data to EDF/BDF
@@ -132,14 +132,14 @@ Converting EEGLAB data to EDF/BDF format:
 from biosigio import Recording
 
 # Load EEGLAB data
-emg = Recording.from_file('data.set', importer='eeglab')
+rec = Recording.from_file('data.set', importer='eeglab')
 
 # Export all channels to EDF/BDF
 output_path = 'eeglab_all_channels'
-emg.to_edf(output_path)  # Format (EDF/BDF) selected automatically
+rec.to_edf(output_path)  # Format (EDF/BDF) selected automatically
 
 # Export only EMG channels
-emg_only = emg.select_channels(channel_type='EMG')
+emg_only = rec.select_channels(channel_type='EMG')
 output_path = 'eeglab_emg_only'
 emg_only.to_edf(output_path)
 

--- a/docs/examples/notebooks.md
+++ b/docs/examples/notebooks.md
@@ -40,10 +40,10 @@ import matplotlib.pyplot as plt
 %matplotlib inline  # For displaying plots in the notebook
 
 # Load EMG data
-emg = Recording.from_file('data.csv', importer='trigno')
+rec = Recording.from_file('data.csv', importer='trigno')
 
 # Plot signals with customized appearance (plot_signals manages its own figure)
-emg.plot_signals(
+rec.plot_signals(
     channels=['EMG1', 'EMG2'],
     time_range=(0, 5),
     title='EMG Signals',
@@ -57,18 +57,18 @@ Jupyter notebooks are excellent for interactively exploring your EMG data:
 
 ```python
 # Load data
-emg = Recording.from_file('data.otb+', importer='otb')
+rec = Recording.from_file('data.otb+', importer='otb')
 
 # Display channel information
-channel_types = emg.get_channel_types()
+channel_types = rec.get_channel_types()
 for ch_type in channel_types:
-    channels = emg.get_channels_by_type(ch_type)
+    channels = rec.get_channels_by_type(ch_type)
     print(f"{ch_type} channels: {len(channels)}")
     
     # Show details of the first channel
     if channels:
         ch_name = channels[0]
-        ch_info = emg.channels[ch_name]
+        ch_info = rec.channels[ch_name]
         print(f"  Sample channel: {ch_name}")
         for key, value in ch_info.items():
             print(f"    {key}: {value}")
@@ -83,10 +83,10 @@ import ipywidgets as widgets
 from IPython.display import display
 
 # Load data
-emg = Recording.from_file('data.set', importer='eeglab')
+rec = Recording.from_file('data.set', importer='eeglab')
 
 # Get all channels
-all_channels = list(emg.channels.keys())
+all_channels = list(rec.channels.keys())
 
 # Create widgets
 channel_dropdown = widgets.Dropdown(
@@ -98,7 +98,7 @@ channel_dropdown = widgets.Dropdown(
 time_slider = widgets.FloatRangeSlider(
     value=[0, 5],
     min=0,
-    max=emg.get_duration(),
+    max=rec.get_duration(),
     step=1,
     description='Time (s):',
     disabled=False,
@@ -110,7 +110,7 @@ time_slider = widgets.FloatRangeSlider(
 # Define update function
 def update_plot(channel, time_range):
     plt.figure(figsize=(12, 6))
-    emg.plot_signals(
+    rec.plot_signals(
         channels=[channel],
         time_range=time_range,
         title=f'Channel: {channel}, Time: {time_range[0]}-{time_range[1]}s',
@@ -135,8 +135,8 @@ You can easily export high-quality figures for publications:
 ```python
 # Create a figure
 plt.figure(figsize=(10, 6), dpi=300)  # High DPI for publication quality
-emg.plot_signals(
-    channels=emg.get_channels_by_type('EMG')[:4],  # First 4 EMG channels
+rec.plot_signals(
+    channels=rec.get_channels_by_type('EMG')[:4],  # First 4 EMG channels
     time_range=(10, 15),
     title='EMG Signals During Movement',
     grid=True,
@@ -162,10 +162,10 @@ plt.show()
    from biosigio.importers.edf import EDFImporter
 
    # Inferred importer (extension-based)
-   emg = Recording.from_file('recording.edf')
+   rec = Recording.from_file('recording.edf')
 
    # Equivalent direct use
-   emg = EDFImporter().load('recording.edf')
+   rec = EDFImporter().load('recording.edf')
    ```
 
 2. **Progress tracking**: For long operations, use `tqdm` for progress bars:
@@ -173,9 +173,9 @@ plt.show()
    from tqdm.notebook import tqdm
    
    channel_stats = {}
-   for channel in tqdm(emg.channels.keys()):
+   for channel in tqdm(rec.channels.keys()):
        # Perform analysis on each channel
-       signal = emg.signals[channel].values
+       signal = rec.signals[channel].values
        channel_stats[channel] = {
            'mean': signal.mean(),
            'std': signal.std(),
@@ -190,7 +190,7 @@ plt.show()
    
    # Convert channel info to DataFrame
    channel_df = pd.DataFrame()
-   for ch_name, ch_info in emg.channels.items():
+   for ch_name, ch_info in rec.channels.items():
        ch_data = pd.Series(ch_info)
        ch_data.name = ch_name
        channel_df = channel_df.append(ch_data)

--- a/docs/examples/otb.md
+++ b/docs/examples/otb.md
@@ -10,28 +10,28 @@ from biosigio import Recording
 
 # Load OTB data
 data_path = 'path_to_your_otb_file.otb+'
-emg = Recording.from_file(data_path, importer='otb')
+rec = Recording.from_file(data_path, importer='otb')
 
 # Print device information
 print("\nDevice Information:")
 print("-" * 50)
-print(f"Device: {emg.get_metadata('device')}")
-print(f"Resolution: {emg.get_metadata('signal_resolution')} bits")
+print(f"Device: {rec.get_metadata('device')}")
+print(f"Resolution: {rec.get_metadata('signal_resolution')} bits")
 
 # Print channel type summary
 print("\nChannel Type Summary:")
 print("-" * 50)
-channel_types = emg.get_channel_types()
+channel_types = rec.get_channel_types()
 for ch_type in channel_types:
-    channels = emg.get_channels_by_type(ch_type)
+    channels = rec.get_channels_by_type(ch_type)
     print(f"{ch_type}: {len(channels)} channels")
 
 # Plot one channel of each type (each call manages its own figure)
 for ch_type in channel_types:
-    channels = emg.get_channels_by_type(ch_type)
+    channels = rec.get_channels_by_type(ch_type)
     if channels:
         # Select the first channel of this type
-        sample_channel = emg.select_channels([channels[0]])
+        sample_channel = rec.select_channels([channels[0]])
         sample_channel.plot_signals(
             time_range=(0, 5),
             title=f"{ch_type} Sample: {channels[0]}"
@@ -48,16 +48,16 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # Load OTB data
-emg = Recording.from_file('otb_data.otb+', importer='otb')
+rec = Recording.from_file('otb_data.otb+', importer='otb')
 
 # Create a new Recording object with only EMG channels
-emg_channels = emg.get_channels_by_type('EMG')
+emg_channels = rec.get_channels_by_type('EMG')
 
 if emg_channels:
     print(f"Found {len(emg_channels)} EMG channels")
     
     # Select EMG channels
-    emg_data = emg.select_channels(emg_channels)
+    rec_data = rec.select_channels(emg_channels)
     
     # Plot EMG data
     plt.figure(figsize=(15, 10))
@@ -65,7 +65,7 @@ if emg_channels:
     # If there are many channels, select a subset
     channels_to_plot = emg_channels[:8] if len(emg_channels) > 8 else emg_channels
     
-    emg_data.plot_signals(
+    rec_data.plot_signals(
         channels=channels_to_plot,
         time_range=(0, 5),
         title='EMG Channels from OTB File',
@@ -79,12 +79,12 @@ if emg_channels:
     plt.figure(figsize=(15, 6))
     
     # Calculate RMS in 100ms windows
-    fs = emg_data.get_sampling_frequency()
+    fs = rec_data.get_sampling_frequency()
     window_size = int(0.1 * fs)  # 100ms window
     
     for i, channel in enumerate(channels_to_plot):
         # Get signal data
-        signal = emg_data.signals[channel].values
+        signal = rec_data.signals[channel].values
         
         # Calculate RMS in windows
         n_windows = len(signal) // window_size
@@ -125,18 +125,18 @@ import matplotlib.pyplot as plt
 file1 = 'session1.otb+'
 file2 = 'session2.otb+'
 
-emg1 = Recording.from_file(file1, importer='otb')
-emg2 = Recording.from_file(file2, importer='otb')
+rec1 = Recording.from_file(file1, importer='otb')
+rec2 = Recording.from_file(file2, importer='otb')
 
 # Add metadata to distinguish them
-emg1.set_metadata('session', '1')
-emg1.set_metadata('condition', 'rest')
-emg2.set_metadata('session', '2')
-emg2.set_metadata('condition', 'contraction')
+rec1.set_metadata('session', '1')
+rec1.set_metadata('condition', 'rest')
+rec2.set_metadata('session', '2')
+rec2.set_metadata('condition', 'contraction')
 
 # Check that they have the same channel structure
-channels1 = set(emg1.channels.keys())
-channels2 = set(emg2.channels.keys())
+channels1 = set(rec1.channels.keys())
+channels2 = set(rec2.channels.keys())
 common_channels = channels1.intersection(channels2)
 
 print(f"File 1 has {len(channels1)} channels")
@@ -145,24 +145,24 @@ print(f"Common channels: {len(common_channels)}")
 
 # Compare EMG channels between sessions
 emg_channels = [ch for ch in common_channels 
-                if emg1.channels[ch]['channel_type'] == 'EMG']
+                if rec1.channels[ch]['channel_type'] == 'EMG']
 
 if emg_channels:
     # Select a channel to compare (each call manages its own figure)
     channel_to_compare = emg_channels[0]
 
     # Plot channel from first session
-    emg1.plot_signals(
+    rec1.plot_signals(
         [channel_to_compare],
         time_range=(0, 5),
-        title=f"Session 1 ({emg1.get_metadata('condition')}): {channel_to_compare}"
+        title=f"Session 1 ({rec1.get_metadata('condition')}): {channel_to_compare}"
     )
 
     # Plot same channel from second session
-    emg2.plot_signals(
+    rec2.plot_signals(
         [channel_to_compare],
         time_range=(0, 5),
-        title=f"Session 2 ({emg2.get_metadata('condition')}): {channel_to_compare}"
+        title=f"Session 2 ({rec2.get_metadata('condition')}): {channel_to_compare}"
     )
 ```
 
@@ -174,39 +174,39 @@ Converting OTB data to EDF/BDF format:
 from biosigio import Recording
 
 # Load OTB data
-emg = Recording.from_file('data.otb+', importer='otb')
+rec = Recording.from_file('data.otb+', importer='otb')
 
 # Add metadata for export
-emg.set_metadata('subject', 'S001')
-emg.set_metadata('recording_date', '2023-01-15')
-emg.set_metadata('experimenter', 'Researcher')
+rec.set_metadata('subject', 'S001')
+rec.set_metadata('recording_date', '2023-01-15')
+rec.set_metadata('experimenter', 'Researcher')
 
 # Export all channels
 output_path = 'otb_all_channels'
-emg.to_edf(output_path)  # Format (EDF/BDF) selected automatically
+rec.to_edf(output_path)  # Format (EDF/BDF) selected automatically
 print(f"Exported all channels to: {output_path}")
 
 # Export only EMG channels for clarity
-emg_channels = emg.get_channels_by_type('EMG')
+emg_channels = rec.get_channels_by_type('EMG')
 if emg_channels:
-    emg_only = emg.select_channels(emg_channels)
+    emg_only = rec.select_channels(emg_channels)
     output_path = 'otb_emg_only'
     emg_only.to_edf(output_path)
     print(f"Exported EMG channels to: {output_path}")
 
 # If there are too many channels for EDF, you might need to split
 # EDF has limitations on the number of channels it can handle
-if len(emg.channels) > 100:  # EDF typically handles fewer channels
+if len(rec.channels) > 100:  # EDF typically handles fewer channels
     print("Large number of channels detected, splitting export")
     
     # Split into groups of 50 channels
-    channel_lists = [list(emg.channels.keys())[i:i+50] 
-                    for i in range(0, len(emg.channels), 50)]
+    channel_lists = [list(rec.channels.keys())[i:i+50] 
+                    for i in range(0, len(rec.channels), 50)]
     
     for i, channel_list in enumerate(channel_lists):
-        subset_emg = emg.select_channels(channel_list)
+        subset_rec = rec.select_channels(channel_list)
         output_path = f'otb_split_{i+1}'
-        subset_emg.to_edf(output_path)
+        subset_rec.to_edf(output_path)
         print(f"Exported channel group {i+1} to: {output_path}")
 ```
 

--- a/docs/examples/otb.md
+++ b/docs/examples/otb.md
@@ -57,7 +57,7 @@ if emg_channels:
     print(f"Found {len(emg_channels)} EMG channels")
     
     # Select EMG channels
-    rec_data = rec.select_channels(emg_channels)
+    emg_data = rec.select_channels(emg_channels)
     
     # Plot EMG data
     plt.figure(figsize=(15, 10))
@@ -65,7 +65,7 @@ if emg_channels:
     # If there are many channels, select a subset
     channels_to_plot = emg_channels[:8] if len(emg_channels) > 8 else emg_channels
     
-    rec_data.plot_signals(
+    emg_data.plot_signals(
         channels=channels_to_plot,
         time_range=(0, 5),
         title='EMG Channels from OTB File',
@@ -79,12 +79,12 @@ if emg_channels:
     plt.figure(figsize=(15, 6))
     
     # Calculate RMS in 100ms windows
-    fs = rec_data.get_sampling_frequency()
+    fs = emg_data.get_sampling_frequency()
     window_size = int(0.1 * fs)  # 100ms window
     
     for i, channel in enumerate(channels_to_plot):
         # Get signal data
-        signal = rec_data.signals[channel].values
+        signal = emg_data.signals[channel].values
         
         # Calculate RMS in windows
         n_windows = len(signal) // window_size
@@ -204,9 +204,9 @@ if len(rec.channels) > 100:  # EDF typically handles fewer channels
                     for i in range(0, len(rec.channels), 50)]
     
     for i, channel_list in enumerate(channel_lists):
-        subset_rec = rec.select_channels(channel_list)
+        subset_emg = rec.select_channels(channel_list)
         output_path = f'otb_split_{i+1}'
-        subset_rec.to_edf(output_path)
+        subset_emg.to_edf(output_path)
         print(f"Exported channel group {i+1} to: {output_path}")
 ```
 

--- a/docs/examples/serialization.md
+++ b/docs/examples/serialization.md
@@ -124,7 +124,7 @@ choose which one to reconstruct:
 
 ```python
 # Explicit importer plus group selector for a multi-rate store
-emg = Recording.from_file('rec.zarr', importer='zarr', group='emg_1000hz')
+rec = Recording.from_file('rec.zarr', importer='zarr', group='emg_1000hz')
 eeg = Recording.from_file('rec.zarr', importer='zarr', group='eeg_250hz')
 ```
 

--- a/docs/examples/trigno.md
+++ b/docs/examples/trigno.md
@@ -11,29 +11,29 @@ import matplotlib.pyplot as plt
 
 # Load data from Trigno CSV file
 data_path = 'path_to_your_trigno_data.csv'
-emg = Recording.from_file(data_path, importer='trigno')
+rec = Recording.from_file(data_path, importer='trigno')
 
 # Print information about the loaded data
-print(f"Number of channels: {emg.get_n_channels()}")
-print(f"Number of samples: {emg.get_n_samples()}")
+print(f"Number of channels: {rec.get_n_channels()}")
+print(f"Number of samples: {rec.get_n_samples()}")
 # Trigno recordings are often mixed-rate (EMG vs ACC/GYRO), so a single overall
 # sampling frequency may not exist. get_sampling_frequency() raises ValueError in
 # that case; read the per-channel rate from channels[ch]['sample_frequency'] instead.
 try:
-    print(f"Sampling frequency: {emg.get_sampling_frequency()} Hz")
+    print(f"Sampling frequency: {rec.get_sampling_frequency()} Hz")
 except ValueError:
     print("Mixed per-channel sampling rates (see per-channel rates below)")
-print(f"Recording duration: {emg.get_duration()} seconds")
+print(f"Recording duration: {rec.get_duration()} seconds")
 
 # List available channels
 print("\nAvailable channels:")
-for ch_name, ch_info in emg.channels.items():
+for ch_name, ch_info in rec.channels.items():
     print(f"- {ch_name} ({ch_info['channel_type']})")
     print(f"  Sampling rate: {ch_info['sample_frequency']} Hz")
     print(f"  Dimension: {ch_info['physical_dimension']}")
 
 # Plot EMG signals
-emg.plot_signals(time_range=(0, 5), title="Raw EMG Signals")
+rec.plot_signals(time_range=(0, 5), title="Raw EMG Signals")
 plt.tight_layout()
 plt.show()
 ```
@@ -44,18 +44,18 @@ Trigno systems often record both EMG and accelerometer data. You can separate th
 
 ```python
 # Get EMG channels
-emg_channels = emg.get_channels_by_type('EMG')
+emg_channels = rec.get_channels_by_type('EMG')
 print(f"EMG channels: {emg_channels}")
 
 # Create EMG-only object
-emg_only = emg.select_channels(emg_channels)
+emg_only = rec.select_channels(emg_channels)
 
 # Get accelerometer channels
-acc_channels = emg.get_channels_by_type('ACC')
+acc_channels = rec.get_channels_by_type('ACC')
 print(f"ACC channels: {acc_channels}")
 
 # Create ACC-only object
-acc_only = emg.select_channels(acc_channels)
+acc_only = rec.select_channels(acc_channels)
 
 # Plot EMG and ACC signals separately (each call manages its own figure)
 emg_only.plot_signals(time_range=(0, 5), title="EMG Signals")
@@ -72,13 +72,13 @@ a common rate) before export; exporting a mixed-rate recording raises a
 
 ```python
 # Export only EMG channels (a single-rate subset)
-emg_only = emg.select_channels(channel_type='EMG')
+emg_only = rec.select_channels(channel_type='EMG')
 output_path = 'trigno_emg_only'
 emg_only.to_edf(output_path)  # Format (EDF/BDF) will be selected automatically
 print(f"Exported EMG channels to: {output_path}")
 
 # Accelerometer channels have a different rate, so export them separately
-acc_only = emg.select_channels(channel_type='ACC')
+acc_only = rec.select_channels(channel_type='ACC')
 acc_only.to_edf('trigno_acc_only')
 print("Exported ACC channels to: trigno_acc_only")
 ```
@@ -121,14 +121,14 @@ import numpy as np
 
 # 1. Load the data
 data_path = 'trigno_recording.csv'
-emg = Recording.from_file(data_path, importer='trigno')
+rec = Recording.from_file(data_path, importer='trigno')
 
 # 2. Add metadata
-emg.set_metadata('subject', 'S001')
-emg.set_metadata('condition', 'reaching')
+rec.set_metadata('subject', 'S001')
+rec.set_metadata('condition', 'reaching')
 
 # 3. Select only EMG channels
-emg_only = emg.select_channels(channel_type='EMG')
+emg_only = rec.select_channels(channel_type='EMG')
 
 # The EMG-only subset has a single rate, so get_sampling_frequency() is safe here
 # (the full mixed-rate recording would raise ValueError).

--- a/docs/examples/verification.md
+++ b/docs/examples/verification.md
@@ -11,21 +11,21 @@ import matplotlib.pyplot as plt
 from biosigio.analysis.verification import compare_signals, report_verification_results
 
 # Load original data from a device-specific format
-emg_original = Recording.from_file('sample_data.csv', importer='trigno')
+rec_original = Recording.from_file('sample_data.csv', importer='trigno')
 # just keep the EMG channels
-emg_channels = [ch for ch, info in emg_original.channels.items() if info['channel_type'] == 'EMG']
-emg_original = emg_original.select_channels(emg_channels)  # Creates a new Recording object with only EMG channels
+emg_channels = [ch for ch, info in rec_original.channels.items() if info['channel_type'] == 'EMG']
+rec_original = rec_original.select_channels(emg_channels)  # Creates a new Recording object with only EMG channels
 
 # Export to EDF (automatically selects EDF or BDF based on signal characteristics).
 # Pass a base path without an extension; the writer appends .edf or .bdf.
-emg_original.to_edf('exported_data')
+rec_original.to_edf('exported_data')
 
 # Reload the exported data. Resolve whichever extension to_edf selected.
 exported_path = 'exported_data.edf' if os.path.exists('exported_data.edf') else 'exported_data.bdf'
-emg_reloaded = Recording.from_file(exported_path)
+rec_reloaded = Recording.from_file(exported_path)
 
 # Verify signals using the verification module
-results = compare_signals(emg_original, emg_reloaded, tolerance=0.01)
+results = compare_signals(rec_original, rec_reloaded, tolerance=0.01)
 is_identical = report_verification_results(results, verify_tolerance=0.01)
 
 print(f"Verification result: {'Passed' if is_identical else 'Failed'}")
@@ -39,13 +39,13 @@ The `plot_comparison()` function provides a visual way to compare signals:
 from biosigio.visualization.static import plot_comparison
 
 # Visual comparison of original and reloaded signals
-plot_comparison(emg_original, emg_reloaded, channels=['EMG1', 'EMG2'])
+plot_comparison(rec_original, rec_reloaded, channels=['EMG1', 'EMG2'])
 plt.show()
 
 # Customize the comparison
 plot_comparison(
-    emg_original,
-    emg_reloaded,
+    rec_original,
+    rec_reloaded,
     channels=['EMG1', 'EMG2'],
     time_range=(0, 5),  # Only show first 5 seconds
     detrend=True,       # Remove mean for easier comparison
@@ -63,8 +63,8 @@ from biosigio.analysis.verification import compare_signals, report_verification_
 
 # Compare with detailed metrics
 results = compare_signals(
-    emg_original,
-    emg_reloaded,
+    rec_original,
+    rec_reloaded,
     tolerance=0.01,  # Set custom tolerance (1%)
     channel_map=None  # Use automatic channel matching
 )
@@ -98,8 +98,8 @@ channel_map = {
 
 # Compare with channel mapping
 results = compare_signals(
-    emg_original,
-    emg_reloaded,
+    rec_original,
+    rec_reloaded,
     tolerance=0.01,
     channel_map=channel_map
 )
@@ -109,8 +109,8 @@ is_identical = report_verification_results(results, verify_tolerance=0.01)
 
 # Visual comparison with channel mapping
 plot_comparison(
-    emg_original,
-    emg_reloaded,
+    rec_original,
+    rec_reloaded,
     channel_map=channel_map,
     time_range=(0, 5)
 )
@@ -127,30 +127,30 @@ from biosigio.analysis.verification import compare_signals, report_verification_
 from biosigio.visualization.static import plot_comparison
 
 # 1. Load original Trigno CSV data
-emg_trigno = Recording.from_file('trigno_data.csv', importer='trigno')
+rec_trigno = Recording.from_file('trigno_data.csv', importer='trigno')
 
 # 2. Export to EDF (the writer appends .edf or .bdf based on signal analysis)
-emg_trigno.to_edf('converted_data')
-print(f"Data exported. Duration: {emg_trigno.get_duration():.2f}s, "
-      f"Channels: {emg_trigno.get_n_channels()}")
+rec_trigno.to_edf('converted_data')
+print(f"Data exported. Duration: {rec_trigno.get_duration():.2f}s, "
+      f"Channels: {rec_trigno.get_n_channels()}")
 
 # 3. Reload from the exported file (resolve the auto-selected extension)
 converted_path = 'converted_data.edf' if os.path.exists('converted_data.edf') else 'converted_data.bdf'
-emg_edf = Recording.from_file(converted_path)
-print(f"Data reloaded. Duration: {emg_edf.get_duration():.2f}s, "
-      f"Channels: {emg_edf.get_n_channels()}")
+rec_edf = Recording.from_file(converted_path)
+print(f"Data reloaded. Duration: {rec_edf.get_duration():.2f}s, "
+      f"Channels: {rec_edf.get_n_channels()}")
 
 # 4. Verification using the analysis module
-results = compare_signals(emg_trigno, emg_edf, tolerance=0.01)
+results = compare_signals(rec_trigno, rec_edf, tolerance=0.01)
 is_identical = report_verification_results(results, verify_tolerance=0.01)
 print(f"Verification result: {'Passed' if is_identical else 'Failed'}")
 
 # 5. Visual verification of a few channels
 plt.figure(figsize=(14, 8))
 plot_comparison(
-    emg_trigno,
-    emg_edf,
-    channels=list(emg_trigno.signals.columns)[:3],  # First 3 channels
+    rec_trigno,
+    rec_edf,
+    channels=list(rec_trigno.signals.columns)[:3],  # First 3 channels
     time_range=(0, 2),  # First 2 seconds
     detrend=True
 )

--- a/docs/examples/wfdb.md
+++ b/docs/examples/wfdb.md
@@ -15,11 +15,11 @@ The `WFDBImporter` automatically detects and loads annotations if the correspond
 1.  **Import `Recording`:** The core class is imported.
 2.  **Define Path:** The path to the WFDB header file (`.hea`) is specified.
 3.  **Load Data:** `Recording.from_file()` is called with the header file path. biosigIO infers the importer (`'wfdb'`) based on the `.hea` extension (this could also be explicitly set using `importer='wfdb'`). The importer reads the header, data, and automatically looks for `100.atr` to load annotations.
-4.  **Access Metadata:** Basic metadata like `record_name` and `sampling_frequency` are accessed using `emg.get_metadata()`.
-5.  **Access Channels:** Information about the loaded channels (`MLII`, `V5`) is iterated through `emg.channels`.
-6.  **Access Annotations:** The script checks if the `emg.events` DataFrame is populated. If the `.atr` file was loaded successfully, it prints the first and last few annotations.
-7.  **Plotting:** A short segment of the first channel is plotted using `emg.plot_signals()`.
-8.  **Exporting:** The loaded data (including annotations) is exported to both EDF+ and BDF+ formats using `emg.to_edf()`. The presence of annotations is noted in the output.
+4.  **Access Metadata:** Basic metadata like `record_name` and `sampling_frequency` are accessed using `rec.get_metadata()`.
+5.  **Access Channels:** Information about the loaded channels (`MLII`, `V5`) is iterated through `rec.channels`.
+6.  **Access Annotations:** The script checks if the `rec.events` DataFrame is populated. If the `.atr` file was loaded successfully, it prints the first and last few annotations.
+7.  **Plotting:** A short segment of the first channel is plotted using `rec.plot_signals()`.
+8.  **Exporting:** The loaded data (including annotations) is exported to both EDF+ and BDF+ formats using `rec.to_edf()`. The presence of annotations is noted in the output.
 
 ## Running the Example
 

--- a/docs/examples/xdf.md
+++ b/docs/examples/xdf.md
@@ -93,8 +93,8 @@ print(f"Channel names: {list(rec.channels.keys())}")
 
 ```python
 # Load only EMG data
-rec_data = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EMG'])
-print(f"EMG channels: {list(rec_data.channels.keys())}")
+emg_data = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EMG'])
+print(f"EMG channels: {list(emg_data.channels.keys())}")
 # Output: ['EMG_L', 'EMG_R']
 
 # Load EEG and EMG together
@@ -107,7 +107,7 @@ print(f"Combined channels: {len(combined.channels)}")
 
 ```python
 # Load specific streams by name
-rec_data = Recording.from_file('examples/multi_stream_test.xdf', stream_names=['TestEMG'])
+emg_data = Recording.from_file('examples/multi_stream_test.xdf', stream_names=['TestEMG'])
 ```
 
 ## Working with Multi-Rate Data

--- a/docs/examples/xdf.md
+++ b/docs/examples/xdf.md
@@ -81,10 +81,10 @@ if mocap:
 from biosigio import Recording
 
 # Load all numeric streams (EEG, EMG, Mocap - excludes Markers)
-emg = Recording.from_file('examples/multi_stream_test.xdf')
+rec = Recording.from_file('examples/multi_stream_test.xdf')
 
-print(f"Total channels: {len(emg.channels)}")
-print(f"Channel names: {list(emg.channels.keys())}")
+print(f"Total channels: {len(rec.channels)}")
+print(f"Channel names: {list(rec.channels.keys())}")
 ```
 
 ## Selective Stream Loading
@@ -93,8 +93,8 @@ print(f"Channel names: {list(emg.channels.keys())}")
 
 ```python
 # Load only EMG data
-emg_data = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EMG'])
-print(f"EMG channels: {list(emg_data.channels.keys())}")
+rec_data = Recording.from_file('examples/multi_stream_test.xdf', stream_types=['EMG'])
+print(f"EMG channels: {list(rec_data.channels.keys())}")
 # Output: ['EMG_L', 'EMG_R']
 
 # Load EEG and EMG together
@@ -107,7 +107,7 @@ print(f"Combined channels: {len(combined.channels)}")
 
 ```python
 # Load specific streams by name
-emg_data = Recording.from_file('examples/multi_stream_test.xdf', stream_names=['TestEMG'])
+rec_data = Recording.from_file('examples/multi_stream_test.xdf', stream_names=['TestEMG'])
 ```
 
 ## Working with Multi-Rate Data
@@ -138,16 +138,16 @@ XDF files contain per-sample LSL timestamps. To preserve these for synchronizati
 
 ```python
 # Load with timestamp channels
-emg = Recording.from_file('examples/multi_stream_test.xdf',
+rec = Recording.from_file('examples/multi_stream_test.xdf',
                     stream_types=['EMG'],
                     include_timestamps=True)
 
 # Each stream gets a timestamp channel
-print(list(emg.channels.keys()))
+print(list(rec.channels.keys()))
 # ['EMG_L', 'EMG_R', 'TestEMG_LSL_timestamps']
 
 # Access the original LSL timestamps
-ts = emg.signals['TestEMG_LSL_timestamps']
+ts = rec.signals['TestEMG_LSL_timestamps']
 print(f"First timestamp: {ts.iloc[0]:.6f}s")
 print(f"Last timestamp: {ts.iloc[-1]:.6f}s")
 ```
@@ -158,16 +158,16 @@ After loading, export to EDF/BDF format:
 
 ```python
 # Load EMG streams with timestamps for synchronization
-emg = Recording.from_file('examples/multi_stream_test.xdf',
+rec = Recording.from_file('examples/multi_stream_test.xdf',
                     stream_types=['EMG'],
                     include_timestamps=True)
 
 # Export to EDF (timestamps are preserved as a channel)
-emg.to_edf('output_emg.edf')
+rec.to_edf('output_emg.edf')
 
 # Verify the export
-emg_reloaded = Recording.from_file('output_emg.edf')
-print(f"Exported channels: {list(emg_reloaded.channels.keys())}")
+rec_reloaded = Recording.from_file('output_emg.edf')
+print(f"Exported channels: {list(rec_reloaded.channels.keys())}")
 ```
 
 ## Complete Workflow Example
@@ -185,18 +185,18 @@ emg_streams = summary.get_streams_by_type('EMG')
 print(f"Found {len(emg_streams)} EMG streams")
 
 # 3. Load selected data
-emg = Recording.from_file('recording.xdf', stream_types=['EMG'])
+rec = Recording.from_file('recording.xdf', stream_types=['EMG'])
 
 # 4. Check loaded data
-print(f"Channels: {list(emg.channels.keys())}")
-print(f"Duration: {emg.signals.index[-1]:.1f}s")
-print(f"Sample rate: {emg.channels[list(emg.channels.keys())[0]]['sample_frequency']} Hz")
+print(f"Channels: {list(rec.channels.keys())}")
+print(f"Duration: {rec.signals.index[-1]:.1f}s")
+print(f"Sample rate: {rec.channels[list(rec.channels.keys())[0]]['sample_frequency']} Hz")
 
 # 5. Plot signals
-emg.plot_signals(time_range=(0, 5))
+rec.plot_signals(time_range=(0, 5))
 
 # 6. Export
-emg.to_edf('emg_export.edf', verify=True)
+rec.to_edf('emg_export.edf', verify=True)
 ```
 
 ## Notes

--- a/docs/formats/csv.md
+++ b/docs/formats/csv.md
@@ -15,13 +15,13 @@ biosigIO provides a flexible CSV importer that can handle a wide variety of CSV-
 from biosigio import Recording
 
 # Basic usage (automatic format detection)
-emg = Recording.from_file('data.csv')
+rec = Recording.from_file('data.csv')
 
 # Force using the generic CSV importer even if specialized format is detected
-emg = Recording.from_file('data.csv', importer='csv', force_csv=True)
+rec = Recording.from_file('data.csv', importer='csv', force_csv=True)
 
 # Specify custom parameters
-emg = Recording.from_file('data.csv', importer='csv', 
+rec = Recording.from_file('data.csv', importer='csv', 
                    sample_frequency=1000,  # Required if no time column
                    has_header=True,        # Whether file has header row
                    delimiter=',',          # Column delimiter
@@ -57,7 +57,7 @@ The CSV importer accepts many customization parameters:
 # 0.001,0.2,0.3,0.4
 # ...
 
-emg = Recording.from_file('data.csv', importer='csv')
+rec = Recording.from_file('data.csv', importer='csv')
 ```
 
 ### Headerless CSV with Custom Names
@@ -68,7 +68,7 @@ emg = Recording.from_file('data.csv', importer='csv')
 # 0.2,0.3,0.4
 # ...
 
-emg = Recording.from_file('data.csv', importer='csv',
+rec = Recording.from_file('data.csv', importer='csv',
                     has_header=False,
                     sample_frequency=1000,  # Required since no time column
                     channel_names=['EMG_L', 'EMG_R', 'ACC_X'])
@@ -77,7 +77,7 @@ emg = Recording.from_file('data.csv', importer='csv',
 ### Setting Channel Types and Units
 
 ```python
-emg = Recording.from_file('data.csv', importer='csv',
+rec = Recording.from_file('data.csv', importer='csv',
                     channel_types={
                         'EMG1': 'EMG',
                         'EMG2': 'EMG',
@@ -94,12 +94,12 @@ emg = Recording.from_file('data.csv', importer='csv',
 
 ```python
 # Only load columns 0 and 2
-emg = Recording.from_file('data.csv', importer='csv',
+rec = Recording.from_file('data.csv', importer='csv',
                     columns=[0, 2],
                     sample_frequency=1000)
 
 # Only load columns named 'EMG1' and 'ACC1'
-emg = Recording.from_file('data.csv', importer='csv',
+rec = Recording.from_file('data.csv', importer='csv',
                     columns=['EMG1', 'ACC1'])
 ```
 

--- a/docs/formats/edf.md
+++ b/docs/formats/edf.md
@@ -71,22 +71,22 @@ The EDF exporter in biosigIO (`biosigio.exporters.edf`) also uses `pyedflib` to:
 from biosigio import Recording
 
 # Import from EDF file
-emg = Recording.from_file('input.edf', importer='edf')
+rec = Recording.from_file('input.edf', importer='edf')
 
 # Print basic information
-print(f"Number of channels: {emg.get_n_channels()}")
-print(f"Sampling frequency: {emg.get_sampling_frequency()} Hz")
-print(f"Recording duration: {emg.get_duration()} seconds")
+print(f"Number of channels: {rec.get_n_channels()}")
+print(f"Sampling frequency: {rec.get_sampling_frequency()} Hz")
+print(f"Recording duration: {rec.get_duration()} seconds")
 
 # Export to EDF/BDF (format selected automatically)
-emg.to_edf('output')  # Will add .edf or .bdf extension automatically
+rec.to_edf('output')  # Will add .edf or .bdf extension automatically
 
 # Force a specific format
-emg.to_edf('output_edf', format='edf')  # Forces 16-bit EDF
-emg.to_edf('output_bdf', format='bdf')  # Forces 24-bit BDF
+rec.to_edf('output_edf', format='edf')  # Forces 16-bit EDF
+rec.to_edf('output_bdf', format='bdf')  # Forces 24-bit BDF
 
 # Export with verification to ensure data integrity 
-emg.to_edf('output_verified', verify=True)
+rec.to_edf('output_verified', verify=True)
 ```
 
 ## Signal Verification
@@ -95,10 +95,10 @@ When exporting EMG data to EDF/BDF format, you can optionally verify the integri
 
 ```python
 # Export with verification
-verification_results = emg.to_edf('output', verify=True)
+verification_results = rec.to_edf('output', verify=True)
 
 # Export with custom verification settings
-verification_results = emg.to_edf(
+verification_results = rec.to_edf(
     'output',
     verify=True,
     verify_tolerance=0.001,  # Absolute tolerance for signal comparison

--- a/docs/formats/eeglab.md
+++ b/docs/formats/eeglab.md
@@ -45,20 +45,20 @@ The EEGLAB importer in biosigIO (`biosigio.importers.eeglab`) works by:
 from biosigio import Recording
 
 # Load data from EEGLAB .set file
-emg = Recording.from_file('data.set', importer='eeglab')
+rec = Recording.from_file('data.set', importer='eeglab')
 
 # Print metadata
-print(f"Subject: {emg.get_metadata('subject')}")
-print(f"Condition: {emg.get_metadata('condition')}")
-print(f"Sampling rate: {emg.get_metadata('srate')} Hz")
+print(f"Subject: {rec.get_metadata('subject')}")
+print(f"Condition: {rec.get_metadata('condition')}")
+print(f"Sampling rate: {rec.get_metadata('srate')} Hz")
 
 # Print channel information
-print(f"Number of channels: {emg.get_n_channels()}")
-channel_types = emg.get_channel_types()
+print(f"Number of channels: {rec.get_n_channels()}")
+channel_types = rec.get_channel_types()
 print(f"Channel types: {channel_types}")
 
 # Plot data
-emg.plot_signals(time_range=(0, 5))
+rec.plot_signals(time_range=(0, 5))
 ```
 
 ## Channel Type Mapping

--- a/docs/formats/otb.md
+++ b/docs/formats/otb.md
@@ -43,22 +43,22 @@ from biosigio import Recording
 import matplotlib.pyplot as plt
 
 # Load data from OTB file
-emg = Recording.from_file('data.otb+', importer='otb')
+rec = Recording.from_file('data.otb+', importer='otb')
 
 # Print device information
-print(f"Device: {emg.get_metadata('device')}")
-print(f"Resolution: {emg.get_metadata('signal_resolution')} bits")
+print(f"Device: {rec.get_metadata('device')}")
+print(f"Resolution: {rec.get_metadata('signal_resolution')} bits")
 
 # Summarize channel types
-channel_types = emg.get_channel_types()
+channel_types = rec.get_channel_types()
 print(f"Channel types: {channel_types}")
 
 for ch_type in channel_types:
-    channels = emg.get_channels_by_type(ch_type)
+    channels = rec.get_channels_by_type(ch_type)
     print(f"{ch_type} channels: {len(channels)}")
 
 # Select only EMG channels
-emg_only = emg.select_channels(channel_type='EMG')
+emg_only = rec.select_channels(channel_type='EMG')
 
 # Plot EMG channels
 emg_only.plot_signals(time_range=(0, 5))

--- a/docs/formats/trigno.md
+++ b/docs/formats/trigno.md
@@ -54,18 +54,18 @@ The Trigno importer in biosigIO (`biosigio.importers.trigno`) processes these fi
 from biosigio import Recording
 
 # Load data from Trigno CSV file
-emg = Recording.from_file('data.csv', importer='trigno')
+rec = Recording.from_file('data.csv', importer='trigno')
 
 # Print identified channel types
-channel_types = emg.get_channel_types()
+channel_types = rec.get_channel_types()
 print(f"Identified channel types: {channel_types}")
 
 # Get EMG channels
-emg_channels = emg.get_channels_by_type('EMG')
+emg_channels = rec.get_channels_by_type('EMG')
 print(f"EMG channels: {emg_channels}")
 
 # Get accelerometer channels
-acc_channels = emg.get_channels_by_type('ACC')
+acc_channels = rec.get_channels_by_type('ACC')
 print(f"ACC channels: {acc_channels}")
 ```
 

--- a/docs/formats/wfdb.md
+++ b/docs/formats/wfdb.md
@@ -18,10 +18,10 @@ To load a WFDB record, provide the path to the **header (`.hea`) file** to `Reco
 from biosigio.core.emg import Recording
 
 # Load using the header file path (extension auto-detected)
-emg = Recording.from_file('path/to/your/record.hea')
+rec = Recording.from_file('path/to/your/record.hea')
 
 # Or load using just the base name (no extension); pass importer explicitly
-# emg = Recording.from_file('record', importer='wfdb')
+# rec = Recording.from_file('record', importer='wfdb')
 ```
 
 biosigIO uses the `wfdb` library (PyPI package `wfdb`) internally. It ships as a core dependency, so no separate installation is required.
@@ -30,7 +30,7 @@ biosigIO uses the `wfdb` library (PyPI package `wfdb`) internally. It ships as a
 
 If an annotation file (e.g., `record.atr`) exists in the same directory and shares the same base name as the header file, the `WFDBImporter` will **automatically load** these annotations.
 
-Loaded annotations are stored in the `emg.events` pandas DataFrame with the following columns:
+Loaded annotations are stored in the `rec.events` pandas DataFrame with the following columns:
 
 - `onset`: The time of the event in seconds from the start of the recording.
 - `duration`: The duration of the event in seconds (typically 0 for standard WFDB point annotations).
@@ -38,4 +38,4 @@ Loaded annotations are stored in the `emg.events` pandas DataFrame with the foll
 
 See the [Metadata Handling](../user-guide/metadata.md#annotations-events) guide for more details on accessing and working with the `events` DataFrame.
 
-If the annotation file is not found, a message will be stored in the `emg.metadata['annotation_status']` field. 
+If the annotation file is not found, a message will be stored in the `rec.metadata['annotation_status']` field. 

--- a/docs/formats/xdf.md
+++ b/docs/formats/xdf.md
@@ -49,7 +49,7 @@ Load all numeric streams from an XDF file:
 from biosigio.core.emg import Recording
 
 # Load all numeric streams (excludes marker/string streams)
-emg = Recording.from_file('recording.xdf')
+rec = Recording.from_file('recording.xdf')
 ```
 
 ### Selective Loading
@@ -58,16 +58,16 @@ XDF files often contain many streams. You can select specific streams:
 
 ```python
 # Load only EMG streams
-emg = Recording.from_file('recording.xdf', stream_types=['EMG'])
+rec = Recording.from_file('recording.xdf', stream_types=['EMG'])
 
 # Load specific stream types
-emg = Recording.from_file('recording.xdf', stream_types=['EMG', 'EXG'])
+rec = Recording.from_file('recording.xdf', stream_types=['EMG', 'EXG'])
 
 # Load by stream name
-emg = Recording.from_file('recording.xdf', stream_names=['MyEMGDevice'])
+rec = Recording.from_file('recording.xdf', stream_names=['MyEMGDevice'])
 
 # Load by stream ID
-emg = Recording.from_file('recording.xdf', stream_ids=[1, 3])
+rec = Recording.from_file('recording.xdf', stream_ids=[1, 3])
 ```
 
 ## Multi-Stream Handling
@@ -80,10 +80,10 @@ When loading multiple streams with different sampling rates, biosigIO:
 
 ```python
 # Load EEG and EMG together (different sample rates)
-emg = Recording.from_file('recording.xdf', stream_types=['EEG', 'EMG'])
+rec = Recording.from_file('recording.xdf', stream_types=['EEG', 'EMG'])
 
 # Channels will be named like: "StreamName_ChannelLabel"
-print(list(emg.channels.keys()))
+print(list(rec.channels.keys()))
 # ['MyEEG_Fp1', 'MyEEG_Fp2', ..., 'MyEMG_Bicep', 'MyEMG_Tricep']
 ```
 
@@ -113,7 +113,7 @@ The XDF importer attempts to infer channel types from:
 
 ```python
 # Set default channel type for streams without explicit type info
-emg = Recording.from_file('recording.xdf', default_channel_type='EMG')
+rec = Recording.from_file('recording.xdf', default_channel_type='EMG')
 ```
 
 ## Metadata
@@ -126,9 +126,9 @@ Loaded XDF files include metadata such as:
 - `srate`: Sampling rate of the reference (highest-rate) stream
 
 ```python
-emg = Recording.from_file('recording.xdf')
-print(emg.get_metadata('stream_count'))
-print(emg.get_metadata('srate'))
+rec = Recording.from_file('recording.xdf')
+print(rec.get_metadata('stream_count'))
+print(rec.get_metadata('srate'))
 ```
 
 ## Preserving LSL Timestamps
@@ -139,10 +139,10 @@ To preserve the original LSL timestamps, use the `include_timestamps` option:
 
 ```python
 # Load with timestamp preservation
-emg = Recording.from_file('recording.xdf', include_timestamps=True)
+rec = Recording.from_file('recording.xdf', include_timestamps=True)
 
 # Each stream gets a timestamp channel named "{stream_name}_LSL_timestamps"
-print(list(emg.channels.keys()))
+print(list(rec.channels.keys()))
 # ['MyEMG_Ch1', 'MyEMG_Ch2', 'MyEMG_LSL_timestamps']
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,16 +62,16 @@ biosigIO simplifies this process by providing a standardized interface for loadi
 from biosigio import Recording
 
 # Load data with automatic format detection, will issue an error to indicate use of the `trigno` importer
-emg = Recording.from_file('data.csv')  # Format detected from file extension
+rec = Recording.from_file('data.csv')  # Format detected from file extension
 
 # Load data with explicit importer
-emg = Recording.from_file('data.csv', importer='trigno')
+rec = Recording.from_file('data.csv', importer='trigno')
 
 # Plot specific channels
-emg.plot_signals(['EMG1', 'EMG2'])
+rec.plot_signals(['EMG1', 'EMG2'])
 
 # Export to EDF/BDF (format automatically determined)
-emg.to_edf('output.edf')  # Extension will be added if not provided
+rec.to_edf('output.edf')  # Extension will be added if not provided
 ```
 
 ## Documentation Structure

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -10,19 +10,19 @@ The main entry point for loading data is the `Recording.from_file()` method. Thi
 from biosigio import Recording
 
 # Automatic importer selection based on file extension
-emg = Recording.from_file('data.csv')  # Will use CSV importer for CSV files
-emg = Recording.from_file('data.edf')  # Will use EDF importer for EDF files
-emg = Recording.from_file('data.set')  # Will use EEGLAB importer for SET files
-emg = Recording.from_file('data.otb')  # Will use OTB importer for OTB files
-emg = Recording.from_file('data.hea')  # Will use WFDB importer for WFDB files
+rec = Recording.from_file('data.csv')  # Will use CSV importer for CSV files
+rec = Recording.from_file('data.edf')  # Will use EDF importer for EDF files
+rec = Recording.from_file('data.set')  # Will use EEGLAB importer for SET files
+rec = Recording.from_file('data.otb')  # Will use OTB importer for OTB files
+rec = Recording.from_file('data.hea')  # Will use WFDB importer for WFDB files
 
 # Explicit importer selection
-emg = Recording.from_file('data.csv', importer='trigno')
-emg = Recording.from_file('data.set', importer='eeglab')
-emg = Recording.from_file('data.otb+', importer='otb')
-emg = Recording.from_file('data.edf', importer='edf')
-emg = Recording.from_file('data.csv', importer='csv')  # Generic CSV importer
-emg = Recording.from_file('data.hea', importer='wfdb')  # WFDB importer
+rec = Recording.from_file('data.csv', importer='trigno')
+rec = Recording.from_file('data.set', importer='eeglab')
+rec = Recording.from_file('data.otb+', importer='otb')
+rec = Recording.from_file('data.edf', importer='edf')
+rec = Recording.from_file('data.csv', importer='csv')  # Generic CSV importer
+rec = Recording.from_file('data.hea', importer='wfdb')  # WFDB importer
 ```
 
 ### Automatic File Type Inference
@@ -49,7 +49,7 @@ For CSV files with specialized formats like Trigno, the generic CSV importer wil
 
 ```python
 # Force using the generic CSV importer even for specialized formats
-emg = Recording.from_file('trigno_data.csv', importer='csv', force_csv=True)
+rec = Recording.from_file('trigno_data.csv', importer='csv', force_csv=True)
 ```
 
 See the [Generic CSV Format](../formats/csv.md) documentation for more details on CSV import options.
@@ -60,13 +60,13 @@ Once you've loaded data, you can access the signals and metadata:
 
 ```python
 # Access raw signal data (returns a pandas DataFrame)
-signals = emg.signals
+signals = rec.signals
 
 # Get information about channels
-channels = emg.channels
+channels = rec.channels
 
 # Get metadata
-device = emg.get_metadata('device')
+device = rec.get_metadata('device')
 ```
 
 ## Plotting Signals
@@ -75,16 +75,16 @@ biosigIO provides methods to visualize the EMG signals:
 
 ```python
 # Plot all channels
-emg.plot_signals()
+rec.plot_signals()
 
 # Plot specific channels
-emg.plot_signals(['EMG1', 'EMG2'])
+rec.plot_signals(['EMG1', 'EMG2'])
 
 # Plot with time range (in seconds)
-emg.plot_signals(time_range=(0, 5))
+rec.plot_signals(time_range=(0, 5))
 
 # Customize plot
-emg.plot_signals(
+rec.plot_signals(
     channels=['EMG1', 'EMG2'],
     time_range=(0, 5),
     title='EMG Signals',
@@ -102,7 +102,7 @@ When exporting and reimporting data, you might want to verify that the signals r
 ```python
 # Method 1: Integrated verification during export
 # Export to EDF with automatic verification
-verification_results = emg_original.to_edf('output', verify=True)
+verification_results = rec_original.to_edf('output', verify=True)
 
 # Method 2: Manual verification with more control
 from biosigio.analysis.verification import compare_signals, report_verification_results
@@ -110,16 +110,16 @@ from biosigio.visualization.static import plot_comparison
 import matplotlib.pyplot as plt
 
 # Export to EDF and reload
-emg_original.to_edf('output')
-emg_reloaded = Recording.from_file('output.edf')
+rec_original.to_edf('output')
+rec_reloaded = Recording.from_file('output.edf')
 
 # Compare signals
-results = compare_signals(emg_original, emg_reloaded)
+results = compare_signals(rec_original, rec_reloaded)
 is_identical = report_verification_results(results, verify_tolerance=0.01)
 print(f"Verification {'passed' if is_identical else 'failed'}")
 
 # Visual verification
-plot_comparison(emg_original, emg_reloaded, channels=['EMG1', 'EMG2'])
+plot_comparison(rec_original, rec_reloaded, channels=['EMG1', 'EMG2'])
 plt.show()
 ```
 
@@ -131,18 +131,18 @@ biosigIO can export data to EDF/BDF formats:
 
 ```python
 # Export to EDF or BDF (format selected automatically)
-emg.to_edf('output')  # Extension (.edf/.bdf) will be added automatically
+rec.to_edf('output')  # Extension (.edf/.bdf) will be added automatically
 
 # Force EDF format
-emg.to_edf('output', format='edf')
+rec.to_edf('output', format='edf')
 
 # Force BDF format
-emg.to_edf('output', format='bdf')
+rec.to_edf('output', format='bdf')
 
 # Control the analysis method for format selection
-emg.to_edf('output', method='svd')  # Use SVD analysis only
-emg.to_edf('output', method='fft')  # Use FFT analysis only
-emg.to_edf('output', method='both')  # Use both methods (default)
+rec.to_edf('output', method='svd')  # Use SVD analysis only
+rec.to_edf('output', method='fft')  # Use FFT analysis only
+rec.to_edf('output', method='both')  # Use both methods (default)
 ```
 
 ## Next Steps

--- a/docs/user-guide/channel-selection.md
+++ b/docs/user-guide/channel-selection.md
@@ -8,10 +8,10 @@ Before selecting channels, you may want to explore the available channels:
 
 ```python
 # Get a dictionary of all channels and their properties
-channels = emg.channels
+channels = rec.channels
 
 # Print channel information
-for ch_name, ch_info in emg.channels.items():
+for ch_name, ch_info in rec.channels.items():
     print(f"Channel: {ch_name}")
     print(f"  Type: {ch_info['channel_type']}")
     print(f"  Unit: {ch_info['physical_dimension']}")
@@ -24,11 +24,11 @@ You can create a new Recording object with only the channels you specify:
 
 ```python
 # Select specific channels by name
-subset_emg = emg.select_channels(['EMG1', 'EMG2', 'ACC1'])
+subset_rec = rec.select_channels(['EMG1', 'EMG2', 'ACC1'])
 
 # The original Recording object remains unchanged
-print(f"Original channels: {len(emg.channels)}")
-print(f"Selected channels: {len(subset_emg.channels)}")
+print(f"Original channels: {len(rec.channels)}")
+print(f"Selected channels: {len(subset_rec.channels)}")
 ```
 
 ## Selecting Channels by Type
@@ -37,18 +37,18 @@ biosigIO allows you to select channels based on their type:
 
 ```python
 # Get available channel types
-channel_types = emg.get_channel_types()
+channel_types = rec.get_channel_types()
 print(f"Available channel types: {channel_types}")
 
 # Get channel names of a specific type
-emg_channels = emg.get_channels_by_type('EMG')
+emg_channels = rec.get_channels_by_type('EMG')
 print(f"EMG channels: {emg_channels}")
-acc_channels = emg.get_channels_by_type('ACC')
+acc_channels = rec.get_channels_by_type('ACC')
 print(f"ACC channels: {acc_channels}")
 
 # Select all channels of a specific type
-emg_only = emg.select_channels(channel_type='EMG')
-acc_only = emg.select_channels(channel_type='ACC')
+emg_only = rec.select_channels(channel_type='EMG')
+acc_only = rec.select_channels(channel_type='ACC')
 ```
 
 ## Selecting Channels by Regular Expression
@@ -60,8 +60,8 @@ import re
 
 # Select all EMG channels with numbers 1-5
 pattern = re.compile(r'EMG[1-5]')
-selected_channels = [ch for ch in emg.channels if pattern.match(ch)]
-subset_emg = emg.select_channels(selected_channels)
+selected_channels = [ch for ch in rec.channels if pattern.match(ch)]
+subset_rec = rec.select_channels(selected_channels)
 ```
 
 ## Working with Selected Channels
@@ -70,10 +70,10 @@ After selecting channels, you can work with the new Recording object just like t
 
 ```python
 # Plot the selected channels
-subset_emg.plot_signals()
+subset_rec.plot_signals()
 
 # Export only the selected channels
-subset_emg.to_edf('output_subset')
+subset_rec.to_edf('output_subset')
 ```
 
 ## Combining Selection Methods
@@ -82,18 +82,18 @@ You can combine different selection methods for more complex filtering:
 
 ```python
 # Get all EMG channels
-emg_channels = emg.get_channels_by_type('EMG')
+emg_channels = rec.get_channels_by_type('EMG')
 
 # Filter to only include those from a specific muscle group
 bicep_channels = [ch for ch in emg_channels if 'Bicep' in ch]
 
 # Create a new Recording object with just these channels
-bicep_emg = emg.select_channels(bicep_channels)
+bicep_rec = rec.select_channels(bicep_channels)
 ```
 
 ## Channel Selection Best Practices
 
-- Always verify the selected channels by checking `emg.channels` after selection
+- Always verify the selected channels by checking `rec.channels` after selection
 - When working with multiple EMG devices, use channel selection to group channels by device
 - For large datasets, selecting only necessary channels can improve performance
 - Consider creating utility functions for commonly used channel selections in your workflow 

--- a/docs/user-guide/channel-selection.md
+++ b/docs/user-guide/channel-selection.md
@@ -24,11 +24,11 @@ You can create a new Recording object with only the channels you specify:
 
 ```python
 # Select specific channels by name
-subset_rec = rec.select_channels(['EMG1', 'EMG2', 'ACC1'])
+subset_emg = rec.select_channels(['EMG1', 'EMG2', 'ACC1'])
 
 # The original Recording object remains unchanged
 print(f"Original channels: {len(rec.channels)}")
-print(f"Selected channels: {len(subset_rec.channels)}")
+print(f"Selected channels: {len(subset_emg.channels)}")
 ```
 
 ## Selecting Channels by Type
@@ -61,7 +61,7 @@ import re
 # Select all EMG channels with numbers 1-5
 pattern = re.compile(r'EMG[1-5]')
 selected_channels = [ch for ch in rec.channels if pattern.match(ch)]
-subset_rec = rec.select_channels(selected_channels)
+subset_emg = rec.select_channels(selected_channels)
 ```
 
 ## Working with Selected Channels
@@ -70,10 +70,10 @@ After selecting channels, you can work with the new Recording object just like t
 
 ```python
 # Plot the selected channels
-subset_rec.plot_signals()
+subset_emg.plot_signals()
 
 # Export only the selected channels
-subset_rec.to_edf('output_subset')
+subset_emg.to_edf('output_subset')
 ```
 
 ## Combining Selection Methods
@@ -88,7 +88,7 @@ emg_channels = rec.get_channels_by_type('EMG')
 bicep_channels = [ch for ch in emg_channels if 'Bicep' in ch]
 
 # Create a new Recording object with just these channels
-bicep_rec = rec.select_channels(bicep_channels)
+bicep_emg = rec.select_channels(bicep_channels)
 ```
 
 ## Channel Selection Best Practices

--- a/docs/user-guide/edf-bdf-selection.md
+++ b/docs/user-guide/edf-bdf-selection.md
@@ -59,19 +59,19 @@ You can control the format selection process when exporting:
 
 ```python
 # Use both methods (default)
-emg.to_edf('output', method='both')
+rec.to_edf('output', method='both')
 
 # Use only SVD analysis
-emg.to_edf('output', method='svd', svd_rank=None)  # Auto threshold
-emg.to_edf('output', method='svd', svd_rank=5)     # Manual threshold
+rec.to_edf('output', method='svd', svd_rank=None)  # Auto threshold
+rec.to_edf('output', method='svd', svd_rank=5)     # Manual threshold
 
 # Use only FFT analysis
-emg.to_edf('output', method='fft', fft_noise_range=None)    # Auto range
-emg.to_edf('output', method='fft', fft_noise_range=(0.1, 10))  # Manual range
+rec.to_edf('output', method='fft', fft_noise_range=None)    # Auto range
+rec.to_edf('output', method='fft', fft_noise_range=(0.1, 10))  # Manual range
 
 # Force a specific format
-emg.to_edf('output', format='edf')  # Force EDF (16-bit)
-emg.to_edf('output', format='bdf')  # Force BDF (24-bit)
+rec.to_edf('output', format='edf')  # Force EDF (16-bit)
+rec.to_edf('output', format='bdf')  # Force BDF (24-bit)
 ```
 
 ## Understanding the Output

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -10,19 +10,19 @@ When you load data into biosigIO, any available metadata from the source file is
 
 ```python
 # Load data
-emg = Recording.from_file('data.set', importer='eeglab')
+rec = Recording.from_file('data.set', importer='eeglab')
 
 # Access all metadata
-all_metadata = emg.metadata
+all_metadata = rec.metadata
 print(all_metadata)
 
 # Access specific metadata field
-subject = emg.get_metadata('subject')
+subject = rec.get_metadata('subject')
 print(f"Subject: {subject}")
 
 # Check if a metadata field exists
-if emg.has_metadata('condition'):
-    condition = emg.get_metadata('condition')
+if rec.has_metadata('condition'):
+    condition = rec.get_metadata('condition')
     print(f"Condition: {condition}")
 ```
 
@@ -30,26 +30,26 @@ You can access the general metadata dictionary directly or use helper methods:
 
 ```python
 # Access the entire metadata dictionary
-all_metadata = emg.metadata
+all_metadata = rec.metadata
 print(all_metadata)
 
 # Get a specific metadata value
-subject_id = emg.get_metadata('subject')
-fs = emg.get_metadata('sampling_frequency')
+subject_id = rec.get_metadata('subject')
+fs = rec.get_metadata('sampling_frequency')
 print(f"Subject: {subject_id}, Fs: {fs}")
 
 # Set or update a metadata value
-emg.set_metadata('task', 'Isometric Contraction')
+rec.set_metadata('task', 'Isometric Contraction')
 ```
 
-The specific keys available in `emg.metadata` depend on the data format and the information present in the source file header. Common keys might include `sampling_frequency`, `subject_id`, `recording_date`, device information, etc.
+The specific keys available in `rec.metadata` depend on the data format and the information present in the source file header. Common keys might include `sampling_frequency`, `subject_id`, `recording_date`, device information, etc.
 
 ## Channel-Specific Information
 
-Information specific to each channel (like its type, physical dimension/unit, or prefiltering details) is stored within the `emg.channels` dictionary, keyed by the channel label:
+Information specific to each channel (like its type, physical dimension/unit, or prefiltering details) is stored within the `rec.channels` dictionary, keyed by the channel label:
 
 ```python
-for channel_name, channel_info in emg.channels.items():
+for channel_name, channel_info in rec.channels.items():
     print(f"Channel: {channel_name}")
     print(f"  Type: {channel_info.get('channel_type', 'N/A')}")
     print(f"  Unit: {channel_info.get('physical_dimension', 'N/A')}")
@@ -57,13 +57,13 @@ for channel_name, channel_info in emg.channels.items():
     print(f"  Prefilter: {channel_info.get('prefilter', 'N/A')}")
 
 # Access info for a specific channel
-emg1_info = emg.channels['EMG1']
+emg1_info = rec.channels['EMG1']
 print(f"EMG1 Unit: {emg1_info['physical_dimension']}")
 ```
 
 ## Annotations / Events
 
-Time-stamped annotations or events associated with the recording are stored in the `emg.events` attribute as a pandas DataFrame.
+Time-stamped annotations or events associated with the recording are stored in the `rec.events` attribute as a pandas DataFrame.
 
 This DataFrame has the following standard columns:
 
@@ -73,22 +73,22 @@ This DataFrame has the following standard columns:
 
 **Loading Annotations:**
 
-*   **EDF/BDF:** Annotations stored in the EDF+/BDF+ annotation channel are automatically loaded into `emg.events` by the `EDFImporter`.
-*   **WFDB:** Annotations stored in a corresponding `.atr` (or similar) file are automatically loaded into `emg.events` by the `WFDBImporter` when loading the `.hea` file.
-*   **EEGLAB `.set`:** EEGLAB events are loaded into `emg.events` by the `EEGLABImporter`; the event latency/duration (samples) are converted to onset/duration in seconds and the event `type` becomes the description.
+*   **EDF/BDF:** Annotations stored in the EDF+/BDF+ annotation channel are automatically loaded into `rec.events` by the `EDFImporter`.
+*   **WFDB:** Annotations stored in a corresponding `.atr` (or similar) file are automatically loaded into `rec.events` by the `WFDBImporter` when loading the `.hea` file.
+*   **EEGLAB `.set`:** EEGLAB events are loaded into `rec.events` by the `EEGLABImporter`; the event latency/duration (samples) are converted to onset/duration in seconds and the event `type` becomes the description.
 *   **Other Formats:** For formats that don't have standardized annotation support within the file (like CSV, Trigno, OTB), annotations are typically not loaded automatically. You may need to load them from a separate file and add them manually.
 
 **Accessing Annotations:**
 
 ```python
 # Check if any events were loaded
-if emg.events is not None and not emg.events.empty:
-    print(f"Loaded {len(emg.events)} events.")
+if rec.events is not None and not rec.events.empty:
+    print(f"Loaded {len(rec.events)} events.")
     print("First 5 events:")
-    print(emg.events.head())
+    print(rec.events.head())
 
     # Filter events by description
-    marker_events = emg.events[emg.events['description'].str.contains('Marker')]
+    marker_events = rec.events[rec.events['description'].str.contains('Marker')]
     print("\nMarker Events:")
     print(marker_events)
 else:
@@ -97,19 +97,19 @@ else:
 
 **Adding Annotations Manually:**
 
-You can add events programmatically using the `emg.add_event()` method:
+You can add events programmatically using the `rec.add_event()` method:
 
 ```python
-emg.add_event(onset=10.5, duration=5.0, description="Rest Period")
-emg.add_event(onset=15.5, duration=0.0, description="Stimulus Onset")
+rec.add_event(onset=10.5, duration=5.0, description="Rest Period")
+rec.add_event(onset=15.5, duration=0.0, description="Stimulus Onset")
 
 print("\nEvents after adding manually:")
-print(emg.events)
+print(rec.events)
 ```
 
 **Exporting Annotations:**
 
-When exporting data using `emg.to_edf()`, the events stored in `emg.events` are automatically written to the EDF+/BDF+ annotation channel.
+When exporting data using `rec.to_edf()`, the events stored in `rec.events` are automatically written to the EDF+/BDF+ annotation channel.
 
 ## Setting Metadata
 
@@ -117,15 +117,15 @@ You can add or modify metadata fields:
 
 ```python
 # Set a single metadata field
-emg.set_metadata('subject', 'S001')
+rec.set_metadata('subject', 'S001')
 
 # Set several fields with repeated set_metadata calls
-emg.set_metadata('condition', 'resting')
-emg.set_metadata('experimenter', 'John Doe')
-emg.set_metadata('recording_date', '2023-01-15')
+rec.set_metadata('condition', 'resting')
+rec.set_metadata('experimenter', 'John Doe')
+rec.set_metadata('recording_date', '2023-01-15')
 
 # Or update the metadata dictionary directly
-emg.metadata.update({
+rec.metadata.update({
     'subject': 'S001',
     'condition': 'resting',
     'experimenter': 'John Doe',
@@ -152,7 +152,7 @@ When exporting to EDF/BDF, biosigIO automatically includes metadata in the file 
 
 ```python
 # Export to EDF with metadata
-emg.to_edf('output')
+rec.to_edf('output')
 
 # This will create:
 # - output.edf or output.bdf (depending on format selection)
@@ -174,13 +174,13 @@ When working with multiple Recording objects, you can copy metadata between them
 
 ```python
 # Create a subset with only EMG channels
-emg_only = emg.select_channels(channel_type='EMG')
+emg_only = rec.select_channels(channel_type='EMG')
 
 # Copy all metadata from original to subset
-emg_only.metadata = emg.metadata.copy()
+emg_only.metadata = rec.metadata.copy()
 
 # Or selectively copy metadata
-emg_only.set_metadata('subject', emg.get_metadata('subject'))
+emg_only.set_metadata('subject', rec.get_metadata('subject'))
 ```
 
 ## Best Practices for Metadata

--- a/docs/user-guide/verification.md
+++ b/docs/user-guide/verification.md
@@ -16,16 +16,16 @@ from biosigio import Recording
 from biosigio.analysis.verification import compare_signals, report_verification_results
 
 # Load original data
-emg_original = Recording.from_file('raw_data.csv', importer='trigno')
+rec_original = Recording.from_file('raw_data.csv', importer='trigno')
 
 # Export to EDF/BDF and reload. to_edf auto-selects the extension, so the
 # written file may be exported_data.edf or exported_data.bdf depending on the
 # signal analysis; reload whichever was created.
-emg_original.to_edf('exported_data')
-emg_reloaded = Recording.from_file('exported_data.edf')  # or 'exported_data.bdf'
+rec_original.to_edf('exported_data')
+rec_reloaded = Recording.from_file('exported_data.edf')  # or 'exported_data.bdf'
 
 # Compare signals with detailed metrics
-results = compare_signals(emg_original, emg_reloaded, tolerance=0.01)
+results = compare_signals(rec_original, rec_reloaded, tolerance=0.01)
 
 # Generate a detailed report (logs to the console)
 is_identical = report_verification_results(results, verify_tolerance=0.01)
@@ -53,17 +53,17 @@ from biosigio.visualization.static import plot_comparison
 import matplotlib.pyplot as plt
 
 # Plot comparison of original and reloaded signals
-plot_comparison(emg_original, emg_reloaded)
+plot_comparison(rec_original, rec_reloaded)
 plt.show()
 
 # Plot specific channels only
-plot_comparison(emg_original, emg_reloaded, channels=['EMG1', 'EMG2'])
+plot_comparison(rec_original, rec_reloaded, channels=['EMG1', 'EMG2'])
 plt.show()
 
 # Customize the comparison
 plot_comparison(
-    emg_original,
-    emg_reloaded,
+    rec_original,
+    rec_reloaded,
     channels=['EMG1', 'EMG2'],
     time_range=(0, 5),  # First 5 seconds only
     detrend=True,       # Remove DC offset
@@ -80,7 +80,7 @@ For more detailed verification, you can use the functions in the `verification` 
 from biosigio.analysis.verification import compare_signals, report_verification_results
 
 # Compare signals with detailed metrics
-results = compare_signals(emg_original, emg_reloaded, tolerance=0.01)
+results = compare_signals(rec_original, rec_reloaded, tolerance=0.01)
 
 # Generate a detailed report (logs to the console)
 is_identical = report_verification_results(results, verify_tolerance=0.01)
@@ -105,13 +105,13 @@ channel_map = {
 }
 
 # Compare with channel mapping
-results = compare_signals(emg_original, emg_reloaded, channel_map=channel_map)
+results = compare_signals(rec_original, rec_reloaded, channel_map=channel_map)
 report_verification_results(results, verify_tolerance=0.01)
 
 # Visual comparison with channel mapping
 from biosigio.visualization.static import plot_comparison
 import matplotlib.pyplot as plt
-plot_comparison(emg_original, emg_reloaded, channel_map=channel_map)
+plot_comparison(rec_original, rec_reloaded, channel_map=channel_map)
 plt.show()
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.0.2"
+version = "1.0.3"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
## 1.0.3 — retire the `emg` variable name → `rec` (#89)

The `EMG` class was renamed to `Recording` (1.0.0) and the package is now multimodal, but a leftover local variable named `emg` remained throughout the codebase and docs (`emg = Recording.from_file(...)`, `emg.events`) — misleading, since a `Recording` may hold EEG/MEG/iEEG data. This retires it. Closes #89.

### What changed (945 replacements, 74 files)
- Recording-instance variables/fixtures → `rec` / `rec_*`: bare `emg`, `new_emg`, `empty_emg`/`sample_emg`, `emg_original`/`emg_reloaded`, the `sample_emg_pair*` fixtures, `emg_trigno`/`emg_otb`/`emg_csv`/`emg_edf`/`emg_bdf`/`emg_mixed`/`emg_hdr`/… across importers, exporters, core, analysis, visualization, CLI, bids, tests, and docs.
- The helper `raw_to_emg` → `raw_to_recording` (+ its callers in `meg.py`/`brainvision.py`).

### Kept distinct (NOT renamed)
- The **module path** `biosigio.core.emg` / `from ..core.emg import` / `core/emg.py` (renaming it would break every import).
- The **EMG modality** term: `channel_type="EMG"`, channel names/labels (`EMG1`, `emg{i}_left`), `"EMG_stream"`, prose.
- **Domain** identifiers that hold a signal array / channel list / stream / plot, not a Recording: `emg_only`, `emg_channels`, `emg_data`, `emg_signal`, `emg_stream(s)`, `emg_plot`.

### How + verification
Per-file agent workflow with an explicit rename-map + keep-list (not a blind sed — `emg` collides with the `core.emg` module and `emg{i}_left` labels). Then a residual sweep caught two misses I fixed by hand: **`importers/neo.py`** (omitted from the groups) and three **stale keyword args** in `docs/api/visualization/static.md` (`emg_object=`/`emg_original=`/`emg_reloaded=` → `rec_*`).

- Full suite **397 passed, 4 skipped** (a partial/inconsistent rename would `NameError`); `ty check biosigio` clean (blocking); ruff check + format clean; `mkdocs build --strict` succeeds; residual `emg`-variable sweep clean.

Cosmetic/internal + doc-example consistency; no behavior or public-API change. Gets `/review-pr` (Sonnet) before merge.