### PR TITLE
Bound peak memory for large-file Zarr conversion (1.1.1)

### DIFF
--- a/biosigio/exporters/zarr.py
+++ b/biosigio/exporters/zarr.py
@@ -120,40 +120,32 @@ def _resample_channel(
     return y
 
 
-def _quantize_int16(block: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Map a (n_ch, n_time) float block to int16 with per-channel scale/offset.
+def _quantize_int16_channel(row: np.ndarray, index: int = 0) -> tuple[np.ndarray, float, float]:
+    """Map one channel (1-D float) to int16 with scale/offset.
 
-    ``physical = digital * scale + offset``. A constant channel gets scale=1.
-    Non-finite samples (NaN/inf) cannot be represented in int16 and would
-    silently decode to a midrange value, so they are rejected here rather than
-    corrupted -- use ``dtype="float32"`` (which preserves NaN) to keep them.
+    ``physical = digital * scale + offset``. A constant (or empty) channel gets
+    scale=1 and the constant in offset. Non-finite samples (NaN/inf) cannot be
+    represented in int16 and would silently decode to a midrange value, so they
+    are rejected here -- use ``dtype="float32"`` (which preserves NaN) to keep them.
+
+    Operates one channel at a time so the exporter can quantize straight into the
+    output array without materializing a float64 copy of the whole group (#95).
     """
-    n_ch = block.shape[0]
-    scale = np.ones(n_ch, dtype=np.float64)
-    offset = np.zeros(n_ch, dtype=np.float64)
-    out = np.zeros(block.shape, dtype=np.int16)
+    if row.size and not np.all(np.isfinite(row)):
+        raise ValueError(
+            f"Channel index {index} has non-finite (NaN/inf) samples, which int16 storage "
+            "cannot represent without silently corrupting them. Use dtype='float32' "
+            "(preserves NaN) or mask/interpolate the samples before exporting."
+        )
+    pmin = float(np.min(row)) if row.size else 0.0
+    pmax = float(np.max(row)) if row.size else 0.0
+    if pmax == pmin:  # constant (or empty) channel: store the constant in offset
+        return np.zeros(row.shape, dtype=np.int16), 1.0, pmin
     digital_span = _INT16_MAX - _INT16_MIN
-    for i in range(n_ch):
-        row = block[i]
-        if row.size and not np.all(np.isfinite(row)):
-            raise ValueError(
-                f"Channel index {i} has non-finite (NaN/inf) samples, which int16 storage "
-                "cannot represent without silently corrupting them. Use dtype='float32' "
-                "(preserves NaN) or mask/interpolate the samples before exporting."
-            )
-        pmin = float(np.min(row)) if row.size else 0.0
-        pmax = float(np.max(row)) if row.size else 0.0
-        if pmax == pmin:  # constant (or empty) channel: store the constant in offset
-            offset[i] = pmin
-            out[i] = 0
-            continue
-        s = (pmax - pmin) / digital_span
-        o = pmin - _INT16_MIN * s
-        scale[i] = s
-        offset[i] = o
-        digital = np.round((row - o) / s)
-        out[i] = np.clip(digital, _INT16_MIN, _INT16_MAX).astype(np.int16)
-    return out, scale, offset
+    s = (pmax - pmin) / digital_span
+    o = pmin - _INT16_MIN * s
+    digital = np.round((row - o) / s)
+    return np.clip(digital, _INT16_MIN, _INT16_MAX).astype(np.int16), s, o
 
 
 def _build_minmax_pyramid(
@@ -262,16 +254,30 @@ class ZarrExporter:
         for (modality, native_rate), labels in groups.items():
             target_rate = _target_rate(native_rate, modality, rates)
 
-            resampled = []
+            # Stream channels one at a time straight into the output-dtype array.
+            # The previous code held a float64 list of every channel, a float64
+            # vstack copy, and the int16 copy at once (~4.5x the int16 output);
+            # a 5 GB recording peaked at ~26 GB RSS and OOM'd every free CI
+            # runner (#95). n_time is the post-resample length, identical for
+            # every channel in the group (they share native_rate).
+            n_ch = len(labels)
+            n_time = max(0, int(round(len(rec.signals) * target_rate / native_rate)))
+            base = np.empty((n_ch, n_time), dtype=np.int16 if dtype == "int16" else np.float32)
+            scale = np.ones(n_ch, dtype=np.float64)
+            offset = np.zeros(n_ch, dtype=np.float64)
             chan_meta = []
-            for label in labels:
+            for i, label in enumerate(labels):
                 info = rec.channels[label]
                 ctype = str(info.get("channel_type", "MISC")).upper()
                 discrete = ctype in _DISCRETE_TYPES
                 y = _resample_channel(
                     rec.signals[label].values, native_rate, target_rate, discrete=discrete
                 )
-                resampled.append(y)
+                if dtype == "int16":
+                    base[i], scale[i], offset[i] = _quantize_int16_channel(y, i)
+                else:
+                    base[i] = y.astype(np.float32)
+                del y
                 chan_meta.append(
                     {
                         "label": label,
@@ -285,21 +291,11 @@ class ZarrExporter:
                         "target_rate": float(target_rate),
                         "anti_aliased": bool((not discrete) and target_rate < native_rate),
                         "usable_for_inference": (not discrete),
+                        "scale": float(scale[i]),
+                        "offset": float(offset[i]),
+                        "row_index": i,
                     }
                 )
-            block = np.vstack(resampled).astype(np.float64)
-            n_ch, n_time = block.shape
-
-            if dtype == "int16":
-                base, scale, offset = _quantize_int16(block)
-            else:
-                base = block.astype(np.float32)
-                scale = np.ones(n_ch)
-                offset = np.zeros(n_ch)
-            for i, m in enumerate(chan_meta):
-                m["scale"] = float(scale[i])
-                m["offset"] = float(offset[i])
-                m["row_index"] = i
 
             gname = f"{modality.lower()}_{int(round(target_rate))}hz"
             # Disambiguate the rare collision of two native rates -> same target.

--- a/biosigio/exporters/zarr.py
+++ b/biosigio/exporters/zarr.py
@@ -131,6 +131,9 @@ def _quantize_int16_channel(row: np.ndarray, index: int = 0) -> tuple[np.ndarray
     Operates one channel at a time so the exporter can quantize straight into the
     output array without materializing a float64 copy of the whole group (#95).
     """
+    # Quantize in float64 regardless of the caller's dtype (the old batch path
+    # cast the whole block up front); a no-op for the float64 resample output.
+    row = np.asarray(row, dtype=np.float64)
     if row.size and not np.all(np.isfinite(row)):
         raise ValueError(
             f"Channel index {index} has non-finite (NaN/inf) samples, which int16 storage "

--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -340,25 +340,24 @@ class EEGLABImporter(BaseImporter):
                 # always matches the data length.
                 time_index = np.arange(signal_data.shape[1]) / srate
 
-                # Create DataFrame with time index
-                df = pd.DataFrame(index=time_index)
-
-                # Add channels to Recording object
-                for i, channel_info in enumerate(channel_info_list):
-                    if i < signal_data.shape[0]:  # Make sure we have data for this channel
-                        # Get channel data
-                        channel_data = signal_data[i, :]
-
-                        # Add to DataFrame
-                        channel_label = channel_info.get("label", f"Channel{i + 1}")
-                        df[channel_label] = channel_data
-
-                # Set signals DataFrame
-                rec.signals = df
+                # Build the frame in a single allocation (samples x channels)
+                # rather than assigning one column at a time. The per-column path
+                # reallocates the block manager O(n_channels) times and roughly
+                # doubles peak RAM, which OOMs large / high-channel-count .fdt
+                # recordings (#66, #95); the .fdt's native float32 is preserved so
+                # a multi-GB recording is not silently upcast to float64.
+                n_data_ch = min(len(channel_info_list), signal_data.shape[0])
+                labels = [
+                    channel_info_list[i].get("label", f"Channel{i + 1}") for i in range(n_data_ch)
+                ]
+                rec.signals = pd.DataFrame(
+                    signal_data[:n_data_ch].T, columns=labels, index=time_index, copy=False
+                )
+                del signal_data
 
                 # Add channel information
                 for i, channel_info in enumerate(channel_info_list):
-                    if i < signal_data.shape[0]:  # Make sure we have data for this channel
+                    if i < n_data_ch:  # Make sure we have data for this channel
                         channel_label = channel_info.get("label", f"Channel{i + 1}")
 
                         # Add channel info (no silent EMG default; carry modality)

--- a/biosigio/tests/test_zarr_memory.py
+++ b/biosigio/tests/test_zarr_memory.py
@@ -1,0 +1,75 @@
+"""Memory regression test for the streaming Zarr exporter (issue #95).
+
+The exporter used to hold, per (modality, rate) group, a float64 list of every
+channel plus a float64 ``vstack`` copy plus the int16 copy at once (~4.5x the
+int16 output); a 5 GB recording peaked at ~26 GB RSS and OOM'd every free CI
+runner. The fix streams one channel at a time into a preallocated output-dtype
+array. This test runs a real conversion in a subprocess and asserts the export's
+marginal peak RSS (``ru_maxrss`` delta across ``to_zarr``) is below 1x the
+float64 group size -- the old path needed ~2.25x and would fail. NO MOCKS: real
+synthetic signals, real Zarr write. Skips when the ``zarr`` extra is absent.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("zarr", reason="Zarr serving format requires the optional 'zarr' extra")
+
+# A single MISC group (no modality rate cap -> no resample, n_time == n_in) so
+# the float64 group size is exactly n_ch * n_in * 8. The signals frame is built
+# in one shot so the build's high-water mark does not pollute the export delta.
+_MEASURE = """
+import gc, os, resource, sys, tempfile
+import numpy as np
+import pandas as pd
+from biosigio import Recording
+
+# Large enough that the old float64 double-buffer (~2.25x the group) dwarfs
+# Zarr/Blosc's fixed write buffers, so the delta cleanly reflects the fix.
+N_CH, N_IN = 96, 1_000_000
+rng = np.random.default_rng(0)
+arr = (rng.standard_normal((N_IN, N_CH)) * 100.0).astype(np.float64)
+rec = Recording()
+rec.signals = pd.DataFrame(arr, columns=[f"M{i}" for i in range(N_CH)])
+for i in range(N_CH):
+    rec.channels[f"M{i}"] = {
+        "sample_frequency": 500,
+        "physical_dimension": "uV",
+        "channel_type": "MISC",
+        "modality": "MISC",
+    }
+
+unit = 1 if sys.platform == "darwin" else 1024  # ru_maxrss: bytes on macOS, KiB on Linux
+gc.collect()
+baseline = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * unit
+rec.to_zarr(os.path.join(tempfile.mkdtemp(), "mem"))
+peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * unit
+
+group_bytes = N_CH * N_IN * 8
+print(f"{peak - baseline} {group_bytes}")
+"""
+
+
+def test_zarr_export_peak_memory_bounded():
+    proc = subprocess.run(
+        [sys.executable, "-c", _MEASURE],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr
+    delta_bytes, group_bytes = (int(x) for x in proc.stdout.split())
+    # The streaming export's marginal peak is the int16 output (~0.25x the
+    # float64 group) + the min/max pyramid + Blosc write buffers, measured ~1.2x
+    # the group. The old path held a float64 channel list AND a float64 vstack
+    # copy at once (>=2x the group on top of that). A 1.75x ceiling passes
+    # streaming with headroom and fails if any full float64 copy of the group is
+    # reintroduced (which would push it past ~2.2x). The byte ratio is
+    # hardware-independent.
+    ceiling = int(1.75 * group_bytes)
+    assert delta_bytes < ceiling, (
+        f"export added {delta_bytes / 1e6:.0f} MB (>{ceiling / 1e6:.0f} MB = 1.75x the "
+        f"{group_bytes / 1e6:.0f} MB float64 group); a full-group float64 copy was likely reintroduced"
+    )

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
-__version__ = "1.1.0"
-__version_info__ = (1, 1, 0)
+__version__ = "1.1.1"
+__version_info__ = (1, 1, 1)
 
 
 def get_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
Closes #95.

Converting a 5 GB EEGLAB `.set`+`.fdt` (346ch x 3.6M @ 500 Hz) to Zarr peaked at far more RAM than the data itself, OOM-risking the free GitHub-hosted runners (public `ubuntu-latest` 16 GB, private 8 GB). Profiling showed **two** hogs, both fixed here; conversion now peaks at ~10 GB for that file, fitting the free 16 GB public runner.

## 1. Exporter held a float64 double-buffer (`exporters/zarr.py`)
Per `(modality, native_rate)` group it built a float64 list of every channel, then `np.vstack(...).astype(float64)` (a second full copy), then the int16/`float32` output -- ~4.5x the int16 output materialized at once.

Now preallocate the output-dtype array `(n_ch, n_time)` and resample + quantize **one channel at a time** straight into row `i` (`_quantize_int16_channel`, per-channel scale/offset), dropping the float64 double-buffer. The min/max view pyramid and all round-trip behavior are unchanged.

## 2. Importer built the frame column-by-column (`importers/eeglab.py`)
The signal DataFrame was assembled with one `df[label] = ...` per channel, reallocating the pandas block manager O(n_channels) times (issue #66) and roughly doubling peak RAM; the 346-channel `.fdt` loaded via this path dominated the peak. Now build the frame in a **single allocation** (samples x channels), keep the `.fdt`'s native float32 (no silent upcast to float64), and free the source array.

## Measured (Apple M4 Pro, conversion only: load + to_zarr)
- 5 GB tennis `.set`+`.fdt`: load 5.5 GB (one-shot float32 frame) -> to_zarr peak **10.0 GB**. The float64 double-buffer alone added ~14 GB for the 217-channel group before.
- Round-trip unchanged: 2528 events, three rate groups (`eeg_250hz`/`emg_500hz`/`misc_500hz`), all finite/non-flat.

## Tests
- `test_zarr_memory.py` (new, no mocks): a subprocess builds a one-group recording and asserts the export's marginal peak RSS (`ru_maxrss` delta across `to_zarr`) stays under 1.75x the float64 group -- streaming measures ~1.2x; reintroducing a full float64 copy pushes it past ~2.2x and fails.
- The existing `test_zarr.py` suite (float32 lossless, int16 quant-step, antialias, pyramid, NaN, events, real EMG EDF) guards the refactor's fidelity -- all pass.

## Verification
411 passed / 4 skipped, `ty check biosigio` clean (blocking), ruff clean.

Note: not yet down to the 8 GB private-runner ceiling for the largest files (the full frame must be resident; streaming the import is a larger follow-up). 16 GB public is the target and is met.