### PR TITLE
zarr: zero-fill non-finite int16 samples instead of failing the recording

### DIFF
--- a/biosigio/exporters/zarr.py
+++ b/biosigio/exporters/zarr.py
@@ -120,13 +120,23 @@ def _resample_channel(
     return y
 
 
-def _quantize_int16_channel(row: np.ndarray, index: int = 0) -> tuple[np.ndarray, float, float]:
+def _quantize_int16_channel(row: np.ndarray) -> tuple[np.ndarray, float, float, int]:
     """Map one channel (1-D float) to int16 with scale/offset.
 
     ``physical = digital * scale + offset``. A constant (or empty) channel gets
-    scale=1 and the constant in offset. Non-finite samples (NaN/inf) cannot be
-    represented in int16 and would silently decode to a midrange value, so they
-    are rejected here -- use ``dtype="float32"`` (which preserves NaN) to keep them.
+    scale=1 and the constant in offset.
+
+    Non-finite samples (NaN/inf) cannot be represented in int16. Rather than fail
+    the whole recording for a single bad channel -- a NaN in one MISC/aux channel
+    (an accelerometer, force plate, or sync line in a MoBI dataset) would otherwise
+    sink the entire recording, including every good EEG channel -- the non-finite
+    samples are zero-filled: the physical range (scale/offset) is computed over the
+    FINITE samples only, then each non-finite sample is written as the digital code
+    for physical 0 (clamped into range). The count of filled samples is returned so
+    the caller can flag the channel (``nonfinite_samples``, and demote it to
+    ``usable_for_inference=False``). The fill is lossy, so it is documented rather
+    than silent, and the BIDS source remains authoritative. Callers that must keep
+    NaN exactly (e.g. for training) should export with ``dtype="float32"``.
 
     Operates one channel at a time so the exporter can quantize straight into the
     output array without materializing a float64 copy of the whole group (#95).
@@ -134,21 +144,22 @@ def _quantize_int16_channel(row: np.ndarray, index: int = 0) -> tuple[np.ndarray
     # Quantize in float64 regardless of the caller's dtype (the old batch path
     # cast the whole block up front); a no-op for the float64 resample output.
     row = np.asarray(row, dtype=np.float64)
-    if row.size and not np.all(np.isfinite(row)):
-        raise ValueError(
-            f"Channel index {index} has non-finite (NaN/inf) samples, which int16 storage "
-            "cannot represent without silently corrupting them. Use dtype='float32' "
-            "(preserves NaN) or mask/interpolate the samples before exporting."
-        )
-    pmin = float(np.min(row)) if row.size else 0.0
-    pmax = float(np.max(row)) if row.size else 0.0
-    if pmax == pmin:  # constant (or empty) channel: store the constant in offset
-        return np.zeros(row.shape, dtype=np.int16), 1.0, pmin
+    finite_mask = np.isfinite(row)
+    n_nonfinite = int(row.size - int(np.count_nonzero(finite_mask))) if row.size else 0
+    finite = row[finite_mask] if n_nonfinite else row
+    if finite.size == 0:  # empty, or every sample non-finite: flat zero channel
+        return np.zeros(row.shape, dtype=np.int16), 1.0, 0.0, n_nonfinite
+    pmin = float(np.min(finite))
+    pmax = float(np.max(finite))
+    if pmax == pmin:  # constant channel: store the constant in offset
+        return np.zeros(row.shape, dtype=np.int16), 1.0, pmin, n_nonfinite
     digital_span = _INT16_MAX - _INT16_MIN
     s = (pmax - pmin) / digital_span
     o = pmin - _INT16_MIN * s
+    if n_nonfinite:  # replace NaN/inf with physical 0 before quantizing
+        row = np.where(finite_mask, row, 0.0)
     digital = np.round((row - o) / s)
-    return np.clip(digital, _INT16_MIN, _INT16_MAX).astype(np.int16), s, o
+    return np.clip(digital, _INT16_MIN, _INT16_MAX).astype(np.int16), s, o, n_nonfinite
 
 
 def _build_minmax_pyramid(
@@ -276,29 +287,33 @@ class ZarrExporter:
                 y = _resample_channel(
                     rec.signals[label].values, native_rate, target_rate, discrete=discrete
                 )
+                n_nonfinite = 0
                 if dtype == "int16":
-                    base[i], scale[i], offset[i] = _quantize_int16_channel(y, i)
+                    base[i], scale[i], offset[i], n_nonfinite = _quantize_int16_channel(y)
                 else:
                     base[i] = y.astype(np.float32)
                 del y
-                chan_meta.append(
-                    {
-                        "label": label,
-                        "channel_type": ctype,
-                        "modality": modality,
-                        "unit": info.get("physical_dimension", "n/a"),
-                        "prefilter": info.get("prefilter", "n/a"),
-                        # The true per-channel rate, not the rounded group key, so a
-                        # non-integer acquisition rate is not lost (metadata loss is data loss).
-                        "original_rate": float(info["sample_frequency"]),
-                        "target_rate": float(target_rate),
-                        "anti_aliased": bool((not discrete) and target_rate < native_rate),
-                        "usable_for_inference": (not discrete),
-                        "scale": float(scale[i]),
-                        "offset": float(offset[i]),
-                        "row_index": i,
-                    }
-                )
+                meta = {
+                    "label": label,
+                    "channel_type": ctype,
+                    "modality": modality,
+                    "unit": info.get("physical_dimension", "n/a"),
+                    "prefilter": info.get("prefilter", "n/a"),
+                    # The true per-channel rate, not the rounded group key, so a
+                    # non-integer acquisition rate is not lost (metadata loss is data loss).
+                    "original_rate": float(info["sample_frequency"]),
+                    "target_rate": float(target_rate),
+                    "anti_aliased": bool((not discrete) and target_rate < native_rate),
+                    # A channel whose NaN/inf gaps were zero-filled is lossy: keep it
+                    # viewable but never inferable (int16 fill is not the real signal).
+                    "usable_for_inference": (not discrete) and n_nonfinite == 0,
+                    "scale": float(scale[i]),
+                    "offset": float(offset[i]),
+                    "row_index": i,
+                }
+                if n_nonfinite:
+                    meta["nonfinite_samples"] = n_nonfinite
+                chan_meta.append(meta)
 
             gname = f"{modality.lower()}_{int(round(target_rate))}hz"
             # Disambiguate the rare collision of two native rates -> same target.

--- a/biosigio/exporters/zarr_stream.py
+++ b/biosigio/exporters/zarr_stream.py
@@ -308,8 +308,9 @@ def stream_to_zarr(
                 discrete = ctype in _DISCRETE_TYPES
                 x = np.asarray(mm[i], dtype=np.float64)
                 y = _resample_channel(x, native_rate, target_rate, discrete=discrete)
+                n_nonfinite = 0
                 if dtype == "int16":
-                    q, scale[i], offset[i] = _quantize_int16_channel(y, i)
+                    q, scale[i], offset[i], n_nonfinite = _quantize_int16_channel(y)
                 else:
                     q = y.astype(np.float32)
                 a0[i, :] = q
@@ -319,22 +320,24 @@ def stream_to_zarr(
                     )
                     for (_li, _eff, av), lvl in zip(view_arrays, pyramid, strict=False):
                         av[:, i, :] = lvl[:, 0, :]
-                chan_meta.append(
-                    {
-                        "label": ci["label"],
-                        "channel_type": ctype,
-                        "modality": modality,
-                        "unit": ci["unit"],
-                        "prefilter": "n/a",
-                        "original_rate": float(native_rate),
-                        "target_rate": float(target_rate),
-                        "anti_aliased": bool((not discrete) and target_rate < native_rate),
-                        "usable_for_inference": (not discrete),
-                        "scale": float(scale[i]),
-                        "offset": float(offset[i]),
-                        "row_index": i,
-                    }
-                )
+                meta = {
+                    "label": ci["label"],
+                    "channel_type": ctype,
+                    "modality": modality,
+                    "unit": ci["unit"],
+                    "prefilter": "n/a",
+                    "original_rate": float(native_rate),
+                    "target_rate": float(target_rate),
+                    "anti_aliased": bool((not discrete) and target_rate < native_rate),
+                    # A zero-filled NaN/inf channel is lossy: viewable, never inferable.
+                    "usable_for_inference": (not discrete) and n_nonfinite == 0,
+                    "scale": float(scale[i]),
+                    "offset": float(offset[i]),
+                    "row_index": i,
+                }
+                if n_nonfinite:
+                    meta["nonfinite_samples"] = n_nonfinite
+                chan_meta.append(meta)
                 del x, y, q
             del mm  # release the memmap before the temp dir is reclaimed
 

--- a/biosigio/tests/test_zarr.py
+++ b/biosigio/tests/test_zarr.py
@@ -108,14 +108,40 @@ def test_zarr_discrete_channel_nearest_not_inference(tmp_path):
     assert root[name]["0"].attrs["usable_for_inference"] is False
 
 
-def test_zarr_int16_rejects_non_finite(tmp_path):
-    """NaN/inf would silently decode to a midrange int16 value, so int16 export rejects it."""
-    data = np.sin(np.arange(1000) / 5.0)
-    data[100] = np.nan
+def test_zarr_int16_zerofills_and_flags_non_finite(tmp_path):
+    """A NaN/inf in one channel must NOT sink the whole recording (a MoBI dataset's
+    aux channel would otherwise take down every good EEG channel with it). int16
+    export zero-fills the non-finite samples -- range computed over finite samples
+    only -- and flags the channel (`nonfinite_samples`, `usable_for_inference` ->
+    False). A clean channel in the same group is untouched."""
+    good = np.sin(np.arange(1000) / 5.0)
+    bad = np.sin(np.arange(1000) / 5.0)
+    bad[100:110] = np.nan  # 10 NaN
+    bad[200] = np.inf  # + 1 inf = 11 non-finite
     rec = Recording()
-    rec.add_channel("C1", data, 250, "uV", "EEG")
-    with pytest.raises(ValueError, match="non-finite"):
-        rec.to_zarr(str(tmp_path / "r"))  # dtype="int16" default
+    rec.add_channel("C_good", good, 250, "uV", "EEG")
+    rec.add_channel("C_bad", bad, 250, "uV", "EEG")
+
+    root = _open(rec.to_zarr(str(tmp_path / "r")))  # dtype="int16" default; must not raise
+    name = next(k for k in root.keys() if k != "events")
+    chans = {c["label"]: c for c in root[name].attrs["channels"]}
+
+    # Clean channel: untouched, inference-usable, unflagged.
+    assert chans["C_good"]["usable_for_inference"] is True
+    assert "nonfinite_samples" not in chans["C_good"]
+
+    # Bad channel: present + viewable, but flagged and demoted.
+    assert chans["C_bad"]["nonfinite_samples"] == 11
+    assert chans["C_bad"]["usable_for_inference"] is False
+
+    # Every decoded sample is finite (the fill never leaves NaN in int16), and the
+    # finite samples still round-trip within one quantization step.
+    arr = root[name]["0"][:]
+    c = chans["C_bad"]
+    decoded = arr[c["row_index"]] * c["scale"] + c["offset"]
+    assert np.all(np.isfinite(decoded))
+    finite_idx = np.isfinite(bad)
+    assert np.allclose(decoded[finite_idx], bad[finite_idx], atol=2 * c["scale"])
 
 
 def test_zarr_float32_preserves_nan(tmp_path):


### PR DESCRIPTION
Fixes #107.

## Problem
A single non-finite (NaN/inf) sample in **one** channel made `to_zarr(dtype=\"int16\")` raise, aborting the **entire** recording -- every good EEG/MEG channel with it. On MoBI datasets (OpenNeuro **on006095**: 120 EEG + 8 EMG + **156 MISC** aux channels) a NaN in a force/accelerometer/sync channel sank all **1182** recordings -> zero Zarr coverage, EEG unviewable in the web viewer.

## Fix
Zero-fill instead of reject, **non-silently**:
- `_quantize_int16_channel` computes scale/offset over the **finite samples only**, then writes each non-finite sample as the digital code for physical 0 (clamped into range) -- a gap renders as a neutral flat segment, not a decoded-garbage midrange value.
- The channel is **flagged**: `nonfinite_samples: <count>` and `usable_for_inference: False` (viewable, never trained on). Clean channels are unchanged -- no new field, still inference-usable.
- `dtype=\"float32\"` still preserves NaN exactly (unchanged).

Shared `_quantize_int16_channel` now returns the fill count; both the in-memory (`zarr.py`) and streaming (`zarr_stream.py`) exporters thread it into channel metadata.

## Tests
- Rewrote `test_zarr_int16_rejects_non_finite` -> `test_zarr_int16_zerofills_and_flags_non_finite`: a NaN+inf channel no longer raises, is flagged + demoted, decodes fully finite, and its finite samples round-trip within one quantization step; a clean channel in the same group is untouched.
- `test_zarr_float32_preserves_nan` unchanged (float32 path intact).
- Full `test_zarr.py` + `test_zarr_stream.py`: **22 passed**. ruff check + format clean.

## Follow-up (not in this PR)
Once released (1.2.1), bump the NEMAR Zarr driver pin (`nemarDatasets/.github` `scripts/zarr/requirements.txt`) to pull the fix, then reconvert affected datasets.