### PR TITLE
release: 1.1.3 — citation metadata + doc refresh

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,26 @@
+{
+  "title": "biosigIO",
+  "description": "biosigIO is a Python package with a unified interface for importing biosignal recordings (EEG, EMG, MEG, iEEG) from many acquisition systems and file formats and exporting them to interoperable targets, including EDF/BDF, Parquet/Arrow, and a cloud-native Zarr serving store for interactive viewing and machine-learning streaming.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "BSD-3-Clause",
+  "creators": [
+    {
+      "name": "Shirazi, Seyed Yahya",
+      "orcid": "0000-0001-5557-259X",
+      "affiliation": "Swartz Center for Computational Neuroscience, University of California San Diego"
+    }
+  ],
+  "keywords": [
+    "biosignal",
+    "electrophysiology",
+    "EEG",
+    "EMG",
+    "MEG",
+    "iEEG",
+    "EDF",
+    "BIDS",
+    "Zarr",
+    "signal-processing"
+  ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -22,5 +22,13 @@
     "BIDS",
     "Zarr",
     "signal-processing"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://pypi.org/project/biosigio/",
+      "relation": "isIdenticalTo",
+      "scheme": "url",
+      "resource_type": "software"
+    }
   ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+cff-version: 1.2.0
+message: "If you use biosigIO in your research, please cite it using the metadata below."
+title: biosigIO
+abstract: >-
+  biosigIO is a Python package with a unified interface for importing biosignal
+  recordings (EEG, EMG, MEG, iEEG) from many acquisition systems and file
+  formats and exporting them to interoperable targets, including EDF/BDF,
+  Parquet/Arrow, and a cloud-native Zarr serving store for interactive viewing
+  and machine-learning streaming.
+type: software
+authors:
+  - family-names: Shirazi
+    given-names: Seyed Yahya
+    orcid: "https://orcid.org/0000-0001-5557-259X"
+    # Swartz Center for Computational Neuroscience, UC San Diego (ROR: https://ror.org/01bt2qm76)
+    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego"
+repository-code: "https://github.com/neuromechanist/biosigio"
+url: "https://neuromechanist.github.io/biosigio/"
+license: BSD-3-Clause
+version: 1.1.3
+date-released: "2026-06-03"
+keywords:
+  - biosignal
+  - electrophysiology
+  - EEG
+  - EMG
+  - MEG
+  - iEEG
+  - EDF
+  - BIDS
+  - Zarr
+  - signal-processing
+# After the Zenodo DOI is minted on the v1.1.3 GitHub release, add the concept
+# (all-versions) DOI here so the GitHub "Cite this repository" widget resolves to it:
+# doi: "10.5281/zenodo.XXXXXXX"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.2.0
+cff-version: 1.3.0
 message: "If you use biosigIO in your research, please cite it using the metadata below."
 title: biosigIO
 abstract: >-
@@ -12,8 +12,9 @@ authors:
   - family-names: Shirazi
     given-names: Seyed Yahya
     orcid: "https://orcid.org/0000-0001-5557-259X"
-    # Swartz Center for Computational Neuroscience, UC San Diego (ROR: https://ror.org/01bt2qm76)
-    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego"
+    affiliation:
+      name: "Swartz Center for Computational Neuroscience"
+      ror: "https://ror.org/01bt2qm76"
 repository-code: "https://github.com/neuromechanist/biosigio"
 url: "https://neuromechanist.github.io/biosigio/"
 license: BSD-3-Clause

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
-__version__ = "1.1.2"
-__version_info__ = (1, 1, 2)
+__version__ = "1.1.3"
+__version_info__ = (1, 1, 3)
 
 
 def get_version() -> str:

--- a/docs/formats/eeglab.md
+++ b/docs/formats/eeglab.md
@@ -34,13 +34,19 @@ A typical EEGLAB `.set` file contains these fields:
 The EEGLAB importer in biosigIO (`biosigio.importers.eeglab`) works by:
 
 1. Loading the `.set` file using `scipy.io.loadmat` (pre-v7.3, non-HDF5 MAT-files only)
-2. Extracting the EEG structure with signal data and metadata. When the matrix is
+2. Normalizing the two EEGLAB save forms to a flat field map. Real EEGLAB saves a
+   dataset as a single MATLAB struct named `EEG`, so `loadmat` returns
+   `{'EEG': struct}` with every field nested one level down; the legacy form
+   writes the fields at the top level. biosigIO unwraps the nested `EEG` struct
+   (and accepts the flat form) before reading any field, so a real-world `.set`
+   loads correctly instead of silently importing as an empty recording
+3. Extracting the EEG structure with signal data and metadata. When the matrix is
    stored in a separate float32 `.fdt` file (EEGLAB's default for large
    recordings, where `EEG.data` holds the `.fdt` filename), the sibling `.fdt`
    next to the `.set` is loaded and reshaped to `(nbchan, pnts * trials)`
-3. Converting channel information to biosigIO's channel format
-4. Creating appropriate metadata dictionary
-5. Loading event markers into the recording's `events` table (onset/duration in seconds)
+4. Converting channel information to biosigIO's channel format
+5. Creating appropriate metadata dictionary
+6. Loading event markers into the recording's `events` table (onset/duration in seconds)
 
 ## Code Example
 
@@ -75,6 +81,7 @@ EEGLAB doesn't always explicitly designate channel types. biosigIO's EEGLAB impo
 
 ## Notes and Limitations
 
+- Both EEGLAB save forms load: the standard single `EEG` struct (`loadmat` returns `{'EEG': struct}`, which is what real EEGLAB writes) and the legacy flat layout. The importer normalizes them before reading, so a nested-struct file no longer imports as an empty recording
 - Only pre-v7.3 (non-HDF5) `.set` files are supported, via `scipy.io.loadmat`; MATLAB v7.3/HDF5 `.set` files are not supported
 - Signal data stored inline in the `.set` or in a separate float32 `.fdt` file is supported; the sibling `.fdt` is resolved by the `.set` path (so BIDS-renamed files load even though `EEG.data` keeps the original `.fdt` name)
 - Event markers are loaded into the `events` table (`rec.events`): EEGLAB event latency/duration (samples) are converted to onset/duration in seconds and the event `type` becomes the description

--- a/docs/formats/zarr.md
+++ b/docs/formats/zarr.md
@@ -143,6 +143,10 @@ The root group attributes carry the format tag and version so a reader can recog
 
 A reader should reject a store whose `format_version` is newer than the one it supports rather than guess at an unknown layout. The biosigIO importer does exactly this: it raises if the store's version exceeds the version this build reads.
 
+### Extended attributes
+
+Downstream tools may attach their own attributes to the root group, a modality group, or the `events` group, for example sensor positions, a line-noise frequency, or richer per-code descriptions alongside the `events` group's `label_map`. The biosigIO reader reads only the attributes it defines and ignores any it does not recognize, so these domain-specific extensions are forward-compatible: they enrich the store for a specialized consumer (such as a scalp-topography viewer) without changing the `format_version` or breaking the store contract.
+
 ## Serving model (external)
 
 The viewing, inference, training, and batch-conversion layers live outside biosigIO. biosigIO only writes and reads the store; the sections below summarize the intended serving model so those external consumers can be built against the same contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,26 +4,34 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]
 maintainers = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]
-description = "A Python package for EMG data import/export and manipulation with unified interface for various EMG systems"
+description = "A unified interface to import, convert, and serve biosignal data (EEG, EMG, MEG, iEEG) across formats, including EDF/BDF, EEGLAB, BrainVision, FIF, and a cloud-native Zarr serving store"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 keywords = [
+    "biosignal",
+    "electrophysiology",
+    "eeg",
     "emg",
     "electromyography",
-    "biosignal",
+    "meg",
+    "ieeg",
+    "eeglab",
     "edf",
     "bdf",
+    "brainvision",
     "wfdb",
     "trigno",
     "delsys",
+    "zarr",
+    "bids",
     "neuroscience",
     "signal-processing",
 ]


### PR DESCRIPTION
## 1.1.3 — citation metadata + documentation refresh

Makes biosigIO formally citable (Zenodo-ready) and catches the docs up to the EEGLAB-robustness and Zarr work.

### Citation / DOI
- **`CITATION.cff`** (validated against CFF schema 1.2.0) and **`.zenodo.json`** with ORCID `0000-0001-5557-259X`, affiliation Swartz Center for Computational Neuroscience, UC San Diego (ROR `https://ror.org/01bt2qm76`), BSD-3-Clause.
- GitHub now shows a "Cite this repository" widget. With the Zenodo-GitHub integration enabled, cutting the `v1.1.3` release mints a DOI; the concept (all-versions) DOI then goes into the commented `doi:` line in `CITATION.cff`.

### Version
- `1.1.2` -> `1.1.3` in `biosigio/version.py` + `pyproject.toml` (kept in sync; pre-commit ruff clean).

### Packaging metadata
- Broaden the stale `description` ("EMG data import/export") to the actual scope: import/convert/serve biosignal data (EEG/EMG/MEG/iEEG) across EDF/BDF, EEGLAB, BrainVision, FIF, and the Zarr serving store.
- Add `eeg`, `meg`, `ieeg`, `eeglab`, `brainvision`, `zarr`, `bids` keywords.

### Docs
- `docs/formats/eeglab.md`: document the two-save-form robustness — real EEGLAB nests everything under a single `EEG` struct (`loadmat` returns `{'EEG': struct}`), which the importer now unwraps so real `.set` files no longer load as an empty recording (was #100).
- `docs/formats/zarr.md`: note that downstream tools can attach forward-compatible extended attributes (sensor positions, line-noise frequency, richer event descriptions); the reader ignores unrecognized attributes, so they don't bump `format_version` or break the contract.

No code logic changed beyond the version string.

### Release sequence (after merge)
1. Enable the Zenodo-GitHub integration for `neuromechanist/biosigio`.
2. Cut the `v1.1.3` GitHub release -> `publish.yml` ships to PyPI and Zenodo mints the DOI.
3. Add the concept DOI to `CITATION.cff` (one-line follow-up).
