### PR TITLE
ci: skip Python checks for citation/metadata-only changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,19 +1,25 @@
 name: Lint
 
 on:
-  # Skip lint/type-check for docs-only changes (a mixed code+docs change still runs).
+  # Skip lint/type-check for docs/metadata-only changes (a mixed code change still runs).
   push:
     branches: [ main ]
     paths-ignore:
       - 'docs/**'
       - '**.md'
       - 'mkdocs.yml'
+      - 'CITATION.cff'
+      - '.zenodo.json'
+      - 'LICENSE'
   # Run on every PR regardless of base so stacked/epic PRs get their own CI.
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '**.md'
       - 'mkdocs.yml'
+      - 'CITATION.cff'
+      - '.zenodo.json'
+      - 'LICENSE'
 
 # Cancel superseded runs on the same ref for fast feedback.
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,25 @@
 name: Tests
 
 on:
-  # Skip the test matrix for docs-only changes (a mixed code+docs change still runs).
+  # Skip the test matrix for docs/metadata-only changes (a mixed code change still runs).
   push:
     branches: [ main ]
     paths-ignore:
       - 'docs/**'
       - '**.md'
       - 'mkdocs.yml'
+      - 'CITATION.cff'
+      - '.zenodo.json'
+      - 'LICENSE'
   # Run on every PR regardless of base so stacked/epic PRs get their own CI.
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '**.md'
       - 'mkdocs.yml'
+      - 'CITATION.cff'
+      - '.zenodo.json'
+      - 'LICENSE'
 
 concurrency:
   group: tests-${{ github.ref }}


### PR DESCRIPTION
Extends the existing `paths-ignore` in `tests.yml` and `lint.yml` to also cover `CITATION.cff`, `.zenodo.json`, and `LICENSE`.

PR #101 ran the full Python matrix because it changed `version.py` + `pyproject.toml` (correctly). But a citation/metadata-only change, such as adding the Zenodo concept DOI to `CITATION.cff` after this release, shouldn't spin up the 4-version test matrix + ruff/ty. `paths-ignore` skips only when **every** changed file matches, so any change that also touches code still runs the full suite.

main is not branch-protected, so there's no required-check-blocking concern with skipped runs.