### PR TITLE
Unwrap EEG struct so real EEGLAB .set files load

### DIFF
--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -231,6 +231,52 @@ class EEGLABImporter(BaseImporter):
         return self._load(filepath)
 
     @staticmethod
+    def _normalize_eeglab_dict(data: dict[str, Any]) -> dict[str, Any]:
+        """Flatten the two on-disk EEGLAB ``.set`` save forms to one flat dict.
+
+        A real EEGLAB export saves the whole dataset as a single MATLAB struct
+        variable named ``EEG``, so ``scipy.io.loadmat`` returns
+        ``{'EEG': <(1, 1) struct>}`` and every field (``nbchan``, ``data``,
+        ``chanlocs``, ``event``, ...) is nested one level under ``data['EEG']``.
+        Some files (and the synthetic test fixtures) instead store those fields at
+        the top level of the ``.mat`` dict. ``_extract_metadata`` and the
+        signal/channel/event reads in :meth:`_load` expect top-level fields, so
+        this normalizes the nested form to the flat form before either runs and
+        passes the flat form through unchanged.
+
+        For a struct *array* (multiple datasets, shape ``(1, N)``) only the first
+        dataset is used; the rest is currently unsupported. Any non-``EEG``
+        top-level keys (e.g. loadmat's ``__header__``) are preserved so nothing is
+        lost.
+
+        Args:
+            data: The raw mapping returned by ``scipy.io.loadmat``.
+
+        Returns:
+            A flat dict whose EEGLAB fields are at the top level.
+        """
+        eeg = data.get("EEG")
+        if eeg is None:
+            return data
+        eeg = np.asarray(eeg)
+        # Only unwrap a MATLAB struct (it exposes named fields via dtype.names);
+        # a flat-form dict has no "EEG" key, or an "EEG" that is not a struct.
+        names = eeg.dtype.names
+        if names is None or eeg.size == 0:
+            return data
+
+        # A struct array (shape (1, N)) holds several datasets; take the first.
+        record = eeg.ravel()[0]
+
+        flat: dict[str, Any] = {name: record[name] for name in names}
+        # Keep any non-EEG top-level keys (loadmat's __header__/__version__, or a
+        # second variable saved alongside) without letting them clobber EEG fields.
+        for key, value in data.items():
+            if key != "EEG" and key not in flat:
+                flat[key] = value
+        return flat
+
+    @staticmethod
     def _read_fdt(
         set_filepath: str, data_field: np.ndarray, metadata: dict[str, Any]
     ) -> np.ndarray:
@@ -284,8 +330,11 @@ class EEGLABImporter(BaseImporter):
     def _load(self, filepath: str) -> Recording:
         """Internal loader (see :meth:`load`)."""
         try:
-            # Load the .set file
-            data = loadmat(filepath)
+            # Load the .set file. A real EEGLAB export wraps every field in a
+            # single ``EEG`` struct, so unwrap it to the flat top-level form that
+            # the metadata/signal/channel/event reads below expect (a no-op for
+            # files already saved flat).
+            data = self._normalize_eeglab_dict(loadmat(filepath))
 
             # Create Recording object
             rec = Recording()

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -327,6 +327,114 @@ def test_eeglab_fdt_size_mismatch_raises(tmp_path):
         EEGLABImporter().load(set_path)
 
 
+def _nested_eeg_struct(n_channels, n_samples, srate, data_field):
+    """Build the dict a real EEGLAB save produces: one top-level ``EEG`` struct.
+
+    ``scipy.io.savemat(path, {'EEG': {...}})`` writes the whole dataset as a
+    single MATLAB struct variable named ``EEG`` (the real-world form), so on
+    reload every field lands under ``data['EEG']`` rather than at the top level.
+    ``data_field`` is either the numeric matrix (inline data) or the ``.fdt``
+    filename char array.
+    """
+    chanlocs = np.zeros(
+        (1, n_channels),
+        dtype=[("labels", "O"), ("type", "O"), ("X", "O"), ("Y", "O"), ("Z", "O")],
+    )
+    for i in range(n_channels):
+        chanlocs[0, i] = (
+            np.array([f"Ch{i + 1}"]),  # labels
+            np.array([]),  # type (empty -> modality falls back, exercised by ERP CORE)
+            np.array([]),  # X
+            np.array([]),  # Y
+            np.array([]),  # Z
+        )
+
+    events = np.zeros((1, 2), dtype=[("latency", "O"), ("duration", "O"), ("type", "O")])
+    events[0, 0] = (np.array([[100]]), np.array([[0]]), np.array(["stim"]))
+    events[0, 1] = (np.array([[150]]), np.array([[0]]), np.array(["resp"]))
+
+    return {
+        "setname": np.array(["nested_test"]),
+        "nbchan": np.array([[n_channels]]),
+        "trials": np.array([[1]]),
+        "pnts": np.array([[n_samples]]),
+        "srate": np.array([[srate]]),
+        "xmin": np.array([[0.0]]),
+        "xmax": np.array([[n_samples / srate]]),
+        "data": data_field,
+        "chanlocs": chanlocs,
+        "event": events,
+    }
+
+
+def test_eeglab_nested_eeg_struct_inline_data(tmp_path):
+    """A real-form .set ({'EEG': struct}) with inline data loads signals + channels.
+
+    Regression for the bug where _extract_metadata/_load read fields from the
+    loadmat top level, so a real EEGLAB export (everything nested under ``EEG``)
+    silently returned an empty Recording.
+    """
+    n_channels, n_samples, srate = 3, 200, 256
+    rng = np.random.default_rng(0)
+    data = (rng.standard_normal((n_channels, n_samples)) * 10).astype(np.float32)
+    set_path = str(tmp_path / "nested_inline_eeg.set")
+    scipy.io.savemat(set_path, {"EEG": _nested_eeg_struct(n_channels, n_samples, srate, data)})
+
+    rec = EEGLABImporter().load(set_path)
+
+    assert rec.signals is not None
+    assert rec.signals.shape == (n_samples, n_channels)  # samples x channels
+    assert len(rec.channels) == n_channels
+    assert rec.get_metadata("srate") == srate
+    assert rec.get_metadata("nbchan") == n_channels
+    for i, label in enumerate(rec.signals.columns):
+        np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)
+    # Events under the nested struct still parse.
+    assert len(rec.events) == 2
+    assert list(rec.events["description"]) == ["stim", "resp"]
+
+
+def test_eeglab_nested_eeg_struct_with_fdt(tmp_path):
+    """A real-form .set whose EEG.data is a .fdt filename loads the sibling .fdt."""
+    n_channels, n_samples, srate = 3, 200, 256
+    rng = np.random.default_rng(1)
+    data = (rng.standard_normal((n_channels, n_samples)) * 10).astype(np.float32)
+    stem = "sub-01_task-x_eeg"
+    (tmp_path / f"{stem}.fdt").write_bytes(b"")  # placeholder, overwritten below
+    data.flatten(order="F").tofile(str(tmp_path / f"{stem}.fdt"))
+    set_path = str(tmp_path / f"{stem}.set")
+    scipy.io.savemat(
+        set_path,
+        {"EEG": _nested_eeg_struct(n_channels, n_samples, srate, np.array([f"{stem}.fdt"]))},
+    )
+
+    rec = EEGLABImporter().load(set_path)
+
+    assert rec.signals.shape == (n_samples, n_channels)
+    assert len(rec.channels) == n_channels
+    for i, label in enumerate(rec.signals.columns):
+        np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)
+
+
+def test_eeglab_nested_eeg_struct_to_zarr_non_empty(tmp_path):
+    """The full path that was broken: real-form .set -> Recording -> non-empty Zarr store."""
+    pytest.importorskip("zarr", reason="Zarr serving format requires the optional 'zarr' extra")
+    import zarr
+
+    n_channels, n_samples, srate = 4, 500, 256
+    rng = np.random.default_rng(2)
+    data = (rng.standard_normal((n_channels, n_samples)) * 10).astype(np.float32)
+    set_path = str(tmp_path / "nested_zarr_eeg.set")
+    scipy.io.savemat(set_path, {"EEG": _nested_eeg_struct(n_channels, n_samples, srate, data)})
+
+    rec = EEGLABImporter().load(set_path)
+    out = rec.to_zarr(str(tmp_path / "rec"))
+
+    assert os.path.exists(os.path.join(out, "zarr.json"))  # root metadata written
+    root = zarr.open_group(store=zarr.storage.LocalStore(out), mode="r")
+    assert root.attrs["channel_groups"]  # at least one channel group serialized
+
+
 def test_eeglab_to_edf_export(sample_eeglab_set):
     """Test exporting EEGLAB data to EDF format."""
     importer = EEGLABImporter()

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
-__version__ = "1.1.1"
-__version_info__ = (1, 1, 1)
+__version__ = "1.1.2"
+__version_info__ = (1, 1, 2)
 
 
 def get_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
## Problem

`EEGLABImporter` could not load **real** EEGLAB `.set` files. `Recording.from_file('x.set')` returned an **empty** Recording (`signals is None`, 0 channels) **silently**, and a later `rec.to_zarr(...)` then raised `ValueError: No signals loaded`.

Real EEGLAB saves the whole dataset as a single MATLAB struct variable named `EEG`, so `scipy.io.loadmat()` returns `{'EEG': <struct>}` with every field (`nbchan`, `pnts`, `srate`, `data`, `chanlocs`, `event`, `trials`, ...) nested one level under `data['EEG']`. `_extract_metadata` and `_load` read those fields from the **top level**, so on a real file every `if "data" in data` / `if "chanlocs" in data` check was `False` and signals/channels/events were silently skipped. The existing tests only used synthetic **flat-dict** fixtures, so the real-world form was never exercised.

Fixes #99.

## Fix

Add `EEGLABImporter._normalize_eeglab_dict(data)`, called once right after `loadmat()` in `_load`, before both `_extract_metadata` and the signal/channel/event reads. It is robust to **both** `.set` save forms:

- **Nested** `{'EEG': struct}` (real-world EEGLAB): flatten the struct's fields to top level via `{name: record[name] for name in eeg.dtype.names}`. For a struct **array** (multiple datasets, shape `(1, N)`) it takes the first dataset. Non-`EEG` top-level keys (e.g. loadmat's `__header__`) are preserved so nothing is lost.
- **Flat** top-level fields (existing fixtures): passed through unchanged.

The unwrapped struct fields keep the same shapes the existing flat-form reads expect (`nbchan` is `(1, 1)`, `chanlocs` is `(1, N)`, `event` is `(1, M)`, `data` is the numeric matrix or the `.fdt` char array), so the downstream code is untouched.

## Tests (no mocks)

Added three tests building real nested-`{'EEG': struct}` `.set` files with `scipy.io.savemat(path, {'EEG': {...}})`:

- `test_eeglab_nested_eeg_struct_inline_data` — inline numeric matrix; asserts `signals` shape `(samples, channels)`, channel count, `srate`/`nbchan` metadata, exact per-channel values, and the 2 events.
- `test_eeglab_nested_eeg_struct_with_fdt` — `EEG.data` is a `.fdt` filename + sibling `.fdt` written via `tofile`; asserts the sibling matrix loads.
- `test_eeglab_nested_eeg_struct_to_zarr_non_empty` — the originally-broken path end-to-end: real-form `.set` -> Recording -> non-empty Zarr store (root `zarr.json` exists, `channel_groups` non-empty).

The existing flat-form eeglab tests and the real flat-form BIDS fixture test continue to pass (the flat passthrough does not regress).

## Validation against a real file

The real ERP CORE export `sub-006_task-P3_eeg.set` (+ sibling `.fdt`) now loads `signals (335872, 33)`, `channels: 33`, and `to_zarr` produces a valid store (was an empty Recording on `main`).

## Checks

- `uv run pytest` — 414 passed, 4 skipped (full suite); the eeglab + zarr subset: 27 passed.
- `uv run ruff check biosigio` / `ruff format --check` — clean.
- `uv run ty check biosigio` — clean (the package gate; `[tool.ty.src]` excludes `biosigio/tests/**` per #43).

## Why this matters

Unblocks the NEMAR Zarr serving-copy pipeline (nemarOrg/nemar-cli#684) and the biosigIO readiness work (#98): real EEGLAB BIDS datasets can now be converted to the Zarr serving store.

## Known limitation / follow-up (NOT fixed here)

Loading this ERP CORE file produced a channel group named `misc_1024hz` instead of `eeg_...`: the EEGLAB `chanlocs` carried no usable channel `type`, so modality detection fell back to `misc` (and no per-modality rate cap applied). A future change could let the BIDS `channels.tsv` / `_eeg` suffix inform modality. Tracking this separately; it is out of scope for this PR.