### PR TITLE
Fix EEGLAB importer one-channel truncation on column-form struct arrays

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,10 +40,10 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Ruff lint
-        run: uvx ruff check --output-format=github .
+        run: uvx ruff@0.15.4 check --output-format=github .
 
       - name: Ruff format check
-        run: uvx ruff format --check .
+        run: uvx ruff@0.15.4 format --check .
 
   ty:
     name: ty (type check)

--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Any
 
 import numpy as np
@@ -139,14 +140,18 @@ class EEGLABImporter(BaseImporter):
         if field_names is None:
             return channel_info_list
 
-        # Process each channel
-        for i in range(len(chanlocs[0])):
+        # EEGLAB saves chanlocs as a struct array whose MATLAB shape survives
+        # loadmat: (1, N) row form OR (N, 1) column form (real exports use both).
+        # Indexing chanlocs[0] assumed the row form and saw exactly ONE channel
+        # on column-form files, silently truncating every later channel; ravel
+        # makes the walk shape-agnostic.
+        for element in np.asarray(chanlocs).ravel():
             channel_info = {}
 
             # Extract channel fields
             for field in field_names:
                 # Get the field value for this channel
-                field_value = chanlocs[0][i][field]
+                field_value = element[field]
                 if field_value.size == 0:
                     continue
                 # scipy.io.loadmat returns scalar struct fields as nested
@@ -194,24 +199,27 @@ class EEGLABImporter(BaseImporter):
         if field_names is None:
             return event_list
 
-        # Process each event
-        for i in range(len(events[0])):
+        # Same row-vs-column shape hazard as chanlocs: walk the raveled struct
+        # array and flatten each field to a scalar instead of assuming (1, 1)
+        # nesting.
+        for element in np.asarray(events).ravel():
             event_info = {}
 
             # Extract event fields
             for field in field_names:
                 # Get the field value for this event
-                field_value = events[0][i][field]
+                field_value = np.asarray(element[field])
+                if field_value.size == 0:
+                    continue
+                scalar = field_value.ravel()[0]
 
                 # Process based on field name
-                if field == "latency" and field_value.size > 0:
-                    event_info["latency"] = float(field_value[0][0])
-                elif field == "type" and field_value.size > 0:
-                    event_info["type"] = str(field_value[0])
-                elif field == "duration" and field_value.size > 0:
-                    event_info["duration"] = (
-                        float(field_value[0][0]) if field_value[0].size > 0 else 0
-                    )
+                if field == "latency":
+                    event_info["latency"] = float(scalar)
+                elif field == "type":
+                    event_info["type"] = str(scalar)
+                elif field == "duration":
+                    event_info["duration"] = float(scalar)
 
             # Add to list if it has required fields
             if "latency" in event_info and "type" in event_info:
@@ -390,18 +398,44 @@ class EEGLABImporter(BaseImporter):
                 # always matches the data length.
                 time_index = np.arange(signal_data.shape[1]) / srate
 
+                # The data matrix is authoritative for the channel count: every
+                # row ships to the caller. chanlocs only NAMES the rows, so a
+                # short/missing chanlocs (or one misread from an odd save form)
+                # must never truncate the signal -- pad with default labels
+                # instead. A longer-than-data chanlocs is trimmed (labels
+                # without signal rows describe nothing).
+                n_data_ch = signal_data.shape[0]
+                if len(channel_info_list) != n_data_ch:
+                    warnings.warn(
+                        f"EEGLAB chanlocs describes {len(channel_info_list)} "
+                        f"channel(s) but the data matrix has {n_data_ch} row(s); "
+                        f"keeping all data rows",
+                        stacklevel=2,
+                    )
+                    channel_info_list = channel_info_list[:n_data_ch]
+                    for i in range(len(channel_info_list), n_data_ch):
+                        channel_info_list.append(
+                            {"label": f"Channel{i + 1}", "channel_type": "OTHER"}
+                        )
+                header_nbchan = int(metadata.get("nbchan", 0))
+                if header_nbchan and header_nbchan != n_data_ch:
+                    warnings.warn(
+                        f"EEGLAB header nbchan={header_nbchan} disagrees with the "
+                        f"data matrix ({n_data_ch} rows); using the data matrix",
+                        stacklevel=2,
+                    )
+
                 # Build the frame in a single allocation (samples x channels)
                 # rather than assigning one column at a time. The per-column path
                 # reallocates the block manager O(n_channels) times and roughly
                 # doubles peak RAM, which OOMs large / high-channel-count .fdt
                 # recordings (#66, #95); the .fdt's native float32 is preserved so
                 # a multi-GB recording is not silently upcast to float64.
-                n_data_ch = min(len(channel_info_list), signal_data.shape[0])
                 labels = [
                     channel_info_list[i].get("label", f"Channel{i + 1}") for i in range(n_data_ch)
                 ]
                 rec.signals = pd.DataFrame(
-                    signal_data[:n_data_ch].T, columns=labels, index=time_index, copy=False
+                    signal_data.T, columns=labels, index=time_index, copy=False
                 )
                 del signal_data
 

--- a/biosigio/importers/eeglab.py
+++ b/biosigio/importers/eeglab.py
@@ -151,13 +151,13 @@ class EEGLABImporter(BaseImporter):
             # Extract channel fields
             for field in field_names:
                 # Get the field value for this channel
-                field_value = element[field]
+                field_value = np.asarray(element[field])
                 if field_value.size == 0:
                     continue
                 # scipy.io.loadmat returns scalar struct fields as nested
                 # (1, 1)-shaped arrays, so field_value[0] is still 1-D and
                 # float()/str() on it fails or mis-formats. Flatten to a scalar.
-                scalar = np.asarray(field_value).ravel()[0]
+                scalar = field_value.ravel()[0]
 
                 # Process based on field name
                 if field == "labels":
@@ -410,7 +410,7 @@ class EEGLABImporter(BaseImporter):
                         f"EEGLAB chanlocs describes {len(channel_info_list)} "
                         f"channel(s) but the data matrix has {n_data_ch} row(s); "
                         f"keeping all data rows",
-                        stacklevel=2,
+                        stacklevel=3,
                     )
                     channel_info_list = channel_info_list[:n_data_ch]
                     for i in range(len(channel_info_list), n_data_ch):
@@ -422,8 +422,29 @@ class EEGLABImporter(BaseImporter):
                     warnings.warn(
                         f"EEGLAB header nbchan={header_nbchan} disagrees with the "
                         f"data matrix ({n_data_ch} rows); using the data matrix",
-                        stacklevel=2,
+                        stacklevel=3,
                     )
+
+                # Labels must be unique: rec.channels is keyed by label and the
+                # exporters slice rec.signals by column name, so a duplicate
+                # (a real channel literally named "Channel4" colliding with a
+                # padded default, or duplicated labels in chanlocs itself)
+                # silently clobbers channel metadata and breaks per-channel
+                # export slicing. Disambiguate with a numeric suffix and warn.
+                used_labels: set[str] = set()
+                for i, channel_info in enumerate(channel_info_list):
+                    label = channel_info.get("label", f"Channel{i + 1}")
+                    if label in used_labels:
+                        k = 2
+                        while f"{label}_{k}" in used_labels:
+                            k += 1
+                        warnings.warn(
+                            f"duplicate EEGLAB channel label {label!r}; renaming to {label}_{k}",
+                            stacklevel=3,
+                        )
+                        label = f"{label}_{k}"
+                    used_labels.add(label)
+                    channel_info["label"] = label
 
                 # Build the frame in a single allocation (samples x channels)
                 # rather than assigning one column at a time. The per-column path
@@ -431,36 +452,34 @@ class EEGLABImporter(BaseImporter):
                 # doubles peak RAM, which OOMs large / high-channel-count .fdt
                 # recordings (#66, #95); the .fdt's native float32 is preserved so
                 # a multi-GB recording is not silently upcast to float64.
-                labels = [
-                    channel_info_list[i].get("label", f"Channel{i + 1}") for i in range(n_data_ch)
-                ]
+                labels = [info["label"] for info in channel_info_list]
                 rec.signals = pd.DataFrame(
                     signal_data.T, columns=labels, index=time_index, copy=False
                 )
                 del signal_data
 
-                # Add channel information
-                for i, channel_info in enumerate(channel_info_list):
-                    if i < n_data_ch:  # Make sure we have data for this channel
-                        channel_label = channel_info.get("label", f"Channel{i + 1}")
+                # Add channel information (the pad/trim above guarantees
+                # channel_info_list has exactly n_data_ch entries with unique labels)
+                for channel_info in channel_info_list:
+                    channel_label = channel_info["label"]
 
-                        # Add channel info (no silent EMG default; carry modality)
-                        ch_type = channel_info.get("channel_type", "OTHER")
-                        rec.channels[channel_label] = {
-                            "sample_frequency": srate,
-                            "physical_dimension": "uV",  # Default unit for EEG/EMG
-                            "prefilter": "n/a",
-                            "channel_type": ch_type,
-                            "modality": infer_modality_from_channel_type(ch_type),
-                        }
+                    # Add channel info (no silent EMG default; carry modality)
+                    ch_type = channel_info.get("channel_type", "OTHER")
+                    rec.channels[channel_label] = {
+                        "sample_frequency": srate,
+                        "physical_dimension": "uV",  # Default unit for EEG/EMG
+                        "prefilter": "n/a",
+                        "channel_type": ch_type,
+                        "modality": infer_modality_from_channel_type(ch_type),
+                    }
 
-                        # Add additional channel metadata
-                        if "X" in channel_info:
-                            rec.channels[channel_label]["X"] = channel_info["X"]
-                        if "Y" in channel_info:
-                            rec.channels[channel_label]["Y"] = channel_info["Y"]
-                        if "Z" in channel_info:
-                            rec.channels[channel_label]["Z"] = channel_info["Z"]
+                    # Add additional channel metadata
+                    if "X" in channel_info:
+                        rec.channels[channel_label]["X"] = channel_info["X"]
+                    if "Y" in channel_info:
+                        rec.channels[channel_label]["Y"] = channel_info["Y"]
+                    if "Z" in channel_info:
+                        rec.channels[channel_label]["Z"] = channel_info["Z"]
 
             return rec
 

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -461,3 +461,107 @@ def test_eeglab_to_edf_export(sample_eeglab_set):
             os.unlink(os.path.splitext(edf_path)[0] + ".bdf")
         if os.path.exists(channels_tsv_path):
             os.unlink(channels_tsv_path)
+
+
+def _column_form_set(tmp_path, n_channels=6, n_samples=300, srate=250):
+    """Write a flat-form .set whose chanlocs/event struct arrays are COLUMN
+    vectors ((N, 1) instead of (1, N)), the shape real EEGLAB exports also use
+    (e.g. OpenNeuro ds002718). Returns the .set path and the data matrix.
+    """
+    rng = np.random.default_rng(7)
+    data = (rng.standard_normal((n_channels, n_samples)) * 10).astype(np.float32)
+
+    chanlocs = np.zeros(
+        (n_channels, 1),
+        dtype=[("labels", "O"), ("type", "O"), ("X", "O"), ("Y", "O"), ("Z", "O")],
+    )
+    for i in range(n_channels):
+        chanlocs[i, 0] = (
+            np.array([f"EEG{i + 1:03d}"]),
+            np.array(["EEG"]),
+            np.array([[float(i)]]),
+            np.array([[0.0]]),
+            np.array([[1.0]]),
+        )
+
+    events = np.zeros((3, 1), dtype=[("latency", "O"), ("duration", "O"), ("type", "O")])
+    for i in range(3):
+        events[i, 0] = (np.array([[i * 50 + 25]]), np.array([[0]]), np.array([f"ev{i}"]))
+
+    set_path = str(tmp_path / "column_form.set")
+    scipy.io.savemat(
+        set_path,
+        {
+            "setname": np.array(["column_form"]),
+            "nbchan": np.array([[n_channels]]),
+            "trials": np.array([[1]]),
+            "pnts": np.array([[n_samples]]),
+            "srate": np.array([[srate]]),
+            "data": data,
+            "chanlocs": chanlocs,
+            "event": events,
+        },
+    )
+    return set_path, data
+
+
+def test_eeglab_column_form_chanlocs_loads_all_channels(tmp_path):
+    """Column-vector ((N, 1)) chanlocs/event struct arrays load every channel.
+
+    Regression for the one-channel bug (nemarDatasets/on002718#1): iterating
+    ``chanlocs[0]`` on a column-form file yielded a single channel-info entry,
+    and the loader then silently truncated the 74-channel data matrix to one
+    channel. The raveled walk must see every channel and every event.
+    """
+    n_channels, n_samples = 6, 300
+    set_path, data = _column_form_set(tmp_path, n_channels, n_samples)
+
+    rec = EEGLABImporter().load(set_path)
+
+    assert rec.signals.shape == (n_samples, n_channels)
+    assert list(rec.signals.columns) == [f"EEG{i + 1:03d}" for i in range(n_channels)]
+    assert len(rec.channels) == n_channels
+    for info in rec.channels.values():
+        assert info["channel_type"] == "EEG"
+    for i, label in enumerate(rec.signals.columns):
+        np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)
+    assert len(rec.events) == 3
+    assert list(rec.events["description"]) == ["ev0", "ev1", "ev2"]
+
+
+def test_eeglab_short_chanlocs_never_truncates_data(tmp_path):
+    """A chanlocs shorter than the data matrix pads labels instead of dropping rows.
+
+    The data matrix is authoritative for the channel count: a malformed or
+    partial chanlocs must warn and keep every signal row, never silently
+    truncate (the failure mode behind nemarDatasets/on002718#1).
+    """
+    n_channels, n_samples, srate = 5, 200, 250
+    rng = np.random.default_rng(11)
+    data = (rng.standard_normal((n_channels, n_samples)) * 10).astype(np.float32)
+
+    chanlocs = np.zeros((1, 2), dtype=[("labels", "O"), ("type", "O")])
+    chanlocs[0, 0] = (np.array(["C1"]), np.array(["EEG"]))
+    chanlocs[0, 1] = (np.array(["C2"]), np.array(["EEG"]))
+
+    set_path = str(tmp_path / "short_chanlocs.set")
+    scipy.io.savemat(
+        set_path,
+        {
+            "nbchan": np.array([[n_channels]]),
+            "trials": np.array([[1]]),
+            "pnts": np.array([[n_samples]]),
+            "srate": np.array([[srate]]),
+            "data": data,
+            "chanlocs": chanlocs,
+        },
+    )
+
+    with pytest.warns(UserWarning, match="keeping all data rows"):
+        rec = EEGLABImporter().load(set_path)
+
+    assert rec.signals.shape == (n_samples, n_channels)
+    assert list(rec.signals.columns)[:2] == ["C1", "C2"]
+    assert len(rec.channels) == n_channels
+    for i, label in enumerate(rec.signals.columns):
+        np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)

--- a/biosigio/tests/test_eeglab_importer.py
+++ b/biosigio/tests/test_eeglab_importer.py
@@ -565,3 +565,76 @@ def test_eeglab_short_chanlocs_never_truncates_data(tmp_path):
     assert len(rec.channels) == n_channels
     for i, label in enumerate(rec.signals.columns):
         np.testing.assert_allclose(rec.signals[label].to_numpy(), data[i], rtol=0, atol=1e-5)
+
+
+def test_eeglab_header_nbchan_mismatch_warns(tmp_path):
+    """A header nbchan that disagrees with the data matrix warns and keeps the data."""
+    n_channels, n_samples, srate = 4, 100, 250
+    rng = np.random.default_rng(3)
+    data = (rng.standard_normal((n_channels, n_samples)) * 10).astype(np.float32)
+
+    chanlocs = np.zeros((1, n_channels), dtype=[("labels", "O"), ("type", "O")])
+    for i in range(n_channels):
+        chanlocs[0, i] = (np.array([f"C{i + 1}"]), np.array(["EEG"]))
+
+    set_path = str(tmp_path / "nbchan_mismatch.set")
+    scipy.io.savemat(
+        set_path,
+        {
+            "nbchan": np.array([[99]]),  # header lies; data matrix is authoritative
+            "trials": np.array([[1]]),
+            "pnts": np.array([[n_samples]]),
+            "srate": np.array([[srate]]),
+            "data": data,
+            "chanlocs": chanlocs,
+        },
+    )
+
+    with pytest.warns(UserWarning, match="nbchan=99 disagrees"):
+        rec = EEGLABImporter().load(set_path)
+
+    assert rec.signals.shape == (n_samples, n_channels)
+    assert len(rec.channels) == n_channels
+
+
+def test_eeglab_padded_label_collision_stays_unique(tmp_path):
+    """A padded default label colliding with a real channel name is disambiguated.
+
+    A real channel literally named "Channel4" must not merge with the padded
+    default for data row 4: duplicate labels clobber rec.channels entries and
+    break per-channel column slicing in the exporters.
+    """
+    n_channels, n_samples, srate = 5, 100, 250
+    rng = np.random.default_rng(5)
+    data = (rng.standard_normal((n_channels, n_samples)) * 10).astype(np.float32)
+
+    chanlocs = np.zeros((1, 2), dtype=[("labels", "O"), ("type", "O")])
+    chanlocs[0, 0] = (np.array(["C1"]), np.array(["EEG"]))
+    chanlocs[0, 1] = (np.array(["Channel4"]), np.array(["EEG"]))
+
+    set_path = str(tmp_path / "label_collision.set")
+    scipy.io.savemat(
+        set_path,
+        {
+            "nbchan": np.array([[n_channels]]),
+            "trials": np.array([[1]]),
+            "pnts": np.array([[n_samples]]),
+            "srate": np.array([[srate]]),
+            "data": data,
+            "chanlocs": chanlocs,
+        },
+    )
+
+    with pytest.warns(UserWarning):
+        rec = EEGLABImporter().load(set_path)
+
+    labels = list(rec.signals.columns)
+    assert len(labels) == n_channels
+    assert len(set(labels)) == n_channels  # unique -> no dict clobber, no 2-D slice
+    assert len(rec.channels) == n_channels
+    assert labels[:2] == ["C1", "Channel4"]
+    # Every column still slices to a 1-D series with faithful values.
+    for i, label in enumerate(labels):
+        col = rec.signals[label].to_numpy()
+        assert col.ndim == 1
+        np.testing.assert_allclose(col, data[i], rtol=0, atol=1e-5)


### PR DESCRIPTION
Fixes #110. Root cause of nemarDatasets/on002718#1 (70+ channel EEG served as 1 channel in every Zarr store).

## Changes

- `_process_channel_info` and `_process_events` walk `np.asarray(...).ravel()` so `(N, 1)` column-form struct arrays (which real EEGLAB exports produce) enumerate every element instead of exactly one.
- `_load` treats the data matrix as authoritative for channel count: a short or missing chanlocs pads default labels and warns instead of silently truncating signal rows; a header `nbchan` that disagrees with the data matrix also warns.
- Event field access flattens scalars via `ravel()[0]` instead of assuming `(1, 1)` nesting.

## Testing

- Real-data check: `sub-002_task-FaceRecognition_eeg.set` from on002718 (`nbchan=74`, `chanlocs` shape `(74, 1)`) now loads `(747750, 74)` signals, 74 typed channels (EEG/EKG/OTHER), 1479 events. On 1.2.1 it loads `(747750, 1)`.
- New regression tests: column-form chanlocs/events load all channels and events with faithful sample values; short-chanlocs file pads labels, warns, and keeps all data rows.
- Full suite: 433 passed, 13 skipped. Ruff check and format clean.