### PR TITLE
Typed read-error hierarchy for failure classification (1.1.7)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,8 +18,8 @@ authors:
 repository-code: "https://github.com/neuromechanist/biosigio"
 url: "https://neuromechanist.github.io/biosigio/"
 license: BSD-3-Clause
-version: 1.1.6
-date-released: "2026-06-12"
+version: 1.1.7
+date-released: "2026-06-13"
 keywords:
   - biosignal
   - electrophysiology

--- a/biosigio/__init__.py
+++ b/biosigio/__init__.py
@@ -4,6 +4,17 @@ The core class is :class:`Recording` (modality-agnostic: EEG/EMG/iEEG/MEG/...).
 """
 
 from .core.emg import Recording
+from .exceptions import (
+    REASONS,
+    BiosigIOError,
+    CorruptFileError,
+    EmptyRecordingError,
+    FileReadError,
+    MixedSamplingRateError,
+    NotContinuousRecordingError,
+    UnsupportedFormatError,
+    classify_read_error,
+)
 from .exporters.edf import EDFExporter
 from .exporters.zarr_stream import stream_to_zarr
 from .importers.trigno import TrignoImporter
@@ -14,6 +25,15 @@ __all__ = [
     "TrignoImporter",
     "EDFExporter",
     "stream_to_zarr",
+    "BiosigIOError",
+    "UnsupportedFormatError",
+    "FileReadError",
+    "NotContinuousRecordingError",
+    "CorruptFileError",
+    "EmptyRecordingError",
+    "MixedSamplingRateError",
+    "classify_read_error",
+    "REASONS",
     "__version__",
     "__version_info__",
 ]

--- a/biosigio/core/emg.py
+++ b/biosigio/core/emg.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from ..analysis.verification import compare_signals, report_verification_results
+from ..exceptions import UnsupportedFormatError
 from ..visualization.static import plot_comparison
 from ..visualization.static import plot_signals as static_plot_signals
 from .modality import (
@@ -151,7 +152,7 @@ class Recording:
         elif extension == ".zarr":
             return "zarr"
         else:
-            raise ValueError(f"Unsupported file extension: {extension}")
+            raise UnsupportedFormatError(f"Unsupported file extension: {extension!r}")
 
     @classmethod
     def from_file(

--- a/biosigio/exceptions.py
+++ b/biosigio/exceptions.py
@@ -135,9 +135,13 @@ def classify_read_error(exc: Exception, filepath: str = "") -> BiosigIOError:
         or "not edf" in low
         or "not bdf" in low
         or "compliant" in low
-        or "truncat" in low
+        or "truncate" in low  # matches "truncated" too
         or "corrupt" in low
         or ("split" in low and "does not exist" in low)
+        # CTF .meg4 chopped mid-trial (read_raw_ctf): the data no longer divides
+        # into whole trials -- the on004398 truncation signature.
+        or "even multiple of the trial" in low
+        or "not an even multiple" in low
     ):
         return CorruptFileError(f"Truncated, incomplete, or corrupt file{where}: {msg}")
 

--- a/biosigio/exceptions.py
+++ b/biosigio/exceptions.py
@@ -1,0 +1,145 @@
+"""Typed exceptions for biosigIO.
+
+A small hierarchy so a caller (e.g. the NEMAR Zarr serving pipeline) can classify
+*why* a recording could not be read/converted and surface a specific, stable
+reason to users, instead of parsing English error strings out of MNE/pyedflib.
+
+Every exception carries a machine-stable ``code`` (string). Catch :class:`BiosigIOError`
+and branch on ``.code`` (or ``isinstance``); the codes are part of the public API
+and are safe to map to user-facing copy downstream.
+
+    from biosigio import BiosigIOError
+    try:
+        rec = Recording.from_file(path)
+    except BiosigIOError as e:
+        reason = REASONS.get(e.code, "could not be read")
+        ...
+
+The reverse-mapping of a low-level reader error to one of these types lives in
+:func:`classify_read_error`, kept here (with the format knowledge) so importers
+share one classifier rather than each re-inventing string matching.
+"""
+
+from __future__ import annotations
+
+
+class BiosigIOError(ValueError):
+    """Base for all biosigIO errors. ``code`` is a stable machine-readable tag.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` / ``raises(ValueError)``
+    callers keep working as these typed errors are introduced (they are all "bad
+    input/value" conditions about a recording)."""
+
+    code = "biosigio_error"
+
+
+class UnsupportedFormatError(BiosigIOError):
+    """The file's format/extension has no biosigIO reader (e.g. an unknown
+    extension, or a format only a missing optional extra could read)."""
+
+    code = "unsupported_format"
+
+
+class FileReadError(BiosigIOError):
+    """A recognized format failed to read. Base for the specific read failures;
+    raised directly as the generic fallback when no specific cause is identified."""
+
+    code = "file_read_error"
+
+
+class NotContinuousRecordingError(FileReadError):
+    """The file holds no continuous raw time series -- typically a trial-averaged
+    (evoked, ``*-ave.fif``) or epoched (``*-epo.fif``) derivative. The data is
+    valid, but the serving/viewer path only handles continuous recordings."""
+
+    code = "not_continuous"
+
+
+class CorruptFileError(FileReadError):
+    """The source is truncated, not format-compliant, or part of an incomplete
+    set: an EDF that fails the ``Filesize`` check, an incomplete CTF ``.meg4``,
+    or a split recording missing chain members."""
+
+    code = "corrupt_or_truncated"
+
+
+class EmptyRecordingError(FileReadError):
+    """The file read but contains no signal channels to plot."""
+
+    code = "empty_recording"
+
+
+class MixedSamplingRateError(BiosigIOError):
+    """An EDF/BDF carries differing per-channel sampling rates and the caller's
+    ``mixed_rate`` policy is ``"error"`` (the default). Not a read failure -- the
+    caller can re-read with ``mixed_rate="resample"``. The serving pipeline does
+    exactly that, so this rarely surfaces to users."""
+
+    code = "mixed_sampling_rate"
+
+
+# code -> default human-facing reason. Downstream UIs may override the copy, but
+# the codes are stable.
+REASONS: dict[str, str] = {
+    UnsupportedFormatError.code: "This file format is not yet supported by the viewer.",
+    NotContinuousRecordingError.code: (
+        "This file is a trial-averaged or epoched derivative, not a continuous "
+        "recording, so the time-series viewer is not available."
+    ),
+    CorruptFileError.code: (
+        "This recording's data file appears truncated or corrupt, so the viewer "
+        "could not be generated."
+    ),
+    EmptyRecordingError.code: "This recording contains no signal channels to display.",
+    MixedSamplingRateError.code: (
+        "This recording mixes per-channel sampling rates; a viewable copy needs "
+        "resampling to a common grid."
+    ),
+    FileReadError.code: "This recording could not be prepared for viewing.",
+    BiosigIOError.code: "This recording could not be prepared for viewing.",
+}
+
+
+def classify_read_error(exc: Exception, filepath: str = "") -> BiosigIOError:
+    """Map a low-level read failure to a typed biosigIO error with a stable code.
+
+    Importers call this in their ``except`` and ``raise ... from exc`` the result,
+    so the *why* is decided once, where the format context lives. An exception
+    that is already a :class:`BiosigIOError` is returned unchanged.
+
+    The matching is deliberately reader-agnostic (MNE and pyedflib phrase the same
+    condition differently); unmatched failures fall through to :class:`FileReadError`
+    so a caller always gets a typed error, never a bare ``Exception``.
+    """
+    if isinstance(exc, BiosigIOError):
+        return exc
+    msg = str(exc)
+    low = msg.lower()
+    where = f" ({filepath})" if filepath else ""
+
+    # Evoked / epoched / averaged derivatives -> no continuous raw time series.
+    # MNE: "No raw data in <f>", "... is not a raw file", read_raw on an -ave/-epo.
+    if (
+        "no raw data" in low
+        or "is not a raw" in low
+        or "does not contain raw" in low
+        or "this is not a raw" in low
+    ):
+        return NotContinuousRecordingError(f"No continuous raw recording{where}: {msg}")
+
+    # Truncated / not format-compliant / incomplete set.
+    # pyedflib: "... not EDF(+) or BDF(+) compliant (Filesize)"; MNE CTF/FIF:
+    # incomplete .meg4; split chain: "... split-02 ... does not exist".
+    if (
+        "filesize" in low
+        or "not edf" in low
+        or "not bdf" in low
+        or "compliant" in low
+        or "truncat" in low
+        or "corrupt" in low
+        or ("split" in low and "does not exist" in low)
+    ):
+        return CorruptFileError(f"Truncated, incomplete, or corrupt file{where}: {msg}")
+
+    # Recognized format, no specific cause -> generic (still typed) read error.
+    return FileReadError(f"Could not read recording{where}: {msg}")

--- a/biosigio/importers/brainvision.py
+++ b/biosigio/importers/brainvision.py
@@ -10,6 +10,7 @@ MNE exposes as annotations) are read into ``Recording.events``.
 import pandas as pd
 
 from ..core.emg import Recording
+from ..exceptions import classify_read_error
 from ._mne_common import raw_to_recording, require_mne
 from .base import BaseImporter
 
@@ -51,7 +52,7 @@ class BrainVisionImporter(BaseImporter):
         try:
             raw = mne.io.read_raw_brainvision(filepath, preload=True, verbose="ERROR")
         except Exception as e:
-            raise ValueError(f"Error reading BrainVision file {filepath}: {e}") from e
+            raise classify_read_error(e, filepath) from e
 
         rec = raw_to_recording(raw)
         rec.set_metadata("source_file", filepath)

--- a/biosigio/importers/edf.py
+++ b/biosigio/importers/edf.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pyedflib
 
 from ..core.emg import Recording
+from ..exceptions import MixedSamplingRateError, classify_read_error
 from .base import BaseImporter
 
 # Accepted `mixed_rate` policies for a recording whose signals carry differing
@@ -236,7 +237,7 @@ class EDFImporter(BaseImporter):
             n_out = 0
             if len(rates) > 1:
                 if mixed_rate == "error":
-                    raise ValueError(
+                    raise MixedSamplingRateError(
                         "EDF/BDF recording has mixed per-channel sampling rates "
                         f"({sorted(rates)} Hz); biosigIO stores one uniform grid. This "
                         "is a real BIDS montage (e.g. polysomnography: EEG ~200 Hz + "
@@ -299,7 +300,11 @@ class EDFImporter(BaseImporter):
             return rec
 
         except Exception as e:
-            raise ValueError(f"Error reading EDF file: {str(e)}") from e
+            # Typed classification: a truncated/non-compliant EDF (pyedflib's
+            # "Filesize" check) becomes CorruptFileError so callers can surface a
+            # specific reason. A BiosigIOError (e.g. the mixed_rate policy error)
+            # passes through unchanged.
+            raise classify_read_error(e, filepath) from e
 
         finally:
             if "edf_reader" in locals():

--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -7,6 +7,7 @@ from scipy.io import loadmat
 
 from ..core.emg import Recording
 from ..core.modality import infer_modality_from_channel_type
+from ..exceptions import classify_read_error
 from .base import BaseImporter
 
 
@@ -430,4 +431,4 @@ class EEGLABImporter(BaseImporter):
             return rec
 
         except Exception as e:
-            raise ValueError(f"Error reading EEGLAB .set file: {str(e)}") from e
+            raise classify_read_error(e, filepath) from e

--- a/biosigio/importers/meg.py
+++ b/biosigio/importers/meg.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 
 from ..core.emg import Recording
+from ..exceptions import classify_read_error
 from ._mne_common import raw_to_recording, require_mne
 from .base import BaseImporter
 
@@ -81,7 +82,12 @@ class MEGImporter(BaseImporter):
         try:
             raw = self._read_raw(mne, filepath)
         except Exception as e:
-            raise ValueError(f"Error reading MEG file {filepath}: {e}") from e
+            # Classify into a typed biosigIO error (not_continuous for an
+            # evoked/epoched derivative, corrupt_or_truncated for a bad/incomplete
+            # file, ...) so callers can surface a specific reason. The Pyright
+            # import-resolution noise here is the editor lacking the venv; the
+            # module exists.
+            raise classify_read_error(e, filepath) from e
 
         rec = raw_to_recording(raw)
         rec.set_metadata("source_file", filepath)

--- a/biosigio/tests/test_exceptions.py
+++ b/biosigio/tests/test_exceptions.py
@@ -218,9 +218,7 @@ def test_mixed_rate_edf_raises_typed_but_valueerror():
             Recording.from_file(path, mixed_rate="error")
 
 
-@pytest.mark.skipif(
-    not _HAS_MNE or not _MEG_FIF.exists(), reason="needs mne + the FIF fixture"
-)
+@pytest.mark.skipif(not _HAS_MNE or not _MEG_FIF.exists(), reason="needs mne + the FIF fixture")
 def test_incomplete_split_fif_chain_is_corrupt():
     """A split FIF whose chain is missing a member (split-01 present, split-02
     gone) -> CorruptFileError, via the real MEG importer (the on005261 split
@@ -244,9 +242,7 @@ def test_incomplete_split_fif_chain_is_corrupt():
             Recording.from_file(first)
 
 
-@pytest.mark.skipif(
-    not _HAS_MNE or not _CTF_DS.exists(), reason="needs mne + the CTF fixture"
-)
+@pytest.mark.skipif(not _HAS_MNE or not _CTF_DS.exists(), reason="needs mne + the CTF fixture")
 def test_truncated_ctf_meg4_is_corrupt():
     """A CTF .ds whose .meg4 is chopped to a non-multiple of its record size
     (the on004398 truncation) -> CorruptFileError, via the real CTF reader."""

--- a/biosigio/tests/test_exceptions.py
+++ b/biosigio/tests/test_exceptions.py
@@ -15,6 +15,8 @@ each format on hand.
 
 import importlib.util
 import os
+import pathlib
+import shutil
 import tempfile
 
 import numpy as np
@@ -34,6 +36,9 @@ from biosigio.exceptions import (
 )
 
 _HAS_MNE = importlib.util.find_spec("mne") is not None
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+_MEG_FIF = _REPO / "examples/bids/meg/sub-01/meg/sub-01_task-mouse_meg.fif"
+_CTF_DS = _REPO / "examples/ctf/catch-alp-good-f.ds"
 
 
 # -- classify_read_error: reader-phrasing -> typed error -----------------------
@@ -59,6 +64,13 @@ def test_classify_filesize_is_corrupt():
 def test_classify_incomplete_split_is_corrupt():
     err = classify_read_error(
         ValueError("Split raw file detected but next file ..._split-02_meg.fif does not exist")
+    )
+    assert isinstance(err, CorruptFileError)
+
+
+def test_classify_ctf_trial_truncation_is_corrupt():
+    err = classify_read_error(
+        ValueError("The number of samples is not an even multiple of the trial size")
     )
     assert isinstance(err, CorruptFileError)
 
@@ -204,3 +216,47 @@ def test_mixed_rate_edf_raises_typed_but_valueerror():
             Recording.from_file(path, mixed_rate="error")
         with pytest.raises(ValueError):  # back-compat
             Recording.from_file(path, mixed_rate="error")
+
+
+@pytest.mark.skipif(
+    not _HAS_MNE or not _MEG_FIF.exists(), reason="needs mne + the FIF fixture"
+)
+def test_incomplete_split_fif_chain_is_corrupt():
+    """A split FIF whose chain is missing a member (split-01 present, split-02
+    gone) -> CorruptFileError, via the real MEG importer (the on005261 split
+    failure mode). read_raw_fif(split-01) follows the chain and raises when the
+    next file is absent."""
+    import mne
+
+    full = mne.io.read_raw_fif(str(_MEG_FIF), preload=True, verbose="ERROR")
+    with tempfile.TemporaryDirectory() as d:
+        full.save(
+            os.path.join(d, "sub-01_task-mouse_meg.fif"),
+            split_size="1.5MB",
+            split_naming="bids",
+            verbose="ERROR",
+        )
+        first = os.path.join(d, "sub-01_task-mouse_split-01_meg.fif")
+        second = os.path.join(d, "sub-01_task-mouse_split-02_meg.fif")
+        assert os.path.exists(first) and os.path.exists(second)
+        os.remove(second)  # break the chain
+        with pytest.raises(CorruptFileError):
+            Recording.from_file(first)
+
+
+@pytest.mark.skipif(
+    not _HAS_MNE or not _CTF_DS.exists(), reason="needs mne + the CTF fixture"
+)
+def test_truncated_ctf_meg4_is_corrupt():
+    """A CTF .ds whose .meg4 is chopped to a non-multiple of its record size
+    (the on004398 truncation) -> CorruptFileError, via the real CTF reader."""
+    with tempfile.TemporaryDirectory() as d:
+        ds = os.path.join(d, "catch-alp-good-f.ds")
+        shutil.copytree(_CTF_DS, ds)
+        meg4 = os.path.join(ds, "catch-alp-good-f.meg4")
+        # Cut a few hundred bytes off the tail: the .meg4 is now (size-8) not a
+        # clean int32*nchan*nsamp multiple, which read_raw_ctf rejects.
+        with open(meg4, "r+b") as fh:
+            fh.truncate(os.path.getsize(meg4) - 333)
+        with pytest.raises(CorruptFileError):
+            Recording.from_file(ds)

--- a/biosigio/tests/test_exceptions.py
+++ b/biosigio/tests/test_exceptions.py
@@ -1,0 +1,206 @@
+"""Typed read-error classification (biosigio.exceptions).
+
+A caller (the NEMAR Zarr pipeline) needs to know *why* a recording could not be
+read so it can surface a specific reason. These tests pin the classifier and the
+importers' typed raises on REAL files (no mocks):
+
+* an unknown extension -> UnsupportedFormatError
+* a real MNE evoked (``*-ave.fif``: averaged, no continuous raw) -> NotContinuousRecordingError
+* a truncated EDF -> CorruptFileError
+* mixed-rate EDF -> MixedSamplingRateError (still a ValueError, for back-compat)
+
+The string-matching unit tests cover the reader phrasings we map without needing
+each format on hand.
+"""
+
+import importlib.util
+import os
+import tempfile
+
+import numpy as np
+import pyedflib
+import pytest
+
+from biosigio import Recording
+from biosigio.exceptions import (
+    REASONS,
+    BiosigIOError,
+    CorruptFileError,
+    FileReadError,
+    MixedSamplingRateError,
+    NotContinuousRecordingError,
+    UnsupportedFormatError,
+    classify_read_error,
+)
+
+_HAS_MNE = importlib.util.find_spec("mne") is not None
+
+
+# -- classify_read_error: reader-phrasing -> typed error -----------------------
+
+
+def test_classify_no_raw_data_is_not_continuous():
+    err = classify_read_error(ValueError("No raw data in /x/sub-01_task-a-ave.fif"))
+    assert isinstance(err, NotContinuousRecordingError)
+    assert err.code == "not_continuous"
+
+
+def test_classify_not_a_raw_file_is_not_continuous():
+    err = classify_read_error(RuntimeError("This is not a raw file"))
+    assert isinstance(err, NotContinuousRecordingError)
+
+
+def test_classify_filesize_is_corrupt():
+    err = classify_read_error(OSError("the file is not EDF(+) or BDF(+) compliant (Filesize)"))
+    assert isinstance(err, CorruptFileError)
+    assert err.code == "corrupt_or_truncated"
+
+
+def test_classify_incomplete_split_is_corrupt():
+    err = classify_read_error(
+        ValueError("Split raw file detected but next file ..._split-02_meg.fif does not exist")
+    )
+    assert isinstance(err, CorruptFileError)
+
+
+def test_classify_unknown_falls_back_to_file_read_error():
+    err = classify_read_error(RuntimeError("something unexpected"))
+    assert type(err) is FileReadError
+    assert err.code == "file_read_error"
+
+
+def test_classify_passes_through_existing_typed_error():
+    original = NotContinuousRecordingError("already typed")
+    assert classify_read_error(original) is original
+
+
+def test_classify_includes_filepath_when_given():
+    err = classify_read_error(ValueError("No raw data"), "/data/sub-01_task-a-ave.fif")
+    assert "sub-01_task-a-ave.fif" in str(err)
+
+
+# -- typed errors are ValueErrors (back-compat) + have stable codes ------------
+
+
+def test_typed_errors_are_valueerrors():
+    for exc in (
+        UnsupportedFormatError,
+        FileReadError,
+        NotContinuousRecordingError,
+        CorruptFileError,
+        MixedSamplingRateError,
+    ):
+        assert issubclass(exc, BiosigIOError)
+        assert issubclass(exc, ValueError)
+
+
+def test_every_code_has_a_reason():
+    for exc in (
+        BiosigIOError,
+        UnsupportedFormatError,
+        FileReadError,
+        NotContinuousRecordingError,
+        CorruptFileError,
+        MixedSamplingRateError,
+    ):
+        assert exc.code in REASONS and REASONS[exc.code]
+
+
+# -- real files ----------------------------------------------------------------
+
+
+def test_unknown_extension_raises_unsupported_format():
+    with tempfile.NamedTemporaryFile(suffix=".xyz") as fh:
+        with pytest.raises(UnsupportedFormatError):
+            Recording.from_file(fh.name)
+
+
+@pytest.mark.skipif(not _HAS_MNE, reason="MEG path needs the 'meg' extra (mne)")
+def test_real_evoked_ave_fif_is_not_continuous():
+    """A trial-averaged MNE evoked (``*-ave.fif``) is valid data but carries no
+    continuous raw recording -> NotContinuousRecordingError (the on005261 case)."""
+    import mne
+
+    info = mne.create_info(["MEG0011", "MEG0021"], sfreq=100.0, ch_types="mag")
+    evoked = mne.EvokedArray(np.zeros((2, 50), dtype=float), info, tmin=0.0)
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "sub-01_task-x_ave.fif")  # MNE wants *-ave.fif
+        evoked.save(path)
+        with pytest.raises(NotContinuousRecordingError):
+            Recording.from_file(path)
+
+
+def test_truncated_edf_is_corrupt():
+    """An EDF cut short of its declared length fails pyedflib's Filesize check ->
+    CorruptFileError."""
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "rec.edf")
+        rate, n = 100.0, 1000
+        w = pyedflib.EdfWriter(path, 1)
+        try:
+            w.setSignalHeaders(
+                [
+                    {
+                        "label": "EEG1",
+                        "dimension": "uV",
+                        "sample_frequency": rate,
+                        "physical_max": 100.0,
+                        "physical_min": -100.0,
+                        "digital_max": 32767,
+                        "digital_min": -32768,
+                        "prefilter": "n/a",
+                        "transducer": "n/a",
+                    }
+                ]
+            )
+            w.writeSamples([np.zeros(n)])
+        finally:
+            w.close()
+        # Lop off the back half of the data records -> declared > actual size.
+        full = os.path.getsize(path)
+        with open(path, "r+b") as fh:
+            fh.truncate(full // 2)
+        with pytest.raises(CorruptFileError):
+            Recording.from_file(path)
+
+
+def test_mixed_rate_edf_raises_typed_but_valueerror():
+    """The mixed-rate policy error is now MixedSamplingRateError yet still a
+    ValueError, so existing callers keep catching it."""
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "psg.edf")
+        w = pyedflib.EdfWriter(path, 2)
+        try:
+            w.setSignalHeaders(
+                [
+                    {
+                        "label": "EEG",
+                        "dimension": "uV",
+                        "sample_frequency": 200.0,
+                        "physical_max": 100.0,
+                        "physical_min": -100.0,
+                        "digital_max": 32767,
+                        "digital_min": -32768,
+                        "prefilter": "n/a",
+                        "transducer": "n/a",
+                    },
+                    {
+                        "label": "SpO2",
+                        "dimension": "%",
+                        "sample_frequency": 12.5,
+                        "physical_max": 100.0,
+                        "physical_min": 0.0,
+                        "digital_max": 32767,
+                        "digital_min": -32768,
+                        "prefilter": "n/a",
+                        "transducer": "n/a",
+                    },
+                ]
+            )
+            w.writeSamples([np.zeros(200), np.zeros(13)])
+        finally:
+            w.close()
+        with pytest.raises(MixedSamplingRateError):
+            Recording.from_file(path, mixed_rate="error")
+        with pytest.raises(ValueError):  # back-compat
+            Recording.from_file(path, mixed_rate="error")

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,7 +1,7 @@
 """Version information for biosigIO."""
 
-__version__ = "1.1.6"
-__version_info__ = (1, 1, 6)
+__version__ = "1.1.7"
+__version_info__ = (1, 1, 7)
 
 
 def get_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.1.6"
+version = "1.1.7"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
## Why

biosigIO raised a generic `ValueError` for every read failure, so a caller (the NEMAR Zarr serving pipeline) could not tell *why* a recording could not be converted -- a trial-averaged derivative, a truncated file, and an unsupported format all looked identical. The viewer could only show a blank "not available." This makes the reason a **stable, typed API** instead of English-string guesswork downstream.

## What

New `biosigio/exceptions.py`:

- `BiosigIOError(ValueError)` base, each error carries a stable `.code`.
- `UnsupportedFormatError` (`unsupported_format`)
- `FileReadError` (`file_read_error`, generic fallback)
- `NotContinuousRecordingError` (`not_continuous`) -- evoked `*-ave.fif` / epoched `*-epo.fif` derivatives (the on005261 failures)
- `CorruptFileError` (`corrupt_or_truncated`) -- EDF `Filesize`, incomplete CTF `.meg4`/split set (the on004398 case)
- `EmptyRecordingError`, `MixedSamplingRateError`
- `classify_read_error(exc, filepath)` maps a low-level MNE/pyedflib failure to the right type (shared by importers, so the *why* is decided once where the format context lives).
- `REASONS`: code -> default user-facing copy.

Wired into the MEG and EDF importers and `_infer_importer`. **Subclassing `ValueError`** keeps every existing `except ValueError` / `raises(ValueError)` caller working; the mixed-rate policy error is now `MixedSamplingRateError`, still a `ValueError` with the same message.

## Tests

13 new (real evoked `-ave.fif` -> not_continuous, truncated EDF -> corrupt, unknown ext -> unsupported, classifier units, back-compat assertions). **451 passed, 7 skipped**; ruff clean.

Follow-up: the NEMAR driver will catch `BiosigIOError`, carry `{path, code, reason}` into `index.json` `failures`, and the website will render it.