### PR TITLE
Stream EDF/BDF via pyedflib (importer parity) (1.2.0)

### DIFF
--- a/biosigio/exporters/zarr_stream.py
+++ b/biosigio/exporters/zarr_stream.py
@@ -102,13 +102,15 @@ class _MneSource:
         self.channels: list[dict] = []
         for i, name in enumerate(self._raw.ch_names):
             ctype = _MNE_TYPE_TO_biosigIO.get(types[i], "OTHER")
-            self.channels.append({
-                "idx": i,
-                "label": name,
-                "channel_type": ctype,
-                "modality": force_modality or infer_modality_from_channel_type(ctype),
-                "unit": _FIFF_UNIT_TO_DIM.get(int(self._raw.info["chs"][i]["unit"]), "n/a"),
-            })
+            self.channels.append(
+                {
+                    "idx": i,
+                    "label": name,
+                    "channel_type": ctype,
+                    "modality": force_modality or infer_modality_from_channel_type(ctype),
+                    "unit": _FIFF_UNIT_TO_DIM.get(int(self._raw.info["chs"][i]["unit"]), "n/a"),
+                }
+            )
 
     def read(self, picks: list[int], start: int, stop: int) -> np.ndarray:
         return self._raw.get_data(picks=picks, start=start, stop=stop)
@@ -150,19 +152,19 @@ class _EdfSource:
             label = cast(str, h["label"]).strip()
             transducer = cast(str, h.get("transducer", "")).strip()
             ctype = typer(label, transducer)
-            self.channels.append({
-                "idx": i,
-                "label": label,
-                "channel_type": ctype,
-                "modality": force_modality or infer_modality_from_channel_type(ctype),
-                "unit": cast(str, h.get("dimension", "")).strip() or "n/a",
-            })
+            self.channels.append(
+                {
+                    "idx": i,
+                    "label": label,
+                    "channel_type": ctype,
+                    "modality": force_modality or infer_modality_from_channel_type(ctype),
+                    "unit": cast(str, h.get("dimension", "")).strip() or "n/a",
+                }
+            )
 
     def read(self, picks: list[int], start: int, stop: int) -> np.ndarray:
         n = stop - start
-        return np.stack(
-            [self._reader.readSignal(i, start, n) for i in picks]
-        ).astype(np.float64)
+        return np.stack([self._reader.readSignal(i, start, n) for i in picks]).astype(np.float64)
 
     def close(self) -> None:
         self._reader.close()

--- a/biosigio/exporters/zarr_stream.py
+++ b/biosigio/exporters/zarr_stream.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import datetime as _dt
 import os
 import tempfile
+from typing import cast
 
 import numpy as np
 
@@ -73,6 +74,107 @@ def _pyramid_level_lengths(
         lengths.append(n_out)
         n = n_out
     return lengths
+
+
+# --- Lazy stream sources (#944) -----------------------------------------------
+# stream_to_zarr needs, per recording: sfreq, n_samples, and per-channel
+# (label / biosigIO type / unit) metadata, plus windowed float64 blocks. MNE
+# (preload=False) covers .fif/.vhdr/.set/CTF. EDF/BDF go through pyedflib INSTEAD
+# -- biosigIO's in-memory path reads EDF via pyedflib, and MNE disagrees on EDF
+# unit scaling (an EDF whose physical dimension is unknown: MNE assumes Volts,
+# pyedflib keeps the file's dimension), so streaming EDF via MNE would NOT match a
+# re-run on the in-memory path. pyedflib.readSignal(chn, start, n) is numerically
+# identical to readSignal(chn) sliced, so the streamed store matches the in-memory
+# store exactly. (EDF-via-stream is not used in production today, so switching its
+# reader changes no existing store.)
+
+
+class _MneSource:
+    """MNE-backed lazy source for the formats MNE reads faithfully
+    (.fif/.vhdr/.set/CTF)."""
+
+    def __init__(self, filepath: str, force_modality: str | None):
+        mne = require_mne()
+        self._raw = mne.io.read_raw(filepath, preload=False, verbose="ERROR")
+        self.sfreq = float(self._raw.info["sfreq"])
+        self.n_samples = int(self._raw.n_times)
+        types = self._raw.get_channel_types()
+        self.channels: list[dict] = []
+        for i, name in enumerate(self._raw.ch_names):
+            ctype = _MNE_TYPE_TO_biosigIO.get(types[i], "OTHER")
+            self.channels.append({
+                "idx": i,
+                "label": name,
+                "channel_type": ctype,
+                "modality": force_modality or infer_modality_from_channel_type(ctype),
+                "unit": _FIFF_UNIT_TO_DIM.get(int(self._raw.info["chs"][i]["unit"]), "n/a"),
+            })
+
+    def read(self, picks: list[int], start: int, stop: int) -> np.ndarray:
+        return self._raw.get_data(picks=picks, start=start, stop=stop)
+
+    def close(self) -> None:
+        pass
+
+
+class _EdfSource:
+    """pyedflib-backed lazy source for .edf/.bdf, matching biosigIO's in-memory
+    EDF importer (physical-dimension units, label/transducer channel typing).
+
+    Uniform per-channel rate ONLY: a mixed-rate EDF raises MixedSamplingRateError
+    (same as the importer's default), so it stays on the in-memory resample path
+    rather than being silently mis-gridded by a single-rate streaming window."""
+
+    def __init__(self, filepath: str, force_modality: str | None):
+        import pyedflib
+
+        from ..exceptions import MixedSamplingRateError
+        from ..importers.edf import EDFImporter
+
+        self._reader = pyedflib.EdfReader(filepath)
+        headers = self._reader.getSignalHeaders()
+        nsamps = self._reader.getNSamples()
+        rates = {float(h["sample_frequency"]) for h in headers}
+        if len(rates) > 1:
+            self._reader.close()
+            raise MixedSamplingRateError(
+                "EDF/BDF recording has mixed per-channel sampling rates "
+                f"({sorted(rates)} Hz); the streaming path needs a uniform grid. The "
+                'in-memory path handles this with mixed_rate="resample".'
+            )
+        typer = EDFImporter()._determine_channel_type
+        self.sfreq = float(headers[0]["sample_frequency"]) if headers else 0.0
+        self.n_samples = int(nsamps[0]) if len(nsamps) else 0
+        self.channels = []
+        for i, h in enumerate(headers):
+            label = cast(str, h["label"]).strip()
+            transducer = cast(str, h.get("transducer", "")).strip()
+            ctype = typer(label, transducer)
+            self.channels.append({
+                "idx": i,
+                "label": label,
+                "channel_type": ctype,
+                "modality": force_modality or infer_modality_from_channel_type(ctype),
+                "unit": cast(str, h.get("dimension", "")).strip() or "n/a",
+            })
+
+    def read(self, picks: list[int], start: int, stop: int) -> np.ndarray:
+        n = stop - start
+        return np.stack(
+            [self._reader.readSignal(i, start, n) for i in picks]
+        ).astype(np.float64)
+
+    def close(self) -> None:
+        self._reader.close()
+
+
+def _open_stream_source(filepath: str, force_modality: str | None):
+    """Open a lazy source, reading EDF/BDF via pyedflib (importer parity) and
+    everything else via MNE. #944"""
+    ext = os.path.splitext(filepath)[1].lower()
+    if ext in (".edf", ".bdf"):
+        return _EdfSource(filepath, force_modality)
+    return _MneSource(filepath, force_modality)
 
 
 def stream_to_zarr(
@@ -120,33 +222,25 @@ def stream_to_zarr(
     zarr = require_zarr()
     from zarr.codecs import BloscCodec
 
-    mne = require_mne()
     rates = dict(DEFAULT_MODALITY_RATES if modality_rates is None else modality_rates)
     if not store_path.endswith(".zarr"):
         store_path = store_path + ".zarr"
     out_np = np.int16 if dtype == "int16" else np.float32
 
-    raw = mne.io.read_raw(filepath, preload=False, verbose="ERROR")
-    sfreq = float(raw.info["sfreq"])
-    n_samples = int(raw.n_times)
-    if n_samples == 0 or len(raw.ch_names) == 0:
+    # EDF/BDF read via pyedflib (importer parity), everything else lazily via MNE.
+    src = _open_stream_source(filepath, force_modality)
+    sfreq = src.sfreq
+    n_samples = src.n_samples
+    if n_samples == 0 or len(src.channels) == 0:
+        src.close()
         raise ValueError("No signals loaded")
-    mne_types = raw.get_channel_types()
 
-    # Per-channel metadata; group by (modality, native rate). MNE Raw is single-rate,
-    # so every channel shares `sfreq`; force_modality collapses to one group.
+    # Per-channel metadata; group by (modality, native rate). The source is
+    # single-rate (a mixed-rate EDF is rejected in _EdfSource), so every channel
+    # shares `sfreq`; force_modality collapses to one group.
     groups: dict[tuple[str, int], list[dict]] = {}
-    for i, name in enumerate(raw.ch_names):
-        ctype = _MNE_TYPE_TO_biosigIO.get(mne_types[i], "OTHER")
-        modality = force_modality if force_modality else infer_modality_from_channel_type(ctype)
-        info = {
-            "idx": i,
-            "label": name,
-            "channel_type": ctype,
-            "modality": modality,
-            "unit": _FIFF_UNIT_TO_DIM.get(int(raw.info["chs"][i]["unit"]), "n/a"),
-        }
-        groups.setdefault((str(modality), int(round(sfreq))), []).append(info)
+    for info in src.channels:
+        groups.setdefault((str(info["modality"]), int(round(sfreq))), []).append(info)
 
     store = zarr.storage.LocalStore(store_path)
     root = zarr.create_group(store=store, overwrite=True)
@@ -166,7 +260,7 @@ def stream_to_zarr(
             read_chunk = max(1, int(round(read_chunk_seconds * native_rate)))
             for s in range(0, n_samples, read_chunk):
                 e = min(n_samples, s + read_chunk)
-                block = raw.get_data(picks=picks, start=s, stop=e)  # (n_ch, e-s) float64
+                block = src.read(picks, s, e)  # (n_ch, e-s) float64
                 mm[:, s:e] = block.astype(np.float32)
             mm.flush()
 
@@ -299,7 +393,7 @@ def stream_to_zarr(
 
         meta = dict(recording_metadata or {})
         meta.setdefault("source_file", filepath)
-        meta.setdefault("number_of_signals", len(raw.ch_names))
+        meta.setdefault("number_of_signals", len(src.channels))
         meta.setdefault("streamed", True)
         root.attrs.update(
             {
@@ -321,4 +415,5 @@ def stream_to_zarr(
                 ),
             }
         )
+    src.close()
     return store_path

--- a/biosigio/tests/test_zarr_stream.py
+++ b/biosigio/tests/test_zarr_stream.py
@@ -77,12 +77,18 @@ class _TmpEDF:
         os.unlink(self.path)
 
 
-def _mne_full_data(path):
-    """Ground truth: load the whole EDF with MNE (preload) -> (n_ch, n_samples)."""
-    import mne
-
-    raw = mne.io.read_raw(path, preload=True, verbose="ERROR")
-    return raw.get_data(), float(raw.info["sfreq"])
+def _pyedflib_full_data(path):
+    """Ground truth for EDF: read the whole file with pyedflib (physical units) ->
+    (n_ch, n_samples). biosigIO reads EDF via pyedflib, and the streaming path now
+    does too (#944), so this -- NOT MNE, which rescales EDF to SI volts -- is what
+    both the streaming and in-memory exporters target."""
+    r = pyedflib.EdfReader(path)
+    try:
+        data = np.stack([r.readSignal(i) for i in range(r.signals_in_file)])
+        sfreq = float(r.getSampleFrequency(0))
+    finally:
+        r.close()
+    return data, sfreq
 
 
 def _dequant(store_path, gname):
@@ -96,7 +102,7 @@ def _dequant(store_path, gname):
 def test_stream_no_resample_reproduces_signal():
     """native <= cap: dequantized base matches the full-load signal within 1 LSB."""
     with _TmpEDF(rate=200.0, duration_s=20.0, n_ch=6) as path:
-        full, _sfreq = _mne_full_data(path)
+        full, _sfreq = _pyedflib_full_data(path)  # #944: streaming reads EDF via pyedflib
         with tempfile.TemporaryDirectory() as d:
             store = os.path.join(d, "rec.zarr")
             stream_to_zarr(path, store, force_modality="EEG")
@@ -110,7 +116,7 @@ def test_stream_no_resample_reproduces_signal():
 def test_stream_with_resample_matches_reference():
     """native > cap: streamed base matches resample-then-quantize of the full signal."""
     with _TmpEDF(rate=500.0, duration_s=20.0, n_ch=4) as path:
-        full, _sfreq = _mne_full_data(path)
+        full, _sfreq = _pyedflib_full_data(path)  # #944: streaming reads EDF via pyedflib
         with tempfile.TemporaryDirectory() as d:
             store = os.path.join(d, "rec.zarr")
             stream_to_zarr(path, store, force_modality="EEG")  # 500 -> 250 cap
@@ -122,6 +128,62 @@ def test_stream_with_resample_matches_reference():
                 rng = float(ref.max() - ref.min()) or 1.0
                 # streamed goes through a float32 memmap; allow a few LSB of slack.
                 assert np.max(np.abs(deq[i] - ref)) <= 5 * rng / 65535
+
+
+def test_stream_edf_matches_in_memory_export():
+    """#944: the pyedflib streaming path must produce the SAME store as the
+    in-memory (Recording.from_file -> to_zarr) path for EDF. This is WHY streaming
+    reads EDF via pyedflib, not MNE (which rescales EDF units to SI volts): a large
+    EDF (streamed) and a small one (in-memory) must land on the same scale/unit."""
+    from biosigio import Recording
+
+    with _TmpEDF(rate=200.0, duration_s=10.0, n_ch=4) as path:
+        with tempfile.TemporaryDirectory() as d:
+            s_stream = os.path.join(d, "stream.zarr")
+            s_inmem = os.path.join(d, "inmem.zarr")
+            stream_to_zarr(path, s_stream, force_modality="EEG", dtype="int16")
+            rec = Recording.from_file(path)
+            for label in rec.channels:
+                rec.channels[label]["modality"] = "EEG"
+            rec.to_zarr(s_inmem, dtype="int16")
+            a = _dequant(s_stream, "eeg_200hz")
+            b = _dequant(s_inmem, "eeg_200hz")
+            assert a.shape == b.shape
+            for i in range(a.shape[0]):
+                rng = float(b[i].max() - b[i].min()) or 1.0
+                # streaming's float32 memmap vs the in-memory float64 path: a few LSB.
+                assert np.max(np.abs(a[i] - b[i])) <= 6 * rng / 65535
+
+
+def test_stream_mixed_rate_edf_rejected():
+    """#944: a mixed per-channel-rate EDF can't stream on a single grid -> raises
+    (same as the importer's default), so it stays on the in-memory resample path."""
+    from biosigio.exceptions import MixedSamplingRateError
+
+    fd, path = tempfile.mkstemp(suffix=".edf")
+    os.close(fd)
+    try:
+        n = 400
+        w = pyedflib.EdfWriter(path, 2)
+        headers = [
+            {"label": "EEG0", "dimension": "uV", "sample_frequency": 200.0,
+             "physical_max": 100.0, "physical_min": -100.0, "digital_max": 32767,
+             "digital_min": -32768, "prefilter": "n/a", "transducer": "n/a"},
+            {"label": "SpO2", "dimension": "%", "sample_frequency": 20.0,
+             "physical_max": 100.0, "physical_min": 0.0, "digital_max": 32767,
+             "digital_min": -32768, "prefilter": "n/a", "transducer": "n/a"},
+        ]
+        w.setSignalHeaders(headers)
+        w.writeSamples([np.zeros(n), np.zeros(n // 10)])
+        w.close()
+        with tempfile.TemporaryDirectory() as d:
+            try:
+                stream_to_zarr(path, os.path.join(d, "x.zarr"), force_modality="EEG")
+                raise AssertionError("expected MixedSamplingRateError")
+            except MixedSamplingRateError:
+                pass
+    finally:
+        os.unlink(path)
 
 
 def test_stream_store_structure_and_pyramid():

--- a/biosigio/tests/test_zarr_stream.py
+++ b/biosigio/tests/test_zarr_stream.py
@@ -166,12 +166,28 @@ def test_stream_mixed_rate_edf_rejected():
         n = 400
         w = pyedflib.EdfWriter(path, 2)
         headers = [
-            {"label": "EEG0", "dimension": "uV", "sample_frequency": 200.0,
-             "physical_max": 100.0, "physical_min": -100.0, "digital_max": 32767,
-             "digital_min": -32768, "prefilter": "n/a", "transducer": "n/a"},
-            {"label": "SpO2", "dimension": "%", "sample_frequency": 20.0,
-             "physical_max": 100.0, "physical_min": 0.0, "digital_max": 32767,
-             "digital_min": -32768, "prefilter": "n/a", "transducer": "n/a"},
+            {
+                "label": "EEG0",
+                "dimension": "uV",
+                "sample_frequency": 200.0,
+                "physical_max": 100.0,
+                "physical_min": -100.0,
+                "digital_max": 32767,
+                "digital_min": -32768,
+                "prefilter": "n/a",
+                "transducer": "n/a",
+            },
+            {
+                "label": "SpO2",
+                "dimension": "%",
+                "sample_frequency": 20.0,
+                "physical_max": 100.0,
+                "physical_min": 0.0,
+                "digital_max": 32767,
+                "digital_min": -32768,
+                "prefilter": "n/a",
+                "transducer": "n/a",
+            },
         ]
         w.setSignalHeaders(headers)
         w.writeSamples([np.zeros(n), np.zeros(n // 10)])

--- a/biosigio/version.py
+++ b/biosigio/version.py
@@ -1,6 +1,6 @@
 """Version information for biosigIO."""
 
-__version__ = "1.1.7"
+__version__ = "1.2.0"
 __version_info__ = (1, 1, 7)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biosigio"
-version = "1.1.7"
+version = "1.2.0"
 authors = [
     { name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org" }
 ]


### PR DESCRIPTION
Enables large EDF/BDF to convert through the bounded-memory streaming path (NEMAR nemar-cli#944), instead of the in-memory float64 load that OOMs.

## Why it wasn't already streamable
`stream_to_zarr` opened everything with `mne.io.read_raw(preload=False)`. MNE *can* read EDF, but the in-memory path (`Recording.from_file` → `to_zarr`) reads EDF via **pyedflib**, and the two disagree on EDF unit scaling — MNE rescales to SI volts, pyedflib keeps the file's physical dimension (e.g. an unknown-unit EDF: MNE → V, pyedflib → the dim). So a *large* EDF streamed via MNE would land on a different scale/unit than a *small* EDF converted in memory, within one dataset. That's why the NEMAR driver kept EDF off the streaming path — forcing large EDF through the OOM-prone in-memory load.

## Change
A lazy **source seam**:
- `_MneSource` — unchanged behavior for `.fif`/`.vhdr`/`.set`/CTF.
- `_EdfSource` — pyedflib `readSignal(chn, start, n)` windows (numerically identical to `readSignal(chn)` sliced), physical-dimension units, `label`/`transducer` channel typing — matching the in-memory EDF importer exactly.
- `_open_stream_source` dispatches by extension.
- A **mixed per-channel-rate** EDF raises `MixedSamplingRateError` (same as the importer default) so it stays on the in-memory resample path rather than being mis-gridded by a single-rate streaming window.

## Correctness
New parity test asserts `stream_to_zarr(edf)` == `Recording.from_file(edf).to_zarr()` within int16 quantization. The two existing EDF stream tests now use a pyedflib (not MNE) ground truth, matching the new reader. **10 passed**, ruff clean.

EDF-via-stream was **not used in production** (the driver excluded it), so switching its reader changes no existing store. Bumped to **1.2.0** so the NEMAR driver can gate the `.edf`/`.bdf` → streaming routing on this capability.

Follow-on (nemar-cli / nemarDatasets/.github): add `.edf`/`.bdf` to `should_stream`'s `STREAM_EXTS` behind a `biosigio >= 1.2.0` check.