### PR TITLE
EEGLAB .fdt + BIDS events.tsv loading (1.1.0)

### DIFF
--- a/biosigio/bids.py
+++ b/biosigio/bids.py
@@ -10,6 +10,7 @@ their real BIDS types (e.g. ``SEEG``) instead of header/label guesses.
 from __future__ import annotations
 
 import logging
+import math
 import os
 from typing import TYPE_CHECKING
 
@@ -164,7 +165,7 @@ def apply_events_tsv(
         except ValueError:
             skipped += 1
             continue
-        if onset != onset:  # NaN
+        if not math.isfinite(onset):  # NaN or +/-inf
             skipped += 1
             continue
         raw_duration = str(row.get("duration", "")).strip()

--- a/biosigio/bids.py
+++ b/biosigio/bids.py
@@ -102,3 +102,96 @@ def apply_channels_tsv(rec: Recording, channels_tsv_path: str) -> int:
                 name,
             )
     return updated
+
+
+def apply_events_tsv(
+    rec: Recording,
+    events_tsv_path: str,
+    *,
+    description_column: str | None = None,
+) -> int:
+    """Replace ``rec.events`` with the authoritative BIDS ``_events.tsv`` list.
+
+    A BIDS ``_events.tsv`` is the curated event table for a recording; it is
+    richer and more reliable than the data file's own markers (e.g. a
+    BrainVision ``.vmrk`` or an EEGLAB event struct), so when it is present it
+    is the source of truth. This loads it into ``rec.events`` as the standard
+    ``onset``/``duration``/``description`` frame, overwriting any
+    importer-loaded events.
+
+    Columns:
+        ``onset`` (required, seconds) and ``duration`` (seconds; ``n/a`` or
+        missing -> ``0.0``) follow the BIDS spec. The ``description`` is taken
+        from ``description_column`` if given, else per row from the first of
+        ``trial_type`` then ``value`` that is present and not ``n/a`` (BIDS
+        names the categorical label ``trial_type`` and the raw marker
+        ``value``; datasets populate one or both). Rows whose ``onset`` is
+        missing or non-numeric are skipped.
+
+    Args:
+        rec: The Recording object to update in place.
+        events_tsv_path: Path to the BIDS ``_events.tsv``.
+        description_column: Force the description to come from this column.
+
+    Returns:
+        The number of events loaded into ``rec.events``.
+    """
+    df = pd.read_csv(events_tsv_path, sep="\t", dtype=str, keep_default_na=False)
+    if "onset" not in df.columns:
+        logging.warning("events.tsv has no 'onset' column: %s", events_tsv_path)
+        return 0
+
+    def _is_na(value: str) -> bool:
+        v = value.strip()
+        return v == "" or v.lower() == "n/a"
+
+    if description_column is not None:
+        if description_column not in df.columns:
+            logging.warning("events.tsv has no %r column: %s", description_column, events_tsv_path)
+            return 0
+        desc_columns = [description_column]
+    else:
+        desc_columns = [c for c in ("trial_type", "value") if c in df.columns]
+
+    onsets: list[float] = []
+    durations: list[float] = []
+    descriptions: list[str] = []
+    skipped = 0
+    for _, row in df.iterrows():
+        raw_onset = str(row["onset"]).strip()
+        try:
+            onset = float(raw_onset)
+        except ValueError:
+            skipped += 1
+            continue
+        if onset != onset:  # NaN
+            skipped += 1
+            continue
+        raw_duration = str(row.get("duration", "")).strip()
+        try:
+            duration = 0.0 if _is_na(raw_duration) else float(raw_duration)
+        except ValueError:
+            duration = 0.0
+        description = "n/a"
+        for col in desc_columns:
+            candidate = str(row.get(col, "")).strip()
+            if not _is_na(candidate):
+                description = candidate
+                break
+        onsets.append(onset)
+        durations.append(duration)
+        descriptions.append(description)
+
+    if skipped:
+        logging.warning(
+            "events.tsv: skipped %d row(s) with missing/non-numeric onset: %s",
+            skipped,
+            events_tsv_path,
+        )
+
+    rec.events = (
+        pd.DataFrame({"onset": onsets, "duration": durations, "description": descriptions})
+        .sort_values(by="onset")
+        .reset_index(drop=True)
+    )
+    return len(onsets)

--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import numpy as np
@@ -227,6 +228,61 @@ class EEGLABImporter(BaseImporter):
         Returns:
             Recording: Recording object containing the loaded data
         """
+        return self._load(filepath)
+
+    @staticmethod
+    def _read_fdt(
+        set_filepath: str, data_field: np.ndarray, metadata: dict[str, Any]
+    ) -> np.ndarray:
+        """Load the signal matrix from a sibling EEGLAB ``.fdt`` float32 file.
+
+        EEGLAB writes the ``[nbchan x pnts x trials]`` matrix to a separate
+        ``.fdt`` in MATLAB column-major order when the data is large; ``EEG.data``
+        then stores only the ``.fdt``'s original (pre-BIDS-rename) filename. The
+        sibling ``.fdt`` next to the ``.set`` is resolved first because BIDS
+        renames the file on disk but not the embedded reference, with the
+        embedded name as a fallback.
+
+        Args:
+            set_filepath: Path to the ``.set`` file being loaded.
+            data_field: The ``EEG.data`` char array holding the ``.fdt`` name.
+            metadata: Extracted header metadata (needs ``nbchan``/``pnts``).
+
+        Returns:
+            The signal matrix as a ``(nbchan, pnts * trials)`` float32 array.
+        """
+        nbchan = int(metadata.get("nbchan", 0))
+        pnts = int(metadata.get("pnts", 0))
+        trials = int(metadata.get("trials", 1)) or 1
+        if nbchan <= 0 or pnts <= 0:
+            raise ValueError(
+                "EEGLAB data is in a separate .fdt file but the .set header is "
+                "missing nbchan/pnts needed to reshape it"
+            )
+        directory = os.path.dirname(set_filepath)
+        sibling = os.path.splitext(set_filepath)[0] + ".fdt"
+        embedded = "".join(np.atleast_1d(data_field).ravel().astype(str)).strip()
+        candidates = [sibling]
+        if embedded:
+            candidates.append(os.path.join(directory, os.path.basename(embedded)))
+        fdt_path = next((p for p in candidates if os.path.isfile(p)), None)
+        if fdt_path is None:
+            raise FileNotFoundError(
+                f"EEGLAB data is in a separate .fdt file but none was found "
+                f"(tried sibling {sibling!r} and embedded name {embedded!r})"
+            )
+        raw = np.fromfile(fdt_path, dtype="<f4")
+        expected = nbchan * pnts * trials
+        if raw.size != expected:
+            raise ValueError(
+                f"{fdt_path} holds {raw.size} float32 samples but the .set header "
+                f"implies {expected} (nbchan {nbchan} x pnts {pnts} x trials {trials})"
+            )
+        # MATLAB stores column-major, so the matrix is (nbchan, samples).
+        return raw.reshape((nbchan, pnts * trials), order="F")
+
+    def _load(self, filepath: str) -> Recording:
+        """Internal loader (see :meth:`load`)."""
         try:
             # Load the .set file
             data = loadmat(filepath)
@@ -270,8 +326,13 @@ class EEGLABImporter(BaseImporter):
 
             # Extract signal data
             if "data" in data and data["data"].size > 0:
-                # Get data array
+                # Get data array. EEGLAB stores large recordings with the signal
+                # matrix in a separate float32 ``.fdt`` file; in that case
+                # ``EEG.data`` holds the ``.fdt`` filename (a char array) rather
+                # than the numeric matrix, so load the sibling ``.fdt`` instead.
                 signal_data = data["data"]
+                if signal_data.dtype.kind in ("U", "S"):
+                    signal_data = self._read_fdt(filepath, signal_data, metadata)
 
                 # Derive the time index in seconds from the sample count. EEGLAB's
                 # `times` field is in milliseconds, so dividing it by srate (the old

--- a/biosigio/tests/test_bids_events_tsv.py
+++ b/biosigio/tests/test_bids_events_tsv.py
@@ -1,0 +1,103 @@
+"""Tests for BIDS events.tsv loading (issue #94).
+
+A BIDS ``_events.tsv`` is the authoritative event table for a recording, richer
+than the data file's own markers. ``bids.apply_events_tsv`` loads it into
+``rec.events`` (the symmetric counterpart of ``apply_channels_tsv``). NO MOCKS:
+uses the real CC0 EEG BIDS fixture and real on-disk TSV files written per test.
+"""
+
+import pathlib
+
+import pytest
+
+from biosigio import Recording
+from biosigio.bids import apply_events_tsv, find_events_tsv
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+EEG_SET = _REPO / "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_eeg.set"
+EEG_EVENTS = _REPO / "examples/bids/eeg/sub-01/eeg/sub-01_task-eyesopen_events.tsv"
+
+
+@pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
+def test_apply_events_tsv_real_fixture():
+    """The real EEG fixture's events.tsv loads with exact onsets/descriptions."""
+    rec = Recording.from_file(str(EEG_SET), importer="eeglab")
+    n = apply_events_tsv(rec, str(EEG_EVENTS))
+    assert n == 3
+    assert rec.events["onset"].tolist() == pytest.approx([0.5, 20.0, 40.0])
+    assert rec.events["duration"].tolist() == pytest.approx([0.0, 0.0, 0.0])
+    assert list(rec.events["description"]) == [
+        "eyes_open_start",
+        "fixation_check",
+        "rest_marker",
+    ]
+
+
+@pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
+def test_apply_events_tsv_replaces_native_events():
+    """events.tsv is authoritative: it overwrites importer-loaded events."""
+    rec = Recording.from_file(str(EEG_SET), importer="eeglab")
+    rec.add_event(onset=999.0, duration=0.0, description="STALE")
+    apply_events_tsv(rec, str(EEG_EVENTS))
+    assert "STALE" not in list(rec.events["description"])
+    assert len(rec.events) == 3
+
+
+@pytest.mark.skipif(not EEG_SET.exists(), reason="EEG BIDS fixture missing")
+def test_find_events_tsv_resolves_sibling():
+    assert find_events_tsv(str(EEG_SET)) is not None
+    assert find_events_tsv("/tmp/nonexistent_eeg.edf") is None
+
+
+def _write_tsv(path: pathlib.Path, text: str) -> None:
+    path.write_text(text)
+
+
+def test_description_prefers_trial_type_then_value(tmp_path):
+    """Per row: trial_type if present and not n/a, else value, else 'n/a'."""
+    rec = Recording()
+    p = tmp_path / "sub-x_events.tsv"
+    _write_tsv(
+        p,
+        "onset\tduration\ttrial_type\tvalue\n"
+        "0.0\t1.0\tgo\tS1\n"  # trial_type wins
+        "1.0\t0\tn/a\tS2\n"  # trial_type n/a -> value
+        "2.0\tn/a\t\tS3\n"  # trial_type empty -> value; duration n/a -> 0.0
+        "3.0\t0\tn/a\tn/a\n",  # both n/a -> 'n/a'
+    )
+    n = apply_events_tsv(rec, str(p))
+    assert n == 4
+    assert list(rec.events["description"]) == ["go", "S2", "S3", "n/a"]
+    assert rec.events["duration"].tolist() == pytest.approx([1.0, 0.0, 0.0, 0.0])
+
+
+def test_description_column_override(tmp_path):
+    rec = Recording()
+    p = tmp_path / "sub-x_events.tsv"
+    _write_tsv(p, "onset\tduration\ttrial_type\tvalue\n0.0\t0\tgo\tS1\n")
+    apply_events_tsv(rec, str(p), description_column="value")
+    assert list(rec.events["description"]) == ["S1"]
+
+
+def test_skips_rows_with_missing_onset(tmp_path):
+    rec = Recording()
+    p = tmp_path / "sub-x_events.tsv"
+    _write_tsv(
+        p,
+        "onset\tduration\tvalue\n"
+        "0.0\t0\tA\n"
+        "n/a\t0\tB\n"  # non-numeric onset -> skipped
+        "2.0\t0\tC\n",
+    )
+    n = apply_events_tsv(rec, str(p))
+    assert n == 2
+    assert list(rec.events["description"]) == ["A", "C"]
+
+
+def test_events_sorted_by_onset(tmp_path):
+    rec = Recording()
+    p = tmp_path / "sub-x_events.tsv"
+    _write_tsv(p, "onset\tduration\tvalue\n5.0\t0\tlate\n1.0\t0\tearly\n")
+    apply_events_tsv(rec, str(p))
+    assert rec.events["onset"].tolist() == pytest.approx([1.0, 5.0])
+    assert list(rec.events["description"]) == ["early", "late"]

--- a/biosigio/tests/test_bids_events_tsv.py
+++ b/biosigio/tests/test_bids_events_tsv.py
@@ -94,6 +94,19 @@ def test_skips_rows_with_missing_onset(tmp_path):
     assert list(rec.events["description"]) == ["A", "C"]
 
 
+def test_skips_rows_with_nonfinite_onset(tmp_path):
+    """inf/-inf onsets are skipped like NaN, not appended and sorted to the end."""
+    rec = Recording()
+    p = tmp_path / "sub-x_events.tsv"
+    _write_tsv(
+        p,
+        "onset\tduration\tvalue\n0.0\t0\tA\ninf\t0\tB\n-inf\t0\tC\nnan\t0\tD\n2.0\t0\tE\n",
+    )
+    n = apply_events_tsv(rec, str(p))
+    assert n == 2
+    assert list(rec.events["description"]) == ["A", "E"]
+
+
 def test_events_sorted_by_onset(tmp_path):
     rec = Recording()
     p = tmp_path / "sub-x_events.tsv"

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -216,6 +216,98 @@ def test_eeglab_event_processing(sample_eeglab_set):
     assert rec.events["onset"].tolist() == pytest.approx(expected_onsets)
 
 
+def _write_set_with_fdt(directory, stem, data, srate, embedded_name):
+    """Write a real EEGLAB .set whose data lives in a sibling float32 .fdt.
+
+    ``data`` is (nbchan, pnts); the .fdt is written MATLAB column-major.
+    ``EEG.data`` stores ``embedded_name`` (the .fdt's original, possibly
+    pre-BIDS-rename name), exercising the sibling-by-path resolution.
+    """
+    nbchan, pnts = data.shape
+    fdt_path = os.path.join(directory, f"{stem}.fdt")
+    data.astype(np.float32).flatten(order="F").tofile(fdt_path)
+    set_path = os.path.join(directory, f"{stem}.set")
+    scipy.io.savemat(
+        set_path,
+        {
+            "setname": np.array(["fdt_test"]),
+            "nbchan": np.array([[nbchan]]),
+            "trials": np.array([[1]]),
+            "pnts": np.array([[pnts]]),
+            "srate": np.array([[srate]]),
+            "xmin": np.array([[0.0]]),
+            "xmax": np.array([[pnts / srate]]),
+            "data": np.array([embedded_name]),  # filename string, not the matrix
+        },
+    )
+    return set_path
+
+
+def test_eeglab_reads_separate_fdt(tmp_path):
+    """A .set whose EEG.data is a .fdt filename loads the sibling .fdt matrix."""
+    rng = np.random.default_rng(0)
+    data = (rng.standard_normal((8, 500)) * 10).astype(np.float32)  # (nbchan, pnts)
+    set_path = _write_set_with_fdt(str(tmp_path), "sub-09_eeg", data, 200, "sub-09_eeg.fdt")
+
+    rec = EEGLABImporter().load(set_path)
+
+    assert rec.signals.shape == (500, 8)  # samples x channels
+    for i, label in enumerate(rec.signals.columns):
+        # Recording stores samples x channels, so column i is data row i.
+        np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)
+
+
+def test_eeglab_fdt_resolves_sibling_despite_renamed_embedded_name(tmp_path):
+    """BIDS renames the .fdt on disk but not EEG.data; the sibling wins."""
+    rng = np.random.default_rng(1)
+    data = (rng.standard_normal((4, 256)) * 5).astype(np.float32)
+    # On-disk sibling is sub-09_task-rest_eeg.fdt, but EEG.data says the
+    # pre-rename "Merged.fdt" (which does not exist) -- the importer must still
+    # find the sibling by the .set path.
+    set_path = _write_set_with_fdt(str(tmp_path), "sub-09_task-rest_eeg", data, 256, "Merged.fdt")
+
+    rec = EEGLABImporter().load(set_path)
+    assert rec.signals.shape == (256, 4)
+    for i, label in enumerate(rec.signals.columns):
+        np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)
+
+
+def test_eeglab_fdt_missing_raises(tmp_path):
+    """A .set pointing at a .fdt with no resolvable file errors clearly."""
+    set_path = os.path.join(str(tmp_path), "sub-09_eeg.set")
+    scipy.io.savemat(
+        set_path,
+        {
+            "nbchan": np.array([[4]]),
+            "trials": np.array([[1]]),
+            "pnts": np.array([[256]]),
+            "srate": np.array([[256]]),
+            "data": np.array(["nowhere.fdt"]),
+        },
+    )
+    with pytest.raises(ValueError, match="separate .fdt"):
+        EEGLABImporter().load(set_path)
+
+
+def test_eeglab_fdt_size_mismatch_raises(tmp_path):
+    """A .fdt whose element count disagrees with the header is rejected."""
+    fdt_path = os.path.join(str(tmp_path), "sub-09_eeg.fdt")
+    np.zeros(8 * 500 - 7, dtype=np.float32).tofile(fdt_path)  # wrong count
+    set_path = os.path.join(str(tmp_path), "sub-09_eeg.set")
+    scipy.io.savemat(
+        set_path,
+        {
+            "nbchan": np.array([[8]]),
+            "trials": np.array([[1]]),
+            "pnts": np.array([[500]]),
+            "srate": np.array([[200]]),
+            "data": np.array(["sub-09_eeg.fdt"]),
+        },
+    )
+    with pytest.raises(ValueError, match="float32 samples"):
+        EEGLABImporter().load(set_path)
+
+
 def test_eeglab_to_edf_export(sample_eeglab_set):
     """Test exporting EEGLAB data to EDF format."""
     importer = EEGLABImporter()

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -219,11 +219,13 @@ def test_eeglab_event_processing(sample_eeglab_set):
 def _write_set_with_fdt(directory, stem, data, srate, embedded_name):
     """Write a real EEGLAB .set whose data lives in a sibling float32 .fdt.
 
-    ``data`` is (nbchan, pnts); the .fdt is written MATLAB column-major.
-    ``EEG.data`` stores ``embedded_name`` (the .fdt's original, possibly
-    pre-BIDS-rename name), exercising the sibling-by-path resolution.
+    ``data`` is (nbchan, pnts) for continuous data or (nbchan, pnts, trials) for
+    epoched data; the .fdt is written MATLAB column-major. ``EEG.data`` stores
+    ``embedded_name`` (the .fdt's original, possibly pre-BIDS-rename name),
+    exercising the sibling-by-path resolution.
     """
-    nbchan, pnts = data.shape
+    nbchan, pnts = data.shape[0], data.shape[1]
+    trials = data.shape[2] if data.ndim == 3 else 1
     fdt_path = os.path.join(directory, f"{stem}.fdt")
     data.astype(np.float32).flatten(order="F").tofile(fdt_path)
     set_path = os.path.join(directory, f"{stem}.set")
@@ -232,7 +234,7 @@ def _write_set_with_fdt(directory, stem, data, srate, embedded_name):
         {
             "setname": np.array(["fdt_test"]),
             "nbchan": np.array([[nbchan]]),
-            "trials": np.array([[1]]),
+            "trials": np.array([[trials]]),
             "pnts": np.array([[pnts]]),
             "srate": np.array([[srate]]),
             "xmin": np.array([[0.0]]),
@@ -270,6 +272,23 @@ def test_eeglab_fdt_resolves_sibling_despite_renamed_embedded_name(tmp_path):
     assert rec.signals.shape == (256, 4)
     for i, label in enumerate(rec.signals.columns):
         np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)
+
+
+def test_eeglab_reads_epoched_fdt(tmp_path):
+    """Epoched (trials > 1) .fdt reshapes to concatenated continuous samples."""
+    rng = np.random.default_rng(2)
+    nbchan, pnts, trials = 4, 100, 3
+    data = (rng.standard_normal((nbchan, pnts, trials)) * 7).astype(np.float32)
+    set_path = _write_set_with_fdt(str(tmp_path), "sub-09_eeg", data, 100, "sub-09_eeg.fdt")
+
+    rec = EEGLABImporter().load(set_path)
+
+    # trials are concatenated: pnts * trials continuous samples per channel.
+    assert rec.signals.shape == (pnts * trials, nbchan)
+    for i, label in enumerate(rec.signals.columns):
+        # Channel i continuous series = [trial0, trial1, trial2] = column-major flatten.
+        expected = data[i].flatten(order="F")
+        np.testing.assert_allclose(rec.signals[label].to_numpy(), expected, rtol=0, atol=1e-5)
 
 
 def test_eeglab_fdt_missing_raises(tmp_path):

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,6 +1,6 @@
 """Version information for biosigIO."""
 
-__version__ = "1.0.3"
+__version__ = "1.1.0"
 __version_info__ = (1, 0, 3)
 
 

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
 __version__ = "1.1.0"
-__version_info__ = (1, 0, 3)
+__version_info__ = (1, 1, 0)
 
 
 def get_version() -> str:

--- a/docs/api/bids.md
+++ b/docs/api/bids.md
@@ -1,9 +1,12 @@
 # BIDS Helpers
 
 Helpers for the Brain Imaging Data Structure (BIDS): locate a sibling
-`_channels.tsv` / `_events.tsv` next to a recording and apply its per-channel
-types/units. Applied automatically by `Recording.from_file` (unless
-`bids_channels="off"`).
+`_channels.tsv` / `_events.tsv` next to a recording, apply its per-channel
+types/units (`apply_channels_tsv`), and load its authoritative event table into
+`rec.events` (`apply_events_tsv`). `apply_channels_tsv` is applied automatically
+by `Recording.from_file` (unless `bids_channels="off"`); `apply_events_tsv` is
+called explicitly when the sidecar events should override the data file's own
+markers.
 
 ## Module Documentation
 

--- a/docs/formats/eeglab.md
+++ b/docs/formats/eeglab.md
@@ -34,7 +34,10 @@ A typical EEGLAB `.set` file contains these fields:
 The EEGLAB importer in biosigIO (`biosigio.importers.eeglab`) works by:
 
 1. Loading the `.set` file using `scipy.io.loadmat` (pre-v7.3, non-HDF5 MAT-files only)
-2. Extracting the EEG structure with signal data and metadata
+2. Extracting the EEG structure with signal data and metadata. When the matrix is
+   stored in a separate float32 `.fdt` file (EEGLAB's default for large
+   recordings, where `EEG.data` holds the `.fdt` filename), the sibling `.fdt`
+   next to the `.set` is loaded and reshaped to `(nbchan, pnts * trials)`
 3. Converting channel information to biosigIO's channel format
 4. Creating appropriate metadata dictionary
 5. Loading event markers into the recording's `events` table (onset/duration in seconds)
@@ -73,6 +76,7 @@ EEGLAB doesn't always explicitly designate channel types. biosigIO's EEGLAB impo
 ## Notes and Limitations
 
 - Only pre-v7.3 (non-HDF5) `.set` files are supported, via `scipy.io.loadmat`; MATLAB v7.3/HDF5 `.set` files are not supported
+- Signal data stored inline in the `.set` or in a separate float32 `.fdt` file is supported; the sibling `.fdt` is resolved by the `.set` path (so BIDS-renamed files load even though `EEG.data` keeps the original `.fdt` name)
 - Event markers are loaded into the `events` table (`rec.events`): EEGLAB event latency/duration (samples) are converted to onset/duration in seconds and the event `type` becomes the description
 - Channel locations (if available) are preserved in the channel information
 - Some EEGLAB-specific information may not be fully preserved in the conversion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.0.3"
+version = "1.1.0"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
Closes #94.

Found while validating BIDS -> Zarr conversion on real OpenNeuro/BIDS datasets. Two gaps blocked faithful conversion of real files; both fixed with real-data tests.

## 1. EEGLAB `.set` with a separate `.fdt` data file
Large EEGLAB recordings store the signal matrix in a separate float32 `.fdt`; `EEG.data` then holds only the `.fdt` filename (a char array), and that embedded name is the pre-BIDS-rename one (e.g. `sub-25_Merged.fdt`, not the on-disk `..._eeg.fdt`). The importer assumed an inline matrix and crashed with `tuple index out of range`, so any multi-GB `.set` (e.g. a 346ch / 3.6M-sample / 5 GB recording) was unconvertible.

- Detect the char-array `EEG.data`, resolve the sibling `.fdt` **by the `.set` path first** (BIDS renames the file, not the embedded reference), fall back to the embedded name.
- Reshape `np.fromfile(<f4)` as `(nbchan, pnts * trials)` MATLAB column-major, with an element-count check vs the header.

## 2. `bids.apply_events_tsv`
We had `apply_channels_tsv` and `find_events_tsv` (locates only) but nothing to load the authoritative BIDS `_events.tsv` into `rec.events`. Files whose native markers are empty but whose events live in the sidecar (e.g. an EMG `.bdf` with no BDF+ annotations) silently produced zero events in the Zarr store.

- `apply_events_tsv(rec, path, description_column=None)`: onset (required), duration (`n/a` -> 0.0), description from `trial_type` then `value` per row; replaces `rec.events`.

## Tests (no mocks)
- `test_eeglab_importer.py`: synthetic `.set`+`.fdt` round-trip (incl. the renamed-embedded-name case), missing-`.fdt` and size-mismatch errors.
- `test_bids_events_tsv.py`: real EEG BIDS fixture end-to-end, plus controlled `trial_type`/`value`/`n/a` fallback, override, onset-skip, and sort cases.

## Verification
408 passed / 4 skipped, `ty check biosigio` clean (blocking), ruff clean, `mkdocs build --strict` ok. Validated end-to-end on real datasets: events round-trip bit-exact (onset diff 0.0, descriptions identical) into the Zarr store.